### PR TITLE
Rework skills into a 5-phase developer journey

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,8 @@
+This project uses vendor-neutral Agent Skills.
+
+Before doing a task, check whether a skill covers it. The full index — a 5-phase
+developer journey (guides) plus one-job task skills — is in skills/README.md.
+Read the matching skills/<name>/SKILL.md and follow it; the steps are exact
+(commands, file paths, console URLs) and work manually or agent-driven.
+
+Project conventions and the same skills index also live in AGENTS.md.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,12 @@
+# Copilot instructions
+
+This project ships vendor-neutral **Agent Skills**. Before implementing a task,
+check whether a skill already covers it.
+
+- Full index — a 5-phase developer journey (guides) plus one-job task skills:
+  [`skills/README.md`](../skills/README.md).
+- Read the matching `skills/<name>/SKILL.md` and follow it. Steps are exact
+  (real commands, file paths, console URLs) and are written to be followed
+  manually or by an agent.
+- Broader project conventions and the same skills index live in
+  [`AGENTS.md`](../AGENTS.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,17 +307,29 @@ Each platform uses its **native** launch screen — no library.
 - Feature folders under `presentation/screens/<feature>/` contain **only** `*Screen.kt`, `*UiState.kt`, `*ViewModel.kt` — never a `*ScreenRoute.kt`.
 
 ### Agent Skills
-Reusable, agent-agnostic skills live in **`skills/<name>/SKILL.md`** (open Agent Skills format; `.claude/skills` symlinks there for Claude Code). Read the matching skill before doing the task — they wrap the scaffolding scripts and quality gates with the project-specific rules:
+Reusable, agent-agnostic skills live in **`skills/<name>/SKILL.md`** (open Agent Skills format; `.claude/skills` symlinks there for Claude Code). Read the matching skill before doing the task — they encode the project-specific steps (commands, file paths, console URLs) so you need neither the docs nor any external CLI. Full index + descriptions: [`skills/README.md`](skills/README.md).
 
-| Skill | Use when |
-|---|---|
-| `skills/refactor-package/` | Renaming the app package / applicationId / bundle ID / display name |
-| `skills/new-screen/` | Adding a new screen |
-| `skills/new-local-model/` | Adding a locally-stored (Room) model |
-| `skills/new-module/` | Adding a Gradle KMP module |
-| `skills/store-screenshots/` | Generating store screenshots |
-| `skills/bump-version/` | Bumping app version for release |
-| `skills/run-quality-gates/` | Validating changes before commit/PR |
+Two layers:
+- **Guides** — one per phase of the developer journey. Each is an ordered checklist whose steps are tagged **Agent Action** / **User Action** / **Validation**; stop at each **User Action** and wait for the developer. Copy the guide's `progress-template.md` to track progress.
+- **Task skills** — one job each, usable standalone; the guides call them by name.
+
+**Developer journey (walk the guides in order):**
+
+| Phase | Guide | Goal |
+|---|---|---|
+| 1 · First Run | `skills/getting-started/` | App running locally on your own device, rebranded, driven purely locally (screen, Room, preference, network call, permission) — no cloud |
+| 2 · Integrations | `skills/integrations/` | Firebase + auth + web-proxy backend wired; real remote calls work |
+| 3 · Publication | `skills/publishing/` | Icons, release signing (keys in CI not the app), store listings, first build in review |
+| 4 · Monetization | `skills/monetization/` | Subscriptions + credit-pack IAPs + paywall + ads |
+| 5 · Growth | `skills/growth/` | Analytics/Crashlytics/RemoteConfig, push, onboarding, virality loops |
+
+**Task skills** (grouped by phase):
+- **P1** `run-the-app`, `new-screen`, `new-local-model`, `add-api-service`, `save-preferences`, `add-permission`, `new-module`
+- **P2** `configure-environment`, `setup-firebase`, `enable-auth`, `integrate-web-proxy`
+- **P3** `refactor-package`, `generate-app-icons`, `bump-version`, `setup-signing`, `store-screenshots`, `setup-appstore-connect`, `setup-google-play`, `publish-release`
+- **P4** `design-paywall`, `setup-subscriptions`, `enable-credits`, `enable-ads`
+- **P5** `setup-analytics`, `enable-notifications`, `design-onboarding`, `add-virality-loop`
+- **Cross-phase** `run-quality-gates`
 
 ### Screen Generation
 **Whenever the user asks for a new screen, run this from `MobileApp/`** instead of hand-creating files:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,9 +324,9 @@ Two layers:
 | 5 · Growth | `skills/growth/` | Analytics/Crashlytics/RemoteConfig, push, onboarding, virality loops |
 
 **Task skills** (grouped by phase):
-- **P1** `run-the-app`, `new-screen`, `new-local-model`, `add-api-service`, `save-preferences`, `add-permission`, `new-module`
+- **P1** `run-the-app`, `refactor-package`, `new-screen`, `new-local-model`, `add-api-service`, `save-preferences`, `add-permission`, `new-module`
 - **P2** `configure-environment`, `setup-firebase`, `enable-auth`, `integrate-web-proxy`
-- **P3** `refactor-package`, `generate-app-icons`, `bump-version`, `setup-signing`, `store-screenshots`, `setup-appstore-connect`, `setup-google-play`, `publish-release`
+- **P3** `generate-app-icons`, `bump-version`, `setup-signing`, `store-screenshots`, `setup-appstore-connect`, `setup-google-play`, `publish-release`
 - **P4** `design-paywall`, `setup-subscriptions`, `enable-credits`, `enable-ads`
 - **P5** `setup-analytics`, `enable-notifications`, `design-onboarding`, `add-virality-loop`
 - **Cross-phase** `run-quality-gates`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ For more details, visit the [full documentation](https://docs.kappmaker.com).
 | **MobileApp** | See [MobileApp/README.md](MobileApp/README.md) for setup, build commands, and architecture |
 | **Web** | Firebase Hosting static site + Node.js Cloud Functions |
 
+> **New here? Follow the developer journey.** The [`skills/`](skills/README.md) folder is a phase-by-phase path from a cloned template to a shipped, earning app: **getting-started** (run it locally) → **integrations** → **publishing** → **monetization** → **growth**. Each guide is a checklist you can follow with an AI agent *or* by hand — real commands, paths, and console steps, no external docs needed.
+
 ### Prerequisites
 
 - JDK 17+
@@ -113,7 +115,7 @@ This project is set up to be AI-ready out of the box — coding agents (Claude C
 - **`AiGuidelines/agents/`** — Specialized role prompts (product designer, UI/UX, paywall, onboarding, etc.)
 - **`AiGuidelines/creative/`** — Animation patterns & easter egg inspiration
 - **`AiGuidelines/project/`** — Product requirements & user flow documentation
-- **`skills/`** — Agent-agnostic skills in the open `SKILL.md` format (new screen, new local model, new module, store screenshots, version bump, quality gates). Claude Code discovers them via the `.claude/skills` symlink; other agents via the Skills section in `AGENTS.md`
+- **`skills/`** — A phase-by-phase **developer journey** as agent-agnostic skills (open `SKILL.md` format): five guides — getting-started → integrations → publishing → monetization → growth — plus the one-job task skills they compose (run the app, new screen/model, Firebase, auth, signing, subscriptions, ads, notifications, …). Each is followable by an AI agent or by hand. Index: [`skills/README.md`](skills/README.md). Claude Code discovers them via the `.claude/skills` symlink; other agents via the Skills section in `AGENTS.md` (Gemini/Cursor/Copilot pointer files included)
 - **Build & test workflows** — All quality gates an agent needs are documented in `AGENTS.md` (Spotless, JVM/Android tests, debug build) and enforced in `.github/workflows/pr_checks.yml`
 - **Scaffolding scripts** — `MobileApp/scripts/generate_screen.sh` and `MobileApp/scripts/make_local.sh` keep agent-generated code consistent with project conventions
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -47,6 +47,7 @@ guide's `progress-template.md` into your repo to track where you are.
 | Skill | Use when |
 |---|---|
 | [run-the-app](run-the-app/SKILL.md) | Building/running the app on Android, Desktop, Web, or iOS for the first time |
+| [refactor-package](refactor-package/SKILL.md) | Renaming the package / applicationId / bundle ID / display name (rebrand) |
 | [new-screen](new-screen/SKILL.md) | Adding a screen (scaffolds UI + route + DI wiring) |
 | [new-local-model](new-local-model/SKILL.md) | Storing a model locally (Room entity + DAO + DI) |
 | [add-api-service](add-api-service/SKILL.md) | Making a network request (DTOs → API service → repository → ViewModel) |
@@ -67,7 +68,6 @@ guide's `progress-template.md` into your repo to track where you are.
 
 | Skill | Use when |
 |---|---|
-| [refactor-package](refactor-package/SKILL.md) | Renaming the package / applicationId / bundle ID / display name (rebrand) |
 | [generate-app-icons](generate-app-icons/SKILL.md) | Setting/replacing the app + launcher icons |
 | [bump-version](bump-version/SKILL.md) | Bumping versionCode / versionName for a release |
 | [setup-signing](setup-signing/SKILL.md) | Release signing + moving keys out of the app into CI secrets |

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,9 +4,21 @@ Vendor-neutral skills for AI coding agents (Claude Code, Codex, Gemini CLI, Curs
 Each skill is a `<name>/SKILL.md` file in the open [Agent Skills](https://agentskills.io) format:
 YAML frontmatter (`name`, `description`) followed by step-by-step instructions.
 
-- Agents with native skill support discover these automatically (`.claude/skills` symlinks here for Claude Code).
-- Agents without native support: read the skill file referenced from the **Skills** section of [AGENTS.md](../AGENTS.md) before doing the matching task.
-- **No AI? Walk them by hand.** Every step is written to be followed manually — real commands, real file paths, real console URLs. The skills encode everything you need; you should not have to read external docs to get from a cloned template to a shipped, earning app.
+The skills are **vendor-neutral** — plain Markdown with real commands, file paths, and console
+URLs; no assistant-specific syntax. Any agent that reads them can run them. Only *discovery* differs
+per tool, so the repo ships a pointer file for each:
+
+| Agent | How it finds the skills |
+|---|---|
+| Claude Code | Auto-discovered — `.claude/skills` symlinks to this folder |
+| Codex | Reads [`AGENTS.md`](../AGENTS.md) (Skills section → this index) |
+| Gemini CLI | Reads `GEMINI.md` (symlinked to `AGENTS.md`) |
+| Cursor | Reads `.cursorrules` (points here) |
+| GitHub Copilot | Reads `.github/copilot-instructions.md` (points here) |
+| Any other / no AI | Open this index and read the matching `SKILL.md` — every step is followable by hand |
+
+**No AI? Walk them manually.** The skills encode everything you need; you should not have to read
+external docs to get from a cloned template to a shipped, earning app.
 
 ## Two layers
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,18 +1,89 @@
 # Agent Skills
 
-Vendor-neutral skills for AI coding agents (Claude Code, Codex, Gemini CLI, Cursor, ...) working in this repo.
+Vendor-neutral skills for AI coding agents (Claude Code, Codex, Gemini CLI, Cursor, …) working in this repo.
 Each skill is a `<name>/SKILL.md` file in the open [Agent Skills](https://agentskills.io) format:
 YAML frontmatter (`name`, `description`) followed by step-by-step instructions.
 
 - Agents with native skill support discover these automatically (`.claude/skills` symlinks here for Claude Code).
 - Agents without native support: read the skill file referenced from the **Skills** section of [AGENTS.md](../AGENTS.md) before doing the matching task.
+- **No AI? Walk them by hand.** Every step is written to be followed manually — real commands, real file paths, real console URLs. The skills encode everything you need; you should not have to read external docs to get from a cloned template to a shipped, earning app.
+
+## Two layers
+
+**Guides** are phase-by-phase blueprints for the whole developer journey. Each owns an ordered
+checklist whose steps are tagged **Agent Action** (an agent/dev does it: code, script, gradle),
+**User Action** (human-only: a browser console, Xcode, a device), or **Validation** (a gate before
+moving on). An agent following a guide **stops at each User Action** and waits for you. Copy the
+guide's `progress-template.md` into your repo to track where you are.
+
+**Task skills** do one job each and are usable standalone. The guides call them by name.
+
+## The journey (5 phases)
+
+| Phase | Guide | You end with |
+|---|---|---|
+| 1 · First Run | [getting-started](getting-started/SKILL.md) | The app **running on your own device**, rebranded, driven purely locally — no cloud. |
+| 2 · Integrations | [integrations](integrations/SKILL.md) | Firebase + auth + the web-proxy backend wired; real remote calls work. |
+| 3 · Publication | [publishing](publishing/SKILL.md) | Icons, release signing (keys in CI, not the app), store listings, first build in review. |
+| 4 · Monetization | [monetization](monetization/SKILL.md) | Subscriptions + credit-pack IAPs + paywall + ads; a test purchase unlocks premium. |
+| 5 · Growth | [growth](growth/SKILL.md) | Analytics/Crashlytics/RemoteConfig, push notifications, onboarding, virality loops. |
+
+## Task skills by phase
+
+**Phase 1 — First Run (local-only)**
 
 | Skill | Use when |
 |---|---|
-| [refactor-package](refactor-package/SKILL.md) | Renaming the app package / applicationId / bundle ID / display name (rebrand) |
-| [new-screen](new-screen/SKILL.md) | Adding a new screen (scaffolds UI + route + DI wiring) |
-| [new-local-model](new-local-model/SKILL.md) | Adding a locally-persisted model (Room entity + DAO + DI) |
+| [run-the-app](run-the-app/SKILL.md) | Building/running the app on Android, Desktop, Web, or iOS for the first time |
+| [new-screen](new-screen/SKILL.md) | Adding a screen (scaffolds UI + route + DI wiring) |
+| [new-local-model](new-local-model/SKILL.md) | Storing a model locally (Room entity + DAO + DI) |
+| [add-api-service](add-api-service/SKILL.md) | Making a network request (DTOs → API service → repository → ViewModel) |
+| [save-preferences](save-preferences/SKILL.md) | Persisting a simple typed key/value setting (DataStore) |
+| [add-permission](add-permission/SKILL.md) | Requesting a runtime permission (camera, notifications, …) |
 | [new-module](new-module/SKILL.md) | Adding a new Gradle KMP library module |
+
+**Phase 2 — Integrations**
+
+| Skill | Use when |
+|---|---|
+| [configure-environment](configure-environment/SKILL.md) | Figuring out where a config value / API key lives (local.properties, gradle.properties, Constants.kt) |
+| [setup-firebase](setup-firebase/SKILL.md) | Connecting the app to Firebase (project, apps, anonymous auth) |
+| [enable-auth](enable-auth/SKILL.md) | Adding Google / Apple social sign-in |
+| [integrate-web-proxy](integrate-web-proxy/SKILL.md) | Deploying the Cloud Functions AI proxy and calling it securely |
+
+**Phase 3 — Publication**
+
+| Skill | Use when |
+|---|---|
+| [refactor-package](refactor-package/SKILL.md) | Renaming the package / applicationId / bundle ID / display name (rebrand) |
+| [generate-app-icons](generate-app-icons/SKILL.md) | Setting/replacing the app + launcher icons |
+| [bump-version](bump-version/SKILL.md) | Bumping versionCode / versionName for a release |
+| [setup-signing](setup-signing/SKILL.md) | Release signing + moving keys out of the app into CI secrets |
 | [store-screenshots](store-screenshots/SKILL.md) | Generating App Store / Play Store screenshots |
-| [bump-version](bump-version/SKILL.md) | Bumping app versionCode/versionName for a release |
-| [run-quality-gates](run-quality-gates/SKILL.md) | Validating changes before commit/PR |
+| [setup-appstore-connect](setup-appstore-connect/SKILL.md) | Creating + configuring the App Store Connect listing |
+| [setup-google-play](setup-google-play/SKILL.md) | Creating + configuring the Google Play Console listing |
+| [publish-release](publish-release/SKILL.md) | Building signed artifacts and submitting for review |
+
+**Phase 4 — Monetization**
+
+| Skill | Use when |
+|---|---|
+| [design-paywall](design-paywall/SKILL.md) | Authoring the offer / pricing / trial / paywall copy |
+| [setup-subscriptions](setup-subscriptions/SKILL.md) | Adding subscriptions (Adapty default / RevenueCat) |
+| [enable-credits](enable-credits/SKILL.md) | Adding a credit balance + credit-pack IAPs |
+| [enable-ads](enable-ads/SKILL.md) | Turning on AdMob banner / interstitial / rewarded ads |
+
+**Phase 5 — Growth**
+
+| Skill | Use when |
+|---|---|
+| [setup-analytics](setup-analytics/SKILL.md) | Analytics, Crashlytics, Remote Config feature flags |
+| [enable-notifications](enable-notifications/SKILL.md) | Push (FCM) + local notifications |
+| [design-onboarding](design-onboarding/SKILL.md) | Designing/polishing the first-run onboarding |
+| [add-virality-loop](add-virality-loop/SKILL.md) | Referral / share / win-back / in-app review prompts |
+
+**Cross-phase**
+
+| Skill | Use when |
+|---|---|
+| [run-quality-gates](run-quality-gates/SKILL.md) | Validating changes before commit/PR (lint, tests, build) |

--- a/skills/add-api-service/SKILL.md
+++ b/skills/add-api-service/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: add-api-service
+description: Add a Ktor-backed network request end-to-end — request/response DTOs, an API service, a repository, and a ViewModel call. Use when the user wants to fetch or post data over HTTP / call any REST endpoint from the app.
+---
+
+# Add an API service (network request)
+
+Generic Ktor call to **any** URL — this is not tied to the project's own backend. Follow the layering:
+DTOs → API service → repository (`Result` wrapping) → ViewModel.
+
+Paths below are under `shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/`.
+
+## 1. DTOs — `data/source/remote/request/` and `data/source/remote/response/`
+
+`*Request` / `*Response` suffixes are required. All DTOs `@Serializable` + `@SerialName`. Response DTOs
+carry an `asDomain()` mapper. **Return raw types, never `Result`** — repositories do the wrapping.
+
+```kotlin
+// response/GetJobsResponse.kt
+@Serializable
+data class GetJobsResponse(
+    @SerialName("jobs") val jobs: List<JobResponse>,
+) {
+    fun asDomain(): List<Job> = jobs.map { it.asDomain() }
+}
+
+@Serializable
+data class JobResponse(
+    @SerialName("id") val id: String,
+    @SerialName("title") val title: String,
+) {
+    fun asDomain(): Job = Job(id = id, title = title)
+}
+```
+
+## 2. API service — `data/source/remote/apiservices/`
+
+Take the shared `HttpClient` (base URL + JSON + logging are already configured in
+`data/source/remote/HttpClientFactory.kt`). Return raw DTOs; let exceptions propagate.
+
+```kotlin
+class JobApiService(private val httpClient: HttpClient) {
+    suspend fun getJobs(request: GetJobsRequest): GetJobsResponse =
+        httpClient.post("/jobs") { setBody(request) }.body()
+}
+```
+Register in `root/Di.kt` `dataModule` alongside the existing `factoryOf(::ApiService)`:
+```kotlin
+factoryOf(::JobApiService)
+```
+
+## 3. Repository — `data/repository/`
+
+Concrete class (no interface). Wrap in `Result` via `backgroundExecutor.execute { }` — it already
+catches, logs, and returns `Result.failure`, so **no redundant try-catch**.
+
+```kotlin
+class JobRepository(
+    private val jobApiService: JobApiService,
+    private val backgroundExecutor: BackgroundExecutor = BackgroundExecutor.IO,
+) {
+    suspend fun getJobs(page: Int, limit: Int): Result<List<Job>> =
+        backgroundExecutor.execute {
+            val response = jobApiService.getJobs(GetJobsRequest(page, limit))
+            Result.success(response.asDomain())
+        }
+}
+```
+Register in `dataModule`: `single { JobRepository(get()) }`.
+
+## 4. Call from a ViewModel
+
+Inject the repository, call the suspend function inside `viewModelScope`, fold the `Result` into UiState.
+
+## Testing
+
+Use Ktor `MockEngine` to stub responses/errors — never hit the real network in unit tests
+(`shared/src/commonTest/`). See `AiGuidelines/tech/api_services.md`.
+
+Validate with the `run-quality-gates` skill.

--- a/skills/add-permission/SKILL.md
+++ b/skills/add-permission/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: add-permission
+description: Request a runtime permission (camera, gallery, location, microphone, notifications, or any other) via the app-level AppPermissionState API. Use when a screen needs to ask the user for a device permission.
+---
+
+# Add a runtime permission
+
+Permissions go through the app-level `AppPermissionState` wrapper (backed by Calf) — real dialogs on
+Android/iOS, granted no-op on desktop/web. **Never use Calf types directly in screens.**
+
+Helpers live in `shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/permissions/AppPermissionState.kt`.
+
+## Ready-made helpers
+
+| Helper | iOS `Info.plist` key |
+|---|---|
+| `rememberNotificationPermissionState()` | — |
+| `rememberCameraPermissionState()` | `NSCameraUsageDescription` |
+| `rememberGalleryPermissionState()` | `NSPhotoLibraryUsageDescription` |
+| `rememberLocationPermissionState()` | `NSLocationWhenInUseUsageDescription` |
+| `rememberMicrophonePermissionState()` | `NSMicrophoneUsageDescription` |
+
+Any other permission: `rememberAppPermissionState(Permission.Bluetooth)`.
+
+## Use it in a screen
+
+Each helper returns `AppPermissionState { isGranted, shouldShowRationale, request(), openSettings() }`:
+
+```kotlin
+@Composable
+fun CameraScreen() {
+    val camera = rememberCameraPermissionState { granted -> /* result after request() */ }
+    when {
+        camera.isGranted -> CameraPreview()
+        camera.shouldShowRationale -> RationaleCard(onAllow = { camera.openSettings() })
+        else -> Button(onClick = { camera.request() }) { Text("Enable camera") }
+    }
+}
+```
+
+## Ask on screen entry
+
+For permissions best requested as the screen appears (e.g. notifications on Home):
+
+```kotlin
+RequestPermissionOnEntry(rememberNotificationPermissionState())
+```
+It skips if already granted, or if the user previously denied (never re-prompt unasked — show a
+rationale UI instead).
+
+## iOS / Android setup
+
+- **iOS**: add the matching `NS*UsageDescription` key to `iosApp/iosApp/Info.plist`. Camera/gallery/
+  location/microphone all require one — a **missing key hard-crashes** the app when the permission opens.
+  Notifications need none.
+- **Android**: add the `<uses-permission>` entry to `androidApp/src/main/AndroidManifest.xml` if the
+  permission requires one.
+
+Validate with the `run-quality-gates` skill.

--- a/skills/add-virality-loop/SKILL.md
+++ b/skills/add-virality-loop/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: add-virality-loop
+description: Add growth loops beyond the onboarding paywall — share/referral surfaces, high-intent conversion prompts, win-back re-engagement, and in-app review prompts. Use when the developer wants virality, referral, sharing, re-engagement / win-back, or to ask users for an app-store rating.
+---
+
+# Add a virality loop
+
+Growth surfaces *beyond* the first onboarding paywall — high-intent moments and shareable value that
+create organic acquisition. Keep it honest and genuinely useful, never nagging. This is a
+designer-handoff skill.
+
+## 1. Fill the spec
+
+Open `AiGuidelines/project/virality_loops.md` and fill its `TAILOR PER APP` markers:
+- **Share / referral loop** — the shareable output the user is proud of (one-tap share), and the
+  referral incentive if any (e.g. "both sides get bonus credits").
+- **High-intent prompts** — a tailored conversion prompt at moments where intent is genuinely high
+  (feature/usage limit hit, post-value win, streak/achievement) — not on a timer.
+- **Win-back** — re-engage lapsed or declined users gracefully; tie messages to the captured goal
+  (re-engagement pushes ride on the `enable-notifications` skill).
+
+Build the surfaces as screens/components via the `new-screen` skill; instrument them with
+`Analytics.logScreenView` / custom events (see `setup-analytics`).
+
+## 2. In-app review prompts
+
+In-app review uses the **native OS APIs** (Play In-App Review / StoreKit) — **no console setup, no
+Firebase**. Reference `Documentation/docs/features/inapp-review.md`.
+
+Trigger from a genuine post-value moment via `rememberInAppReviewTrigger()`
+(`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/inappreview/InAppReviewManager.kt`):
+```kotlin
+val reviewTrigger = rememberInAppReviewTrigger()
+LaunchedEffect(Unit) {
+    reviewTrigger.triggerAfterSuccessfulPurchase()   // or triggerWhileGenerationIsInProgress()
+}
+```
+- `InAppReviewTrigger` applies a **7-day cooldown** (`COOLDOWN_DURATION`) plus usage conditions — add
+  your own `trigger*` method for your primary action rather than spamming.
+- Respect the store quotas (Android/iOS limit how often the prompt shows); the OS may silently no-op.
+- For the raw prompt without cooldown, use `rememberInAppReviewManager().requestReview()`.
+
+## Done
+A share/referral surface works and the review prompt fires at a real post-value moment. This is the
+`add-virality-loop` step of the `growth` phase.

--- a/skills/bump-version/SKILL.md
+++ b/skills/bump-version/SKILL.md
@@ -21,3 +21,7 @@ The script updates the Android `versionCode`/`versionName` (in `androidApp/build
 
 1. Show the user the resulting versions (the script prints them).
 2. Releases are tag-driven: pushing a `*-android` tag triggers `.github/workflows/publish_android_playstore.yml`, a `*-ios` tag triggers `publish_ios_appstore.yml`. Don't push tags unless the user asks for a release.
+
+---
+
+*Phase 3 · Publication — part of the [publishing](../publishing/SKILL.md) guide.*

--- a/skills/configure-environment/SKILL.md
+++ b/skills/configure-environment/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: configure-environment
+description: Lay out the full catalog of environment configuration — local.properties API keys, the gradle.properties subscription toggle, and Constants.kt fields — with what each is for, where to get it, and which phase needs it. Use when setting up a new app's keys, wiring a service, or figuring out where a config value lives.
+---
+
+# Configure environment
+
+Three files hold all app configuration. Nothing here is a code change to business logic — it's
+credentials, IDs, and toggles.
+
+| File | Holds | Committed? |
+|------|-------|-----------|
+| `MobileApp/local.properties` | SDK path + all secret API keys | **No — gitignored** |
+| `MobileApp/gradle.properties` | subscription-provider toggle | Yes |
+| `shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/Constants.kt` | URLs, emails, feature flags, Cloud Functions URL | Yes |
+
+> `MobileApp/local.properties` is gitignored (`MobileApp/.gitignore`), so it never ships in the
+> template — you always create/fill it yourself. Keys are read at build time by
+> `shared/build.gradle.kts` via `getRequiredProperty(...)`; missing keys with no default fail the
+> build with `Make sure you added \`<KEY>\` in local.properties`. Most keys have a `defaultValue`
+> ("testValue" or "") so the app still builds without them, but the corresponding feature won't work.
+
+## `MobileApp/local.properties` — key catalog
+
+| Key | For | Where to get it | Needed in phase |
+|-----|-----|-----------------|-----------------|
+| `sdk.dir` | Android SDK location | Your machine's SDK path (`/Users/<you>/Library/Android/sdk`) | getting-started |
+| `GOOGLE_WEB_CLIENT_ID` | Google sign-in (Android + iOS) | Firebase → Auth → Google provider → **Web client ID** | integrations (`enable-auth`) |
+| `SUBSCRIPTION_PROVIDER_ANDROID_API_KEY` | Billing SDK public key (Android) | Adapty or RevenueCat dashboard | publishing / monetization |
+| `SUBSCRIPTION_PROVIDER_IOS_API_KEY` | Billing SDK public key (iOS) | Adapty or RevenueCat dashboard | publishing / monetization |
+| `ADMOB_APP_ID_ANDROID` | AdMob app id (Android) | Google AdMob console | monetization (ads) |
+| `ADMOB_BANNER_AD_ID_ANDROID` | Banner ad unit (Android) | AdMob console | monetization |
+| `ADMOB_INTERSTITIAL_AD_ID_ANDROID` | Interstitial ad unit (Android) | AdMob console | monetization |
+| `ADMOB_REWARDED_AD_ID_ANDROID` | Rewarded ad unit (Android) | AdMob console | monetization |
+| `ADMOB_BANNER_AD_ID_IOS` | Banner ad unit (iOS) | AdMob console | monetization |
+| `ADMOB_INTERSTITIAL_AD_ID_IOS` | Interstitial ad unit (iOS) | AdMob console | monetization |
+| `ADMOB_REWARDED_AD_ID_IOS` | Rewarded ad unit (iOS) | AdMob console | monetization |
+| `IMGBB_TOKEN` | Image hosting/upload token | https://api.imgbb.com/ account | when using image upload |
+| `OPENAI_API_KEY` | Local/dev OpenAI calls | https://platform.openai.com/ | integrations (dev only — prod keys live in Secret Manager, see `integrate-web-proxy`) |
+
+> The AdMob and `ADMOB_APP_ID_ANDROID` value is also consumed in `androidApp/build.gradle.kts`
+> (manifest placeholder). Production Cloud Functions read `OPENAI_API_KEY` / `REPLICATE_API_KEY`
+> from **Google Cloud Secret Manager**, not from `local.properties` — see the `integrate-web-proxy`
+> skill.
+
+Example `MobileApp/local.properties`:
+
+```properties
+sdk.dir=/Users/you/Library/Android/sdk
+GOOGLE_WEB_CLIENT_ID=1234567890-abcdef.apps.googleusercontent.com
+SUBSCRIPTION_PROVIDER_ANDROID_API_KEY=
+SUBSCRIPTION_PROVIDER_IOS_API_KEY=
+ADMOB_APP_ID_ANDROID=
+IMGBB_TOKEN=
+```
+
+## `MobileApp/gradle.properties` — subscription provider toggle
+
+One switch selects the billing backend module and drives `Constants.subscriptionProviderFactory`.
+Default is `ADAPTY`; the alternative is `REVENUECAT`. Both must compile.
+
+```properties
+# Possible options for SUBSCRIPTION_PROVIDER: ADAPTY, REVENUECAT
+SUBSCRIPTION_PROVIDER=ADAPTY
+```
+
+Switching providers = change this property **plus** the provider's API keys in `local.properties`.
+Never hardcode a concrete provider in `Constants.kt`.
+
+## `Constants.kt` — code-level config
+
+`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/Constants.kt`:
+
+| Field | Purpose |
+|-------|---------|
+| `CLOUD_FUNCTIONS_URL` | Base URL of the deployed web proxy — `https://REGION-PROJECT_ID.cloudfunctions.net` (default region `us-central1`). Set in the `integrate-web-proxy` skill. |
+| `AUTH_SOCIAL_LOGIN_ENABLED` | `true` = show Apple + Google sign-in; `false` = anonymous only. |
+| `URL_PRIVACY_POLICY` | Privacy policy URL (needed before store publishing). |
+| `URL_TERMS_CONDITIONS` | Terms & conditions URL. |
+| `CONTACT_EMAIL` | Support/contact email shown in-app. |
+| `APPSTORE_APP_ID` | Numeric App Store app id (for rate/review deep links). |
+| `PAYWALL_PREMIUM_ACCESS` | Entitlement / access-level id for Premium. |
+| `PAYWALL_PLACEMENT_*` | Paywall placement identifiers (credits pack, default, onboarding). |
+
+Runtime **feature flags** live separately in
+`shared/src/commonMain/.../data/source/featureflag/FeatureFlagManager.kt`.
+
+## Next
+
+With the catalog understood, continue the `integrations` guide: `setup-firebase` →
+`enable-auth` → `integrate-web-proxy`.

--- a/skills/design-onboarding/SKILL.md
+++ b/skills/design-onboarding/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: design-onboarding
+description: Design and build the app's first-run onboarding — capture the user's goal, deliver a first taste of value, and prime permissions — grounded in the onboarding designer role and the project onboarding spec. Use when the developer wants to create, redesign, or polish onboarding / the first-run flow / activation.
+---
+
+# Design onboarding
+
+Onboarding's job: **capture intent → build commitment → deliver first value → hand off to the
+paywall** at the motivation peak. This is a designer-handoff skill — the strategy lives in the
+guidelines, the screens are built with the `new-screen` skill.
+
+## 1. Fill the product spec first
+
+Open `AiGuidelines/project/onboarding.md` and fill its `TAILOR PER APP` markers for this app:
+- **Pattern** — short emotional (3–4 screens) vs. questionnaire/quiz-led (9–20). Pick with a reason
+  tied to the app, don't default to a length.
+- **Goal-capture question** — the user's primary goal, asked early and echoed on the paywall (usually
+  the biggest lever).
+- **First-taste moment** — let the user *use the core mechanic once* (a real output) before any ask.
+- **Permission priming** — a benefit-framed screen before every system permission; never open with a
+  permission wall.
+
+## 2. Author the flow with the designer role
+
+Read `AiGuidelines/agents/onboarding_designer.md` and act in that role to produce the screen-by-screen
+copy brief (headlines, subcopy, CTAs, step order). It reads the spec you just filled plus
+`prd.md` / `user_flow.md`.
+
+## 3. Build the screens
+
+Existing onboarding lives at
+`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/presentation/screens/onboarding/`
+(`OnBoardingScreen.kt`, `OnBoardingScreenVariation1/2.kt`, `OnBoardingUiState.kt`,
+`OnBoardingViewModel.kt`). Refine those or add new steps via the **`new-screen`** skill (Screen +
+UiState + ViewModel, wired into navigation + DI).
+
+- **Permission priming ties to `enable-notifications`.** The notification-permission priming step
+  should precede `rememberNotificationPermissionState().request()` with a benefit-framed screen (e.g.
+  "reminders for your goal").
+- Persist "onboarding shown" with the `save-preferences` skill so it runs once.
+- Instrument each step with `Analytics.logScreenView` (see `setup-analytics`) so drop-off is
+  measurable.
+
+## Done
+Onboarding runs end to end, captures the goal, delivers a first taste, and primes permissions. This is
+the `design-onboarding` step of the `growth` phase.

--- a/skills/design-paywall/SKILL.md
+++ b/skills/design-paywall/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: design-paywall
+description: >-
+  Author the app's paywall offer — primary model, prices, trial framing, credit-pack sizes, and
+  benefit-oriented copy — using the paywall_designer role prompt and the paywall.md template, then map
+  the decisions onto PaywallUiState / PaywallMode and the paywall_* strings. Use when the user wants to
+  design a paywall, define the offer/pricing/trial, or write paywall copy. Part of the `monetization`
+  phase; run it before `setup-subscriptions`.
+---
+
+# Design the paywall
+
+This is a **designer-handoff** skill, not a code generator. It produces the *offer decisions* that
+`setup-subscriptions` and `enable-credits` then create products for — so run it **first**. The custom
+paywall UI already exists; you're authoring what it sells and how it reads.
+
+## 1. Author the offer
+
+Read the two source docs and use them to make real decisions (honest framing only — no fake scarcity,
+no buried cancel, no misleading "free"):
+
+- **`AiGuidelines/agents/paywall_designer.md`** — the monetization-strategist role prompt: offer
+  architecture (hook → anchor → discount → backup), trial-length tradeoffs, credit-pack anchoring, the
+  A/B variation toolkit, and the events to measure.
+- **`AiGuidelines/project/paywall.md`** — the fill-in template. Search for **`TAILOR PER APP`** markers
+  and replace each with a real decision:
+  - **Primary model** — subscription-first, credit-pack, or remote? (Don't weight two equally if one
+    leads.)
+  - **Prices & packages** — monthly $ / annual $ (save %) / lifetime $.
+  - **Trial length + reasoning** — short (3-day, urgency) vs. longer (higher considered-purchase
+    conversion). State terms honestly: "X days free, then $Y/period. Cancel anytime."
+  - **Credit-pack sizes + the genuinely recommended pack.**
+
+Also reuse the goal captured in onboarding (`AiGuidelines/project/onboarding.md`) so the paywall reads
+"To help you *{goal}*, your plan includes…". Placement is the **post-onboarding motivation peak**, not
+a cold launch wall.
+
+## 2. Map decisions onto the code
+
+The offer flows into the existing paywall layer at
+`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/presentation/screens/paywall/`:
+
+- **`PaywallMode`** (`SUBSCRIPTION` / `CREDIT_PACK`) selects the child screen. Your primary model picks
+  which the paywall leads with; the credit-pack flow opens via
+  `Constants.PAYWALL_PLACEMENT_CREDITS_PACK`.
+- **`PaywallUiStateMapper`** is the only place formatting lives — it turns raw provider packages +
+  selection + mode into a `MappedPaywall { packages, ctaText, aboveCtaText, belowCtaText }`. Screens
+  stay display-only. You usually don't change the mapper; you change the **copy** it references.
+- **Strings** live in `composeResources/values/strings.xml` under three prefixes — edit these to land
+  your copy (benefit-oriented CTA, honest reassurance + disclosure):
+  - `paywall_*` — shared chrome (toolbar, footer, BEST VALUE / SAVE N% badges).
+  - `paywall_sub_*` — subscription flow (plan titles, subtitles, reassurance/disclosure templates, CTA).
+  - `paywall_cp_*` — credit-pack flow (title, subtitle, per-credit unit, CTA).
+  - `paywall_unit_*` — period units as **plurals** (`paywall_unit_day` bare vs. `paywall_unit_day_count`
+    for durations).
+  - `strings.xml` here is plain XML, not Android aapt — do **not** backslash-escape apostrophes; use the
+    typographic `'` (U+2019) to match existing copy. Format args stay `%1$s` / `%1$d`.
+- To add a **brand-new placement** (beyond subscription / credit-pack), see CLAUDE.md → *Paywall Layer*:
+  add a `Constants.PAYWALL_PLACEMENT_*`, a `PaywallMode` entry, mapper branches, a `PaywallScreen`
+  route, and a new `paywall_<prefix>_*` string group.
+
+## Preview your copy
+
+Fixtures in `PaywallPreviewData` (`subscriptionState(...)`, `paidIntroSubscriptionState()`,
+`creditPackState()`) drive the `@Preview` composables so you can eyeball copy without billing wired up.
+Run the design-system desktop preview or use the `store-screenshots` skill for pixel captures.
+
+## Hand-off
+
+Once `paywall.md` has **no** remaining `TAILOR PER APP` markers, the offer is decided — proceed to
+**`setup-subscriptions`** (subscriptions) and **`enable-credits`** (credit packs) to create the matching
+products.
+
+## Related skills
+
+`setup-subscriptions` · `enable-credits` · `store-screenshots` (paywall PNGs) ·
+`monetization` (phase guide).

--- a/skills/design-paywall/SKILL.md
+++ b/skills/design-paywall/SKILL.md
@@ -55,7 +55,7 @@ The offer flows into the existing paywall layer at
     for durations).
   - `strings.xml` here is plain XML, not Android aapt — do **not** backslash-escape apostrophes; use the
     typographic `'` (U+2019) to match existing copy. Format args stay `%1$s` / `%1$d`.
-- To add a **brand-new placement** (beyond subscription / credit-pack), see CLAUDE.md → *Paywall Layer*:
+- To add a **brand-new placement** (beyond subscription / credit-pack), see `AGENTS.md` → *Paywall Layer*:
   add a `Constants.PAYWALL_PLACEMENT_*`, a `PaywallMode` entry, mapper branches, a `PaywallScreen`
   route, and a new `paywall_<prefix>_*` string group.
 

--- a/skills/enable-ads/SKILL.md
+++ b/skills/enable-ads/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: enable-ads
+description: >-
+  Turn on Google AdMob in KMPStarterKit — flip the ads feature flag, drop banner/interstitial/rewarded
+  ad composables in, add the AdMob app + ad-unit IDs to local.properties (+ iOS BaseConfig.xcconfig),
+  and update store data-safety declarations. Use when the user wants ads, AdMob, banner/interstitial/
+  rewarded ads, or ad-based monetization. Part of the `monetization` phase.
+---
+
+# Enable ads (AdMob)
+
+Ads are **off by default**. This skill turns them on and places the three supported ad types. All
+manual — AdMob console + a few config + code edits. Gradle commands run from `MobileApp/`.
+
+## 1. Flip the feature flag
+
+Set `IS_ADS_ENABLED` to `true` in `data/source/featureflag/FeatureFlagManager.kt`. It's a feature
+flag, so you can also toggle it remotely via **Firebase Remote Config** (key `is_ads_enabled`) without
+shipping a build. While ads are disabled, `rememberInterstitialAdDisplayer()` /
+`rememberRewardedAdDisplayer()` return `null` — that's expected.
+
+## 2. Ad-unit IDs → `local.properties`
+
+Add the IDs for the platforms + ad types you want (`MobileApp/local.properties`):
+
+```properties
+# Android
+ADMOB_APP_ID_ANDROID=
+ADMOB_BANNER_AD_ID_ANDROID=
+ADMOB_INTERSTITIAL_AD_ID_ANDROID=
+ADMOB_REWARDED_AD_ID_ANDROID=
+
+# iOS
+ADMOB_BANNER_AD_ID_IOS=
+ADMOB_INTERSTITIAL_AD_ID_IOS=
+ADMOB_REWARDED_AD_ID_IOS=
+```
+
+**iOS app id** goes in `iosApp`'s `BaseConfig.xcconfig` as `ADMOB_APP_ID=YOUR_ADMOB_IOS_APP_ID_HERE`
+(not in `local.properties`).
+
+Create the app + ad units in the [AdMob console](https://apps.admob.com/) (Apps → Add app → Ad units).
+
+## 3. Use test ad IDs during development
+
+**Do not** hammer your real ad units while developing — clicking your own live ads violates AdMob
+policy and can get the account suspended. Use Google's official
+[sample ad unit IDs](https://developers.google.com/admob/android/test-ads) in `local.properties`
+during dev, and swap in the real IDs only for release builds.
+
+## 4. Place ads
+
+**Banner** — drop the composable into any screen:
+
+```kotlin
+AdmobBanner(modifier = Modifier.fillMaxWidth())
+```
+
+**Interstitial** — full-screen, show on a natural break (level end, screen exit):
+
+```kotlin
+val interstitialAdDisplayer = rememberInterstitialAdDisplayer()
+// on some action:
+interstitialAdDisplayer?.show()
+```
+
+**Rewarded** — user opts in for a reward (great with the credit system — grant credits on reward):
+
+```kotlin
+val rewardedAdDisplayer = rememberRewardedAdDisplayer(onRewarded = { rewardItem ->
+    // reward the user here, e.g. creditRepository.addCredits(...)
+})
+rewardedAdDisplayer?.show()
+```
+
+Preload to avoid a wait — inject `AdsManager` (e.g. `koinInject<AdsManager>()`) and call
+`adsManager.rewardedAdLoader.load()` / `adsManager.interstitialAdLoader.load()` ahead of time; both
+loaders are singletons so preloading is safe.
+
+## 5. Store data-safety implications (User Action)
+
+AdMob collects the **advertising ID** and device/usage data. You must disclose this:
+
+- **Google Play** → App content → **Data safety**: declare collection of advertising ID + usage data,
+  and complete the ads declaration.
+- **App Store Connect** → App Privacy: declare the data types the ad SDK collects; add
+  **App Tracking Transparency** prompt handling on iOS if you track across apps.
+
+Skipping this can get the app rejected or pulled.
+
+## Validation
+
+- `./gradlew :androidApp:assembleDebug` builds; run the app and confirm a **test** banner/interstitial/
+  rewarded ad renders.
+- Run the `run-quality-gates` skill before committing.
+
+## Related skills
+
+`enable-credits` (rewarded ads → credits) · `setup-subscriptions` · `monetization` (phase guide).

--- a/skills/enable-auth/SKILL.md
+++ b/skills/enable-auth/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: enable-auth
+description: Enable Google and Apple social sign-in on top of Firebase Auth — enable the providers, set GOOGLE_WEB_CLIENT_ID, wire iOS Info.plist client IDs, add the iOS Sign In with Apple capability, and confirm the AUTH_SOCIAL_LOGIN_ENABLED flag. Use when the developer wants social login / Google or Apple sign-in in the app.
+---
+
+# Enable social auth (Google + Apple)
+
+Adds Google and Apple sign-in on top of the base Firebase project. Requires `setup-firebase` done
+first (project + registered apps + anonymous auth). Auth is implemented via the `libs/auth/` module
+(`auth-api` contracts + `auth-firebase` implementation, using KMPAuth); `UserRepository` exposes
+`continueAsGuest()`, `logOut()`, `deleteAccount()`, and `currentUser`. `SignInScreen` already wires
+the UI — you're supplying credentials, not writing auth code.
+
+## 1. Confirm the feature flag — Agent Action
+
+In `shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/Constants.kt`:
+
+```kotlin
+const val AUTH_SOCIAL_LOGIN_ENABLED = true
+```
+
+`true` (default) shows Apple + Google buttons; `false` = anonymous/guest only. Leave `true` for this
+skill.
+
+## 2. Enable providers in Firebase — User Action
+
+Firebase Console → **Authentication → Sign-in method**:
+- Enable **Google**.
+- Enable **Apple**.
+
+After enabling, re-download `google-services.json` (Android) and `GoogleService-Info.plist` (iOS)
+and replace the files placed in `setup-firebase` — enabling a provider can change the config.
+
+## 3. Google sign-in — Web client ID — User Action
+
+Google sign-in on **both** Android and iOS uses the Firebase **Web client ID**.
+
+- Find it in Firebase → Auth → Google provider (or Google Cloud → APIs & Services → Credentials →
+  "Web client (auto created by Google Service)").
+- Put it in `MobileApp/local.properties`:
+
+  ```properties
+  GOOGLE_WEB_CLIENT_ID=1234567890-abcdef.apps.googleusercontent.com
+  ```
+
+### iOS Info.plist — User Action
+
+In `MobileApp/iosApp/iosApp/Info.plist`, fill these using values from `GoogleService-Info.plist`
+(`CLIENT_ID`, `REVERSED_CLIENT_ID`) and the same Web client ID:
+
+```xml
+<key>GIDServerClientID</key>
+<string>YOUR_WEB_CLIENT_ID</string>
+
+<key>GIDClientID</key>
+<string>YOUR_IOS_CLIENT_ID</string>
+
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>YOUR_DOT_REVERSED_IOS_CLIENT_ID</string>
+    </array>
+  </dict>
+</array>
+```
+
+## 4. Apple sign-in — User Action
+
+**iOS:** In Xcode → target → **Signing & Capabilities → + → Sign In with Apple**.
+
+**Android (Apple via web flow):** needs an Apple Developer setup —
+1. Create a **Sign In with Apple** auth key (`.p8`); note the **Key ID** and **Team ID**.
+2. Create a **Service ID** (e.g. `com.yourcompany.yourapp.auth`), enable Sign In with Apple,
+   configure with the Primary App ID, and set:
+   - Return URL: `https://<your-app-id>.firebaseapp.com/__/auth/handler`
+   - Domain: `<your-app-id>.firebaseapp.com`
+3. In Firebase → Auth → Apple provider, paste the `.p8` content, Key ID, Team ID, and Service ID.
+
+## 5. Validate — Validation
+
+Build and run (Android is fastest — `./gradlew :androidApp:assembleDebug` from `MobileApp/`, then
+launch). On `SignInScreen`, Google and Apple buttons should appear and complete a real sign-in;
+**Continue as guest** should still work (calls `continueAsGuest()`).
+
+## Next
+
+Deploy the AI web proxy and make an authenticated remote call → `integrate-web-proxy`.

--- a/skills/enable-credits/SKILL.md
+++ b/skills/enable-credits/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: enable-credits
+description: >-
+  Configure KMPStarterKit's local credit system — the earn/spend DSL (one-time bonuses, recurring
+  daily/weekly/monthly rewards, credit-source ordering) in root/Di.kt, and wire credit-pack IAPs
+  (consumables) to credit grants. Use when the user wants credits, tokens, a credit balance,
+  credit packs, or a consumable in-app purchase that adds credits. Part of the `monetization` phase.
+---
+
+# Enable credits
+
+KMPStarterKit has a fully local, configurable credit system: users **earn, buy, and spend** credits,
+balances + transactions are stored on-device (mix of `UserPreferences` + Room), and behavior is
+defined with a small DSL. A `CreditBalanceScreen` and a Home-toolbar balance badge already exist.
+This skill is about configuring the rules and wiring credit-pack purchases. Everything is manual.
+
+## 1. Configure the credit DSL
+
+The config lives in **`root/Di.kt`**, in the `initializeCreditSystem()` method, as a
+`creditSystemConfig { ... }` block passed to `CreditRepository`:
+
+```kotlin
+val appCreditSystemConfig = creditSystemConfig {
+    // One-time bonus for new users
+    oneTimeBonus("welcome_bonus_credit", 1)
+
+    // Optional: conditional one-time bonus
+    // oneTimeBonus(
+    //     id = "referral_bonus",
+    //     amount = 1,
+    //     condition = { userPreferences.getBoolean(UserPreferences.KEY_REFERRAL_COMPLETED) },
+    // )
+
+    // Free plan → 2 credits weekly
+    // recurringWeekly(
+    //     id = "free_plan_weekly",
+    //     amount = 2,
+    //     condition = { !subscriptionRepository.hasPremiumAccess() },
+    // )
+
+    // Premium → 10 credits weekly
+    recurringWeekly(
+        id = "premium_plan_weekly",
+        amount = 10,
+        condition = { subscriptionRepository.hasPremiumAccess() },
+    )
+}
+```
+
+Available rule builders:
+
+- `oneTimeBonus(id, amount, condition?)` — granted once (optionally gated by a condition).
+- `recurringDaily(id, amount, condition?)` / `recurringWeekly(...)` / `recurringMonthly(...)` —
+  time-based grants; `condition` typically checks `subscriptionRepository.hasPremiumAccess()` or the
+  subscription duration type.
+
+Each rule declares its own **credit source**; the order you list rules defines the **deduction
+ordering** (which source is spent first). Give every rule a stable unique `id` — it keys the
+per-source balance and the once-only accounting.
+
+## 2. Spend and grant credits in code
+
+```kotlin
+// Deduct (default 1). Throws CreditRequiredException if balance is insufficient.
+creditRepository.useCredits()                        // 1 credit
+creditRepository.useCredits(3)                        // 3 credits
+creditRepository.useCredits(1, "AI Room Generation")  // with description
+
+// Add credits (from a purchase, a rewarded ad, a promo code)
+creditRepository.addCredits(
+    amount = 10,
+    type = CreditTransaction.Type.PURCHASE,
+    description = "10-credit pack",
+)
+```
+
+Gate a premium feature by catching `CreditRequiredException` and routing to the credit-pack paywall.
+
+## 3. Credit-pack IAPs (consumables)
+
+Credit packs are sold through the **same subscription provider** as `setup-subscriptions`, as a
+separate paywall placement:
+
+- The provider/entitlement plumbing is shared — see the **`setup-subscriptions`** skill first.
+- The credit-pack placement id is `Constants.PAYWALL_PLACEMENT_CREDITS_PACK` (`"credits_pack"`). Open
+  it with `navigator.navigate(PaywallScreenRoute(placementId = Constants.PAYWALL_PLACEMENT_CREDITS_PACK))`;
+  `PaywallViewModel` derives `PaywallMode.CREDIT_PACK` and renders `CreditPackPaywallScreen`.
+- **Store side (User Action):** create the credit packs as **consumable** in-app products (NOT
+  subscriptions) in **App Store Connect** and **Google Play Console**, with aligned cross-platform IDs.
+  Register them under the credit-pack placement in the provider dashboard
+  ([Adapty](https://app.adapty.io/) / [RevenueCat](https://app.revenuecat.com/)).
+- **Grant on success:** on a successful credit-pack purchase, call `creditRepository.addCredits(amount,
+  CreditTransaction.Type.PURCHASE, ...)` with the pack's credit count. The paywall success handling in
+  `PaywallViewModel` is where the pack → credit-count mapping is applied.
+
+## Storage note
+
+Credits are **local-only** by default (on-device). That's fine for most early-stage apps. Only add
+backend/server-verified credit sync (e.g. Firestore) if you see abuse, need cross-device sync, or need
+server-verified purchases — it adds real cost and complexity.
+
+## Validation
+
+- App builds (`./gradlew :androidApp:assembleDebug`) and the `CreditBalanceScreen` / toolbar badge
+  reflect configured bonuses.
+- The credit-pack paywall lists your packs; a sandbox purchase calls `addCredits(...)` and the balance
+  increases.
+- Run the `run-quality-gates` skill before committing.
+
+## Related skills
+
+`setup-subscriptions` (provider + placement plumbing) · `design-paywall` (credit-pack offer copy) ·
+`enable-ads` (rewarded ads can grant credits) · `monetization` (phase guide).

--- a/skills/enable-notifications/SKILL.md
+++ b/skills/enable-notifications/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: enable-notifications
+description: Enable push (FCM) and local notifications in the KMP app via KMPNotifier 2.0, set up iOS APNs, request the notification runtime permission, and send a test push. Use when the developer wants push notifications, local notifications, re-engagement pings, or FCM. Firebase must already be set up (integrations phase).
+---
+
+# Enable notifications (push + local)
+
+Notifications use **KMPNotifier 2.0**, split into two modules already on the classpath:
+`kmpnotifier-local` (local notifications) + `kmpnotifier-push-firebase` (FCM push). Push rides on the
+Firebase project from the `integrations` phase — no new project.
+
+## 1. Listeners (already wired)
+
+`AppInitializer.initializeNotification()`
+(`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/root/AppInitializer.kt`) registers:
+- `KMPNotifier.addListener { onNotificationClicked(data) }` — user tapped a notification.
+- `KMPNotifier.addPushListener { onNewToken(token); onPushNotificationWithPayloadData(...) }` — the
+  device FCM token (log it) and incoming pushes.
+
+To grab the device token for a test send, it's logged as `Firebase onNewToken: <token>` — read it
+from the logs after launch. Send local notifications with the `KMPNotifier` local API when you need
+an on-device reminder (no server round-trip). Deep-link taps by branching on the payload in
+`onNotificationClicked`.
+
+## 2. Runtime permission (Android 13+ / iOS)
+
+Ask through the app-level permission wrapper, not KMPNotifier or Calf directly. Use
+`rememberNotificationPermissionState()` and prime it benefit-first (see the `add-permission` skill).
+The demo `HomeScreen` uses `RequestPermissionOnEntry(rememberNotificationPermissionState { ... })`.
+Notifications need **no** iOS `Info.plist` usage-description key.
+
+## 3. iOS APNs setup (User Action)
+
+Push on iOS requires an APNs auth key uploaded to Firebase:
+1. **Apple Developer portal** (https://developer.apple.com/account/) → **Certificates, Identifiers &
+   Profiles → Keys → +**. Name it, check **Apple Push Notifications service (APNs)**, Continue →
+   Register, and **download the `.p8`** (one-time download — keep it safe; note the Key ID + Team ID).
+2. **Firebase Console → Project settings → Cloud Messaging → Apple app configuration** → upload the
+   `.p8` with its Key ID and Team ID.
+3. **Xcode** → app target → **Signing & Capabilities**: add **Push Notifications** and **Background
+   Modes → Remote notifications**; confirm the correct **Team** is selected (must match the APNs
+   key's team). iOS deployment target must be **16.0+**.
+
+Android needs no APNs — `google-services.json` already carries the FCM config.
+
+## 4. Send a test push (User Action)
+
+Firebase Console → **Messaging (Cloud Messaging) → Send a message** → compose a notification → **Send
+test message** → paste the device FCM token from the logs. Confirm it arrives on a real device (push
+does not deliver to simulators/emulators reliably — use a physical device for iOS).
+
+## Done
+A test push is received on-device and the notification permission prompt appears on first entry. This
+is the `enable-notifications` step of the `growth` phase. Advanced usage:
+https://github.com/mirzemehdi/KMPNotifier#usage.

--- a/skills/generate-app-icons/SKILL.md
+++ b/skills/generate-app-icons/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: generate-app-icons
+description: Generate the iOS AppIcon.appiconset and Android adaptive launcher mipmaps from one source logo. Use when the user wants to set/replace the app icon, launcher icon, or app store icon before publishing.
+---
+
+# Generate app icons
+
+Produce all platform icon assets from **one square source logo** (PNG, at least
+1024×1024, no transparency for the App Store 1024 marketing icon). This is part of
+the **publishing** phase — do it once per rebrand.
+
+## Source logo
+
+Ask the user for a single square PNG. Everything below is derived from it. If they
+only have an SVG, rasterize it to a 1024×1024 PNG first.
+
+## Android — adaptive launcher (`androidApp/src/main/res/`)
+
+Android uses an **adaptive icon**: a foreground layer + a background color, composited
+and masked by the launcher. The starter kit already has the wiring — you replace the
+raster foregrounds and the background color:
+
+```
+androidApp/src/main/res/
+├── mipmap-mdpi/     ic_launcher.webp, ic_launcher_foreground.webp, ic_launcher_round.webp
+├── mipmap-hdpi/     …same three…
+├── mipmap-xhdpi/    …
+├── mipmap-xxhdpi/   …
+├── mipmap-xxxhdpi/  …
+├── mipmap-anydpi-v26/  ic_launcher.xml, ic_launcher_round.xml   (adaptive descriptors — leave as-is)
+└── values/colors.xml   → <color name="ic_launcher_background">…</color>
+```
+
+Foreground `ic_launcher_foreground.webp` sizes per density bucket (foreground is drawn
+into a 108dp × 108dp canvas; only the centre 72dp × 72dp "safe zone" is guaranteed
+visible after masking, so keep the logo well inside):
+
+| Density bucket | Foreground px |
+|----------------|---------------|
+| mdpi (1×)      | 108 × 108     |
+| hdpi (1.5×)    | 162 × 162     |
+| xhdpi (2×)     | 216 × 216     |
+| xxhdpi (3×)    | 324 × 324     |
+| xxxhdpi (4×)   | 432 × 432     |
+
+The legacy `ic_launcher.webp` / `ic_launcher_round.webp` fallbacks are 48/72/96/144/192
+px for the same buckets.
+
+**Easiest path (recommended):** Android Studio → right-click `androidApp/src/main/res/`
+→ **New > Image Asset** → *Launcher Icons (Adaptive and Legacy)* → pick the source PNG →
+Finish. It regenerates every density + WebP conversion automatically. Then set the
+adaptive background in `androidApp/src/main/res/values/colors.xml`
+(`ic_launcher_background`).
+
+The adaptive-icon descriptors in `mipmap-anydpi-v26/` and the `<color>` names are already
+correct — only the pixels and the background color change.
+
+## iOS — `iosApp/iosApp/Assets.xcassets/AppIcon.appiconset/`
+
+The appiconset ships a full flat file set (`Contents.json` maps each filename to a
+`size`/`scale`/`idiom`). Regenerate the whole set from the 1024 source and drop the
+files in, keeping the **same filenames** so `Contents.json` still resolves. Required
+sizes (rendered px = size × scale):
+
+| Purpose                | pt    | scales      | px files                 |
+|------------------------|-------|-------------|--------------------------|
+| iPhone notification    | 20    | 2×, 3×      | 40, 60                   |
+| iPhone settings        | 29    | 2×, 3×      | 58, 87                   |
+| iPhone spotlight       | 40    | 2×, 3×      | 80, 120                  |
+| iPhone app             | 60    | 2×, 3×      | 120, 180                 |
+| iPad notification      | 20    | 1×, 2×      | 20, 40                   |
+| iPad settings          | 29    | 1×, 2×      | 29, 58                   |
+| iPad spotlight         | 40    | 1×, 2×      | 40, 80                   |
+| iPad app               | 76    | 1×, 2×      | 76, 152                  |
+| iPad Pro app           | 83.5  | 2×          | 167                      |
+| App Store marketing    | 1024  | 1×          | 1024 (no alpha)          |
+
+**Easiest path:** upload the 1024 PNG to a generator like
+[appicon.co](https://www.appicon.co/) (select iPhone + iPad), download the produced
+`AppIcon.appiconset`, and replace the folder contents in
+`iosApp/iosApp/Assets.xcassets/AppIcon.appiconset/` (keep the generated `Contents.json`).
+
+## Splash logo (separate from the launcher icon)
+
+Publishing branding also touches the native splash screens (see CLAUDE.md → *Splash
+Screen*). The splash uses the **brand logo shown uncut**, not the masked launcher icon:
+
+- iOS splash logo → `iosApp/iosApp/Assets.xcassets/ic_logo.imageset/ic_logo.png` (single
+  universal image). Splash background → `SplashBackground.colorset` (keep equal to the
+  app window background `windowBackgroundColor`, currently `#F0EDE5`, so the hand-off has
+  no flash).
+- Android splash background → `windowBackgroundColor` in
+  `androidApp/src/main/res/values/colors.xml` (the native splash icon is the masked
+  adaptive launcher icon; the uncut brand logo is drawn by the Compose onboarding
+  `LogoImage`).
+
+## Validate
+
+- Android: `./gradlew :androidApp:assembleDebug` (from `MobileApp/`), install, confirm the
+  launcher icon renders crisp and uncropped in the app drawer.
+- iOS: open the workspace in Xcode, check the target's **General → App Icons** shows a full
+  set with no missing-slot warnings.

--- a/skills/generate-app-icons/SKILL.md
+++ b/skills/generate-app-icons/SKILL.md
@@ -82,7 +82,7 @@ sizes (rendered px = size × scale):
 
 ## Splash logo (separate from the launcher icon)
 
-Publishing branding also touches the native splash screens (see CLAUDE.md → *Splash
+Publishing branding also touches the native splash screens (see `AGENTS.md` → *Splash
 Screen*). The splash uses the **brand logo shown uncut**, not the masked launcher icon:
 
 - iOS splash logo → `iosApp/iosApp/Assets.xcassets/ic_logo.imageset/ic_logo.png` (single

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: getting-started
+description: Phase-1 blueprint for the KMP starter kit — get the app running locally on your own device, rebrand it, and drive it with a screen, a Room model, a preference, a network call, and a permission (all LOCAL-only). Use when getting started with the KMP contest starter kit / on first run / initial setup, before touching Firebase, backend, or publishing.
+---
+
+# Getting Started — Phase 1 (First Run, LOCAL-ONLY)
+
+**Goal:** get the app **running on your own device/emulator**, rebranded to your app, and driven
+**purely locally** — one screen, one Room model, one preference, one plain network request, one device
+permission. Prove the loop end-to-end before adding any cloud services.
+
+**Explicitly deferred to later phases** (do NOT do these now):
+- Firebase (Analytics, Messaging, Crashlytics, RemoteConfig), authentication, backend / web-proxy → the **`integrations`** guide.
+- App Store / Play Store, signing for release, subscriptions/monetization → the **`publishing`** guide.
+
+## STOP rule
+
+> When the next unchecked item is a **User Action**, stop and wait for the developer to confirm they've
+> done it before continuing. Never fabricate device state or credentials.
+
+## Role labels
+
+- **Agent Action** — an AI agent (or dev) can do it directly: edit code, run a script/gradle.
+- **User Action** — human-only: install tooling, set paths, run the app on a device, look at the screen.
+- **Validation** — a concrete check/gate before moving on.
+
+---
+
+## Checklist (ordered)
+
+### A. Prerequisites & first run
+
+1. **User Action** — Install **JDK 17+** and **Android Studio** (bundles the Android SDK). macOS-only for iOS: install **Xcode**.
+2. **Agent Action** — Ensure `sdk.dir=/path/to/Android/sdk` is set in `MobileApp/local.properties` (see the `run-the-app` skill).
+3. **User Action** — Run the app once. Fastest sanity check is Desktop: `./gradlew :desktopApp:run` from `MobileApp/`. (Android: emulator + `:androidApp:installDebug`; Web: `:webApp:wasmJsBrowserDevelopmentRun`.) Use the `run-the-app` skill for exact commands per platform.
+4. **Validation** — The app launches and shows the **Home** screen on at least one platform.
+
+### B. Rebrand to your app
+
+5. **Agent Action** — Rename the package / applicationId / iOS bundle ID + display name with the **`refactor-package`** skill:
+   ```bash
+   ./scripts/refactor_package.sh --app-id com.example.newapp --app-name NewApp
+   ```
+6. **Validation** — App still builds after the rename (`./gradlew :androidApp:assembleDebug` or `:desktopApp:run`).
+
+### C. Define the product (grounds everything downstream)
+
+7. **Agent Action** — Fill `AiGuidelines/project/prd.md` (what the app is, who it's for, scope, core value). Search for `TAILOR PER APP` markers.
+8. **Agent Action** — Fill `AiGuidelines/project/user_flow.md` (primary flows + screen sequence).
+
+### D. Build the local loop
+
+9. **Agent Action** — Add a screen with the **`new-screen`** skill (`./scripts/generate_screen.sh YourScreenName` — scaffolds Screen + UiState + ViewModel and wires route + DI). Implement the UI.
+10. **Agent Action** — Persist data locally with the **`new-local-model`** skill (`./scripts/make_local.sh ModelName` — Room entity + DAO + DB registration + Koin). Add real columns and use it from a repository/ViewModel.
+11. **Agent Action** — Add a network request with the **`add-api-service`** skill (DTOs → API service → repository via `backgroundExecutor.execute { }` → ViewModel). Any public URL works — no project backend needed.
+12. **Agent Action** — Store a setting with the **`save-preferences`** skill (add a key to `UserPreferences.Keys`, read/write via the injected `UserPreferences`).
+13. **Agent Action** — Ask for a device permission with the **`add-permission`** skill (`rememberCameraPermissionState()` etc. or `rememberAppPermissionState(...)`; add iOS `NS*UsageDescription` if needed).
+
+### E. Validate
+
+14. **Agent Action** — Run the **`run-quality-gates`** skill (`spotlessApply`/`spotlessCheck`, `:shared:jvmTest :shared:testAndroidHostTest`, `:androidApp:assembleDebug`).
+15. **User Action** — Re-run the app and confirm the new screen + data/preference/permission behave as expected on a device.
+
+---
+
+## Validation gate (Phase 1 done)
+
+> **App launches on at least one platform and shows the Home screen; quality gates pass.**
+
+Once green, move on to the **`integrations`** guide (Firebase, auth, backend/web-proxy), then
+**`publishing`**.
+
+Track your progress by copying `progress-template.md` (next to this file) into your repo.

--- a/skills/getting-started/progress-template.md
+++ b/skills/getting-started/progress-template.md
@@ -1,0 +1,35 @@
+# Phase 1 progress — First Run (LOCAL-ONLY)
+
+Copy this file into your repo (e.g. `PROGRESS.md`) and tick items as you go. Full instructions are in
+the `getting-started` skill. Role labels: **User** = human-only, **Agent** = AI/dev can do it,
+**Validation** = a gate. Stop at any unchecked **User** item and wait for confirmation.
+
+## A. Prerequisites & first run
+- [ ] **User** — Install JDK 17+ and Android Studio (Android SDK). macOS/iOS: install Xcode.
+- [ ] **Agent** — `sdk.dir=` set in `MobileApp/local.properties` (`run-the-app` skill).
+- [ ] **User** — Run the app (`./gradlew :desktopApp:run`, or Android/Web) from `MobileApp/`.
+- [ ] **Validation** — App launches and shows the Home screen on at least one platform.
+
+## B. Rebrand
+- [ ] **Agent** — Rename package/appId/bundle/name (`refactor-package` skill).
+- [ ] **Validation** — App still builds after the rename.
+
+## C. Define the product
+- [ ] **Agent** — Fill `AiGuidelines/project/prd.md`.
+- [ ] **Agent** — Fill `AiGuidelines/project/user_flow.md`.
+
+## D. Local loop
+- [ ] **Agent** — Add a screen (`new-screen` skill) and implement its UI.
+- [ ] **Agent** — Persist a model locally (`new-local-model` skill).
+- [ ] **Agent** — Add a network request (`add-api-service` skill).
+- [ ] **Agent** — Store a setting (`save-preferences` skill).
+- [ ] **Agent** — Request a device permission (`add-permission` skill).
+
+## E. Validate
+- [ ] **Agent** — Run quality gates (`run-quality-gates` skill).
+- [ ] **User** — Re-run the app; confirm new screen/data/preference/permission work on a device.
+
+## Gate
+- [ ] App launches on at least one platform and shows the Home screen; quality gates pass.
+
+Next: the `integrations` guide (Firebase, auth, backend), then `publishing`.

--- a/skills/growth/SKILL.md
+++ b/skills/growth/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: growth
+description: Phase-5 guide to retain and scale a monetizing KMP app — Firebase Analytics + Crashlytics + Remote Config feature flags, push + local notifications, onboarding polish, and virality/referral loops with in-app review. Use when the developer asks to do growth / retention / scale the KMP contest starter kit, add analytics, wire push notifications, improve onboarding, or add referral/share/win-back loops. Prereq: Firebase from the `integrations` phase.
+---
+
+# Phase 5 — Growth (retention & scale)
+
+**Goal:** take the monetizing app and grow it — instrument it so you can *see* behaviour
+(Analytics + Crashlytics + Remote Config feature flags), bring users back (push + local
+notifications), sharpen the first-run funnel (onboarding), and turn happy users into new ones
+(virality / referral loops + in-app review prompts).
+
+This is the **blueprint orchestrator** for the phase. Work the checklist top to bottom. Each step is
+tagged **Agent Action** (you do it), **User Action** (the developer must do it in a browser/console),
+or **Validation** (prove it works). Steps compose the four atomic skills — read the referenced skill
+before doing that step.
+
+Track progress in a copy of [`progress-template.md`](progress-template.md).
+
+## Prerequisite
+
+A Firebase project already exists and the app builds against it (the `integrations` phase). Analytics,
+Crashlytics, Remote Config, and Cloud Messaging are all **the same Firebase project** — no new project.
+
+## STOP rule (read verbatim)
+
+> When the next unchecked item is a **User Action**, stop and wait for the developer to confirm
+> they've done it before continuing. Never fabricate analytics data, remote-config values, or push
+> tokens.
+
+Console work (upload the APNs `.p8` key, add Remote Config parameters, send a test push, read
+DebugView) is **User Action** — you cannot do it. Guide, then wait.
+
+## Checklist
+
+### 1. Instrument the app — `setup-analytics`
+- **Agent Action** — Read the `setup-analytics` skill. Add analytics events at the funnel points that
+  matter (screen views via `Analytics.logScreenView`, key conversions), log crashes via Crashlytics,
+  and add any new feature flag to `FeatureFlagManager.Keys` + `DEFAULT_VALUES`.
+- **User Action** — In the Firebase Console enable **Analytics**, **Crashlytics**, and **Remote
+  Config**, and add each flag key as a Remote Config parameter with its production value. **Stop and
+  confirm.**
+- **Validation** — With a debug build, an event appears in Firebase **DebugView**.
+
+### 2. Wire notifications — `enable-notifications`
+- **Agent Action** — Read the `enable-notifications` skill (KMPNotifier 2.0: push via FCM + local
+  notifications). Confirm the notification listeners in `AppInitializer.initializeNotification()`,
+  and prime the runtime permission with `rememberNotificationPermissionState()` (see the
+  `add-permission` skill).
+- **User Action** — In the Apple Developer portal generate an **APNs auth key** (`.p8`) and upload it
+  under Firebase **Project settings → Cloud Messaging**; in Xcode add the **Push Notifications** +
+  **Background Modes (Remote notifications)** capabilities (deployment target 16.0+). **Stop and
+  confirm.**
+- **User Action** — In Firebase **Cloud Messaging → Send a message**, send a test push to the device
+  token (logged as `Firebase onNewToken`). **Stop and confirm.**
+- **Validation** — The test push is received on a real device.
+
+### 3. Polish onboarding — `design-onboarding`
+- **Agent Action** — Read the `design-onboarding` skill. Fill the `TAILOR PER APP` markers in
+  `AiGuidelines/project/onboarding.md` (goal-capture question, first-taste moment, permission
+  priming), then build/refine the onboarding screens via the `new-screen` skill. Tie the
+  notification-permission priming step to step 2.
+- **Validation** — Onboarding runs end to end; screen-view events for each step land in DebugView.
+
+### 4. Add virality + review loops — `add-virality-loop`
+- **Agent Action** — Read the `add-virality-loop` skill. Fill the `TAILOR PER APP` markers in
+  `AiGuidelines/project/virality_loops.md` (share/referral artifact, high-intent prompts, win-back),
+  build the surfaces, and wire `rememberInAppReviewTrigger()` at a genuine post-value moment.
+- **Validation** — A share/referral surface works and the in-app review prompt fires (respecting its
+  7-day cooldown).
+
+### 5. Validation gate
+- **Validation** — An analytics event shows in the Firebase console **DebugView** *and* a test push
+  notification is received on-device. Run the `run-quality-gates` skill.
+
+## Done → the loop repeats
+
+There is no "next phase". Growth is a loop, not a finish line: **measure → improve → measure**. Read
+the funnel (onboarding drop-off, event counts, crash-free rate), form a hypothesis, ship a change
+behind a Remote Config flag, and measure again. The deeper conversion science and the self-improve
+loop live in `AiGuidelines/` — `AiGuidelines/agents/` (onboarding / paywall / UX designers) and, when
+installed, `AiGuidelines/loop/CONVERSION_PLAYBOOK.md`.

--- a/skills/growth/progress-template.md
+++ b/skills/growth/progress-template.md
@@ -1,0 +1,38 @@
+# Phase 5 — Growth progress
+
+Copy this file and tick items as you go. Role labels: **[Agent]** you do it, **[User]** the developer
+does it in a browser/console, **[Validate]** prove it works.
+
+## 1. Instrument the app — `setup-analytics`
+- [ ] **[Agent]** Add analytics events at funnel points (`Analytics.logScreenView`, key conversions)
+- [ ] **[Agent]** Add any new flag to `FeatureFlagManager.Keys` + `DEFAULT_VALUES`
+- [ ] **[User]** Enable Analytics, Crashlytics, and Remote Config in the Firebase Console
+- [ ] **[User]** Add each flag key as a Remote Config parameter with its production value
+- [ ] **[Validate]** An event appears in Firebase DebugView (debug build)
+
+## 2. Notifications — `enable-notifications`
+- [ ] **[Agent]** Confirm listeners in `AppInitializer.initializeNotification()`
+- [ ] **[Agent]** Prime notification permission with `rememberNotificationPermissionState()` (`add-permission`)
+- [ ] **[User]** Generate APNs auth key (`.p8`) in Apple Developer portal
+- [ ] **[User]** Upload the `.p8` under Firebase Project settings → Cloud Messaging
+- [ ] **[User]** Add Push Notifications + Background Modes (Remote notifications) capabilities in Xcode (target 16.0+)
+- [ ] **[User]** Send a test push from Firebase Cloud Messaging → Send a message
+- [ ] **[Validate]** Test push received on a real device
+
+## 3. Onboarding — `design-onboarding`
+- [ ] **[Agent]** Fill `TAILOR PER APP` in `AiGuidelines/project/onboarding.md` (goal / first-taste / priming)
+- [ ] **[Agent]** Build/refine onboarding screens via the `new-screen` skill
+- [ ] **[Validate]** Onboarding runs end to end; per-step screen-view events land in DebugView
+
+## 4. Virality + review loops — `add-virality-loop`
+- [ ] **[Agent]** Fill `TAILOR PER APP` in `AiGuidelines/project/virality_loops.md`
+- [ ] **[Agent]** Build the share/referral + high-intent + win-back surfaces
+- [ ] **[Agent]** Wire `rememberInAppReviewTrigger()` at a post-value moment
+- [ ] **[Validate]** A share/referral surface works; in-app review prompt fires (7-day cooldown)
+
+## 5. Validation gate
+- [ ] **[Validate]** An analytics event shows in Firebase DebugView AND a test push is received on-device
+- [ ] **[Validate]** Run the `run-quality-gates` skill
+
+## The loop repeats
+- [ ] Measure → improve → measure. Ship changes behind Remote Config flags; re-read the funnel.

--- a/skills/integrate-web-proxy/SKILL.md
+++ b/skills/integrate-web-proxy/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: integrate-web-proxy
+description: Deploy the Web/functions Cloud Functions AI proxy (OpenAI/Replicate), store API keys in Google Cloud Secret Manager, set CLOUD_FUNCTIONS_URL, and call it from a Ktor client with a Firebase Bearer token. Use when the developer wants live AI/backend calls, to deploy the Cloud Functions, or to wire the app to OpenAI/Replicate securely.
+---
+
+# Integrate the web proxy (Cloud Functions AI backend)
+
+OpenAI and Replicate keys must never live in the mobile app. The `Web/functions` backend is a
+pre-built Firebase Cloud Functions proxy: the app calls it with a Firebase ID token, the function
+reads the real API key from **Google Cloud Secret Manager**, forwards the request, and returns a
+uniform envelope. Requires a Blaze-plan Firebase project (`setup-firebase`) and auth
+(`enable-auth` / anonymous).
+
+## What's in `Web/functions`
+
+- `index.js` — exports the enabled functions (`replicate*`, `openAi*`); comment a line to disable one.
+- `api/openai.js` — `openAiCreateTextCompletion`, `openAiCreateImage` (secret `OPENAI_API_KEY`).
+- `api/replicate.js` — `replicateCreatePrediction`, `replicateCreateModelPrediction`,
+  `replicateGetPredictionStatus`, `replicateCancelPrediction` (secret `REPLICATE_API_KEY`).
+- `utils/validation.js` — `Validation.validateAll(req, res, { requireAuth, requirePostRequest })`.
+  With `requireAuth: true` (the default for most endpoints) the request **must** carry
+  `Authorization: Bearer <Firebase ID token>`; the function verifies it via `admin.auth().verifyIdToken`.
+- `utils/utils.js` — `makeApiRequest(...)` forwards the call and `sendApiResponse(...)` shapes the reply.
+
+### Response envelope
+
+Every function returns the same JSON shape (`utils/utils.js` → `sendApiResponse`):
+
+```json
+{ "statusCode": 200, "errorMessage": null, "data": { /* raw provider response */ } }
+```
+
+- `statusCode` — HTTP status.
+- `errorMessage` — non-null only on error (e.g. `403 "Missing Authorization header..."`).
+- `data` — the provider's raw response object on success.
+
+Model your response DTO on this envelope with a nested `data` payload.
+
+## 1. Store API keys in Secret Manager — User Action
+
+1. Get keys: OpenAI (https://platform.openai.com/), Replicate (https://replicate.com/).
+2. Enable + open Secret Manager:
+   https://console.cloud.google.com/security/secret-manager (select the Firebase project).
+3. **Create secret** with the **exact** name `OPENAI_API_KEY`, paste the key. Repeat for
+   `REPLICATE_API_KEY`. (Names must match `defineSecret(...)` in `api/*.js`.)
+4. Grant the functions' service account access to each secret.
+
+## 2. Deploy — User Action
+
+Install the standard Firebase CLI if needed (`npm install -g firebase-tools`), then from the `Web/`
+directory:
+
+```bash
+firebase login
+firebase deploy --only functions
+```
+
+The deploy prints the base URL, shaped
+`https://REGION-PROJECT_ID.cloudfunctions.net` (default region `us-central1`). Copy it.
+
+> To disable an endpoint before deploy, comment out its `exports.<fn>` line in
+> `Web/functions/index.js`. To allow unauthenticated calls on an endpoint (dev/testing only), set
+> `requireAuth: false` in that function's `Validation.validateAll(...)` call.
+
+## 3. Point the app at the URL — User Action / Agent Action
+
+Set the base URL in
+`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/Constants.kt`:
+
+```kotlin
+const val CLOUD_FUNCTIONS_URL = "https://us-central1-your-project-id.cloudfunctions.net"
+```
+
+## 4. Test locally first (optional) — Agent Action
+
+From `Web/`:
+
+```bash
+firebase emulators:start --only functions
+```
+
+Point `CLOUD_FUNCTIONS_URL` at the emulator host while iterating, then switch back to the deployed URL.
+
+## 5. Call it from the app — Agent Action
+
+Follow the `add-api-service` skill to build the Ktor client end-to-end (request/response DTOs, API
+service, repository, ViewModel call). Two specifics for this backend:
+
+- **Base URL** = `Constants.CLOUD_FUNCTIONS_URL`; the path is the function name
+  (e.g. `/openAiCreateTextCompletion`). Most endpoints are `POST`.
+- **Auth header** — attach the current Firebase ID token as
+  `Authorization: Bearer <token>` (the same token from the anonymous/social session). Without it,
+  auth-gated endpoints return `403` in `errorMessage`.
+- **Response** — parse the `{ statusCode, errorMessage, data }` envelope; on non-null `errorMessage`,
+  surface it as a failure in the repository's `Result`.
+
+## 6. Validate — Validation
+
+On a real device/emulator with a signed-in (anonymous or social) user, invoke the wired call and
+confirm the function returns `data`. This is the phase's validation gate.
+
+## Next
+
+Live remote calls + auth working completes the `integrations` phase → move to `publishing`.

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: integrations
+description: Phase-2 guide that connects the locally-running KMP app to services — Firebase + anonymous auth, Google/Apple social auth, and the web-proxy Cloud Functions (OpenAI/Replicate) wired via CLOUD_FUNCTIONS_URL. Use when the developer asks to do integrations / connect services for the KMP contest starter kit, hook the app up to Firebase, enable sign-in, or wire real remote API calls.
+---
+
+# Phase 2 — Integrations (connect to services)
+
+**Goal:** take the app that already builds and runs locally (from the `getting-started` phase) and
+connect it to real services — a Firebase project with anonymous auth, Google/Apple social sign-in,
+and the web-proxy Cloud Functions backend (OpenAI / Replicate) so live remote calls return data.
+
+This is the **blueprint orchestrator** for the phase. Work the checklist top to bottom. Each step is
+tagged **Agent Action** (you do it), **User Action** (the developer must do it in a browser/console),
+or **Validation** (prove it works). Steps compose the four atomic skills — read the referenced skill
+before doing that step.
+
+Track progress in a copy of [`progress-template.md`](progress-template.md).
+
+## STOP rule (read verbatim)
+
+> When the next unchecked item is a **User Action**, stop and wait for the developer to confirm
+> they've done it before continuing. Never fabricate credentials, project IDs, or console state.
+
+Most of this phase is heavy **User Action** work — creating a Firebase project in the browser,
+downloading `google-services.json` / `GoogleService-Info.plist`, enabling providers, setting Secret
+Manager keys, pasting API keys into `local.properties`. You cannot do these; guide, then wait.
+
+## Checklist
+
+### 1. Lay out the key catalog — `configure-environment`
+- **Agent Action** — Read the `configure-environment` skill. Walk the developer through the full
+  catalog of `MobileApp/local.properties` keys, the `MobileApp/gradle.properties`
+  `SUBSCRIPTION_PROVIDER` toggle, and the `Constants.kt` fields. Establish which values this phase
+  needs (`GOOGLE_WEB_CLIENT_ID`, `CLOUD_FUNCTIONS_URL`) vs. later phases.
+- **User Action** — Ensure `MobileApp/local.properties` exists with at least `sdk.dir`. It is
+  gitignored, so it never came from the template. **Stop and confirm.**
+
+### 2. Create the Firebase project + apps + anonymous auth — `setup-firebase`
+- **Agent Action** — Read the `setup-firebase` skill. Read the app's `applicationId` /
+  iOS bundle id so the developer registers the right identifiers. Run
+  `./gradlew :androidApp:signingReport` from `MobileApp/` to get the debug SHA-1 for them to paste.
+- **User Action** — In https://console.firebase.google.com/ create the project, register the Android
+  app (package = `applicationId`, add the SHA-1) and the iOS app (bundle id), download and place
+  `google-services.json` → `MobileApp/androidApp/` and `GoogleService-Info.plist` →
+  `MobileApp/iosApp/iosApp/`, enable **Anonymous** sign-in, and upgrade to the **Blaze** plan (needed
+  for Cloud Functions in step 4). **Stop and confirm each.**
+- **Validation** — `./gradlew :androidApp:assembleDebug` succeeds with the real
+  `google-services.json` in place.
+
+### 3. Enable social sign-in (Google / Apple) — `enable-auth`
+- **Agent Action** — Read the `enable-auth` skill. Confirm `Constants.AUTH_SOCIAL_LOGIN_ENABLED = true`
+  (default). Point the developer at the **Web client ID** they'll copy from Firebase.
+- **User Action** — In Firebase Auth → Sign-in method, enable **Google** and **Apple**; copy the
+  **Web client ID** into `GOOGLE_WEB_CLIENT_ID` in `MobileApp/local.properties`; wire iOS
+  `Info.plist` client IDs and (for Apple on iOS) add the **Sign In with Apple** capability in Xcode.
+  **Stop and confirm.**
+
+### 4. Deploy the web proxy + point the client at it — `integrate-web-proxy`
+- **Agent Action** — Read the `integrate-web-proxy` skill. Explain the `Web/functions` backend, the
+  `{statusCode, errorMessage, data}` response shape, and the `requireAuth` Firebase-token gate.
+- **User Action** — Set Secret Manager secrets `OPENAI_API_KEY` / `REPLICATE_API_KEY`
+  (https://console.cloud.google.com/security/secret-manager), then from `Web/` run
+  `firebase deploy --only functions`. Copy the printed base URL
+  (`https://REGION-PROJECT_ID.cloudfunctions.net`) into `Constants.CLOUD_FUNCTIONS_URL`. **Stop and confirm.**
+- **Agent Action** — Wire a client that calls the deployed function following the `add-api-service`
+  pattern (Ktor service + DTOs, Firebase ID token in the `Authorization: Bearer` header, repository
+  wraps in `Result`). Optionally test the backend locally first with
+  `firebase emulators:start --only functions` from `Web/`.
+
+### 5. Validation gate
+- **Validation** — The app authenticates (anonymous **or** social) and a **live remote call**
+  (e.g. one of the Cloud Functions) returns data on a real device/emulator. Run the
+  `run-quality-gates` skill.
+
+## Done → next phase
+
+When authentication works and a live Cloud Function returns data, the app is connected. Proceed to
+the **`publishing`** phase to prepare store listings, signing, and release builds.

--- a/skills/integrations/progress-template.md
+++ b/skills/integrations/progress-template.md
@@ -1,0 +1,39 @@
+# Phase 2 — Integrations progress
+
+Copy this file and tick items as you go. Role labels: **[Agent]** you do it, **[User]** the developer
+does it in a browser/console, **[Validate]** prove it works.
+
+## 1. Key catalog — `configure-environment`
+- [ ] **[Agent]** Walk through `local.properties` keys, `gradle.properties` `SUBSCRIPTION_PROVIDER`, `Constants.kt` fields
+- [ ] **[User]** `MobileApp/local.properties` exists with `sdk.dir` (gitignored — confirm)
+
+## 2. Firebase project + apps + anonymous auth — `setup-firebase`
+- [ ] **[Agent]** Read `applicationId` / iOS bundle id; run `./gradlew :androidApp:signingReport` for the SHA-1
+- [ ] **[User]** Create Firebase project at console.firebase.google.com
+- [ ] **[User]** Register Android app (package = applicationId, add SHA-1)
+- [ ] **[User]** Register iOS app (bundle id)
+- [ ] **[User]** Place `google-services.json` → `MobileApp/androidApp/`
+- [ ] **[User]** Place `GoogleService-Info.plist` → `MobileApp/iosApp/iosApp/`
+- [ ] **[User]** Enable Anonymous sign-in
+- [ ] **[User]** Upgrade to Blaze plan (needed for Cloud Functions)
+- [ ] **[Validate]** `./gradlew :androidApp:assembleDebug` succeeds with real `google-services.json`
+
+## 3. Social sign-in (Google / Apple) — `enable-auth`
+- [ ] **[Agent]** Confirm `Constants.AUTH_SOCIAL_LOGIN_ENABLED = true`
+- [ ] **[User]** Enable Google + Apple providers in Firebase Auth
+- [ ] **[User]** Copy Web client ID → `GOOGLE_WEB_CLIENT_ID` in `local.properties`
+- [ ] **[User]** Wire iOS `Info.plist` client IDs + add "Sign In with Apple" capability in Xcode
+
+## 4. Web proxy deploy + client wiring — `integrate-web-proxy`
+- [ ] **[Agent]** Explain `Web/functions`, `{statusCode, errorMessage, data}` shape, `requireAuth`
+- [ ] **[User]** Set Secret Manager `OPENAI_API_KEY` / `REPLICATE_API_KEY`
+- [ ] **[User]** `firebase deploy --only functions` from `Web/`
+- [ ] **[User]** Paste base URL into `Constants.CLOUD_FUNCTIONS_URL`
+- [ ] **[Agent]** Wire a client (Ktor + Firebase Bearer token) per the `add-api-service` pattern
+
+## 5. Validation gate
+- [ ] **[Validate]** App authenticates (anonymous or social) AND a live Cloud Function returns data
+- [ ] **[Validate]** Run the `run-quality-gates` skill
+
+## Next
+- [ ] Proceed to the `publishing` phase

--- a/skills/monetization/SKILL.md
+++ b/skills/monetization/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: monetization
+description: >-
+  PHASE 4 GUIDE — turn the published KMPStarterKit app into a revenue app: subscriptions +
+  credit-pack IAPs (Adapty default, or RevenueCat), a wired paywall, and AdMob ads. Orchestrates
+  the atomic skills design-paywall, setup-subscriptions, enable-credits, and enable-ads.
+  Use when the developer wants to monetize / add monetization / get to revenue / set up
+  subscriptions, in-app purchases, paywall, credits, or ads on the KMP contest starter kit
+  (aliases: monetization / monetize the KMP contest starter kit).
+---
+
+# Phase 4 — Monetization (get to revenue)
+
+This is the **blueprint orchestrator** for turning a published app into a revenue app. It composes
+four atomic skills into one ordered flow. Work the checklist top-to-bottom; do not skip ahead.
+
+## Goal
+
+A shipping app that can take money: subscriptions **and** credit-pack in-app purchases (through
+**Adapty** — the default — or **RevenueCat**), a paywall wired to a real offer, and AdMob ads
+enabled where they fit. The exit gate is a **completed sandbox/test purchase that unlocks premium**.
+
+## Prerequisite
+
+Store presence must already exist — the **App Store Connect** app record and the **Google Play
+Console** app must be created (that's the `publishing` phase). Real subscription/IAP products are
+created **inside those store consoles**, so you cannot finish this phase without them. If the stores
+don't exist yet, send the developer back to `publishing` first.
+
+## STOP rule
+
+When the next unchecked item is a **User Action**, stop and wait for the developer to confirm
+they've done it before continuing. Never fabricate product IDs, entitlements, or dashboard state.
+
+## Progress tracking
+
+Copy `skills/monetization/progress-template.md` into the working area at the start and tick items as
+you go. Each line is labelled with who owns it (Agent / User).
+
+## Ordered checklist
+
+### 1. Design the offer
+
+- [ ] **Agent Action** — Run the **`design-paywall`** skill. This hands the developer the paywall
+      designer role prompt and the `paywall.md` fill-in template so they author the offer
+      architecture (primary model, prices, trial framing, credit packs) *before* any product is
+      created. Products are shaped by the offer, so this comes first.
+- [ ] **User Action** — Fill in the `TAILOR PER APP` blanks in `AiGuidelines/project/paywall.md`
+      (primary model, monthly/annual/lifetime prices, trial length, credit-pack sizes).
+- [ ] **Validation** — `AiGuidelines/project/paywall.md` has no remaining `TAILOR PER APP` markers.
+
+### 2. Set up subscriptions
+
+- [ ] **Agent Action** — Run the **`setup-subscriptions`** skill: confirm/select the provider via
+      `SUBSCRIPTION_PROVIDER` in `MobileApp/gradle.properties`, and confirm the paywall entitlement
+      key (`Constants.PAYWALL_PREMIUM_ACCESS`, default `"Premium"`).
+- [ ] **User Action** — Put the provider's Android + iOS SDK keys in `MobileApp/local.properties`
+      (`SUBSCRIPTION_PROVIDER_ANDROID_API_KEY`, `SUBSCRIPTION_PROVIDER_IOS_API_KEY`).
+- [ ] **User Action** — Create the subscription products in **App Store Connect** and **Google Play
+      Console** with cross-platform-aligned product IDs (the prices from step 1).
+- [ ] **User Action** — In the **provider dashboard** (Adapty or RevenueCat), link those store
+      products, map them to the `Premium` entitlement / access level, and configure the paywall
+      placement(s).
+- [ ] **Validation** — `./gradlew :androidApp:assembleDebug` builds; the subscription paywall shows
+      real products fetched from the provider.
+
+### 3. Enable credit packs
+
+- [ ] **Agent Action** — Run the **`enable-credits`** skill: configure the credit DSL in
+      `root/Di.kt` (`initializeCreditSystem`) and wire credit-pack purchases to credit grants.
+- [ ] **User Action** — Create the credit-pack products as **consumable** IAPs in ASC + Play, and
+      register them under the credit-pack placement in the provider dashboard.
+- [ ] **Validation** — The credit-pack paywall (`PaywallMode.CREDIT_PACK`) shows the packs and a
+      successful purchase calls `creditRepository.addCredits(...)`.
+
+### 4. Enable ads
+
+- [ ] **Agent Action** — Run the **`enable-ads`** skill: flip `IS_ADS_ENABLED` and place
+      banner/interstitial/rewarded ads where they fit the UX.
+- [ ] **User Action** — Create the AdMob app + ad units and paste the IDs into
+      `MobileApp/local.properties` (+ iOS app id into `BaseConfig.xcconfig`).
+- [ ] **User Action** — Update the store **data-safety / privacy** declarations for advertising IDs.
+- [ ] **Validation** — Test ads render in a debug build (Google test ad IDs during development).
+
+## Exit gate
+
+**A sandbox / test purchase completes and unlocks premium** — the paywall dismisses (subscription)
+or credits are added (credit pack). Validate this on at least one platform before declaring the
+phase done.
+
+## Next phase
+
+Once revenue plumbing works end-to-end, move on to the **`growth`** phase (analytics, retention,
+virality — see `AiGuidelines/project/virality_loops.md`).

--- a/skills/monetization/progress-template.md
+++ b/skills/monetization/progress-template.md
@@ -1,0 +1,26 @@
+# Monetization progress
+
+## 1. Design the offer
+- [ ] (Agent) Run `design-paywall` — hand over designer prompt + paywall template
+- [ ] (User) Fill `TAILOR PER APP` blanks in `AiGuidelines/project/paywall.md`
+- [ ] (User) No `TAILOR PER APP` markers remain
+
+## 2. Set up subscriptions
+- [ ] (Agent) Run `setup-subscriptions` — pick provider (`SUBSCRIPTION_PROVIDER`), confirm entitlement key
+- [ ] (User) Provider Android + iOS keys in `MobileApp/local.properties`
+- [ ] (User) Create subscription products in App Store Connect + Google Play Console (aligned IDs)
+- [ ] (User) Link products + map to `Premium` entitlement + configure placement in provider dashboard
+- [ ] (Agent) `:androidApp:assembleDebug` builds; subscription paywall shows real products
+
+## 3. Enable credit packs
+- [ ] (Agent) Run `enable-credits` — configure credit DSL, wire pack purchase → credit grant
+- [ ] (User) Create consumable credit-pack IAPs in ASC + Play, register under credit-pack placement
+- [ ] (Agent) Credit-pack paywall shows packs; purchase calls `addCredits(...)`
+
+## 4. Enable ads
+- [ ] (Agent) Run `enable-ads` — flip `IS_ADS_ENABLED`, place banner/interstitial/rewarded ads
+- [ ] (User) Create AdMob app + ad units, paste IDs into `local.properties` (+ iOS `BaseConfig.xcconfig`)
+- [ ] (User) Update store data-safety / privacy for advertising IDs
+
+## Exit gate
+- [ ] Sandbox/test purchase completes and unlocks premium (paywall dismisses / credits added)

--- a/skills/new-local-model/SKILL.md
+++ b/skills/new-local-model/SKILL.md
@@ -28,3 +28,7 @@ Insertion points are marked `// Add new ... — make_local.sh inserts here.` —
 3. Rules: use `androidx.room3.*` imports (never `androidx.room.*`); DAO functions must be `suspend` or return `Flow<T>`; repositories inject DAOs directly (no LocalDataSource abstraction).
 4. DAO tests go in `shared/src/jvmTest/` using `Room.inMemoryDatabaseBuilder<AppDatabase>().setDriver(BundledSQLiteDriver())` — see `ExampleDaoTest.kt` for the pattern.
 5. Validate with the `run-quality-gates` skill.
+
+---
+
+*Phase 1 · First Run building block — part of the [getting-started](../getting-started/SKILL.md) guide.*

--- a/skills/new-module/SKILL.md
+++ b/skills/new-module/SKILL.md
@@ -22,3 +22,7 @@ The script creates the module directories, a `build.gradle.kts` using the conven
 1. Follow the existing module layout for API/impl splits — see `libs/auth/` (`auth-api` + `auth-firebase`) and `libs/subscription/` (`subscription-api` + provider implementations) for the pattern.
 2. Add the module to consumers' dependencies (`implementation(projects.libs....)`).
 3. Validate with the `run-quality-gates` skill.
+
+---
+
+*Phase 1 · First Run building block — part of the [getting-started](../getting-started/SKILL.md) guide.*

--- a/skills/new-screen/SKILL.md
+++ b/skills/new-screen/SKILL.md
@@ -33,3 +33,7 @@ Insertion points in those three files are marked with
 2. Implement the UI in the pure-composable overload; keep logic in the ViewModel.
 3. Feature folders contain **only** `*Screen.kt`, `*UiState.kt`, `*ViewModel.kt` — never a `*ScreenRoute.kt` (routes live in `Routes.kt`).
 4. Validate with the `run-quality-gates` skill.
+
+---
+
+*Phase 1 · First Run building block — part of the [getting-started](../getting-started/SKILL.md) guide.*

--- a/skills/publish-release/SKILL.md
+++ b/skills/publish-release/SKILL.md
@@ -67,7 +67,7 @@ fastlane ios appstore_release submit_for_review:true # auto-submit for review
 It archives the `iosApp` scheme (Release), exports to `distribution/ios/iosApp.ipa`, and
 uploads via the ASC API key (Fastlane `pilot`/`deliver` under the hood). If Xcode warns
 about SwiftPM linkage, follow the linkage-package steps in
-`Documentation/docs/production/iOS.md` (and CLAUDE.md → iOS SwiftPM) before archiving.
+`Documentation/docs/production/iOS.md` (and `AGENTS.md` → iOS SwiftPM) before archiving.
 
 ## CI path (tag-driven)
 

--- a/skills/publish-release/SKILL.md
+++ b/skills/publish-release/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: publish-release
+description: Build the signed release artifacts and ship them — Android AAB to a Play track and iOS archive to TestFlight/App Store, via Fastlane lanes or the tag-driven CI workflows, then submit for review. Use when the user wants to build a release, upload to Play/TestFlight, cut a release, or submit the app for review.
+---
+
+# Build and publish a release
+
+Produce the signed release artifacts and upload them. Prereqs (do these first): release
+signing wired (`setup-signing`), store apps created (`setup-google-play`,
+`setup-appstore-connect`), version bumped (`bump-version`), release notes updated in
+`distribution/whatsnew/whatsnew-en-US`.
+
+All commands run from `MobileApp/`. Fastlane is the pre-wired path
+(`MobileApp/fastlane/Fastfile`); the tag-driven GitHub workflows do the same in CI.
+
+## Android
+
+### Build the signed AAB
+
+```bash
+./gradlew :androidApp:bundleRelease
+# → androidApp/build/outputs/bundle/release/androidApp-release.aab
+```
+
+Signed automatically when `distribution/android/keystore/keystore.properties` exists
+(see `setup-signing`).
+
+### First upload (manual — required by Google)
+
+The **very first** upload to a new Play app must go through the console. Use the Fastlane
+helper to build + stage the AAB, then upload it by hand:
+
+```bash
+fastlane android first_time_build
+# copies the AAB to distribution/android/app-release.aab for manual upload
+```
+
+Upload it in Play Console → **Internal testing → Create new release** (see
+`setup-google-play`).
+
+### Subsequent releases (automated)
+
+```bash
+fastlane android playstore_release                    # internal track (default)
+fastlane android playstore_release track:production    # promote to production
+# useful options: upload_metadata:true upload_screenshots:true submit_for_review:true
+```
+
+Uses the Fastlane `supply` action + the Play service-account JSON
+(`~/credentials/google-service-app-publisher.json`, or `service_account:` option).
+
+## iOS
+
+### Easiest — Xcode
+
+Open the workspace → **Product → Archive** → in Organizer, **Distribute App** → App Store
+Connect → upload to TestFlight / App Store.
+
+### Fastlane
+
+```bash
+fastlane ios appstore_release                       # build + upload IPA to App Store Connect
+fastlane ios appstore_release submit_for_review:true # auto-submit for review
+# also: upload_metadata:true upload_screenshots:true
+```
+
+It archives the `iosApp` scheme (Release), exports to `distribution/ios/iosApp.ipa`, and
+uploads via the ASC API key (Fastlane `pilot`/`deliver` under the hood). If Xcode warns
+about SwiftPM linkage, follow the linkage-package steps in
+`Documentation/docs/production/iOS.md` (and CLAUDE.md → iOS SwiftPM) before archiving.
+
+## CI path (tag-driven)
+
+The GitHub workflows do the above in CI when you push a version tag (after the CI secrets
+from `setup-signing` are set):
+
+- push a `*-android` tag → `.github/workflows/publish_android_playstore.yml` → Play internal
+  track
+- push a `*-ios` tag → `.github/workflows/publish_ios_appstore.yml` → App Store Connect
+
+Only push tags when the user asks to release.
+
+## Submit for review
+
+- **Android:** in Play Console, promote the internal-track build to a review-eligible track
+  (closed/open testing or production) → **Send for review**. Or Fastlane
+  `playstore_release track:production submit_for_review:true`.
+- **iOS:** in App Store Connect, attach the uploaded build to the 1.0.0 version → **Add for
+  Review → Submit**. Or `appstore_release submit_for_review:true`.
+
+## Validate
+
+The signed release build **uploads and appears in the console**: on the Play **internal
+track** (Play Console → Internal testing) and in **TestFlight** (App Store Connect →
+TestFlight). Once verified there, submit for review.

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: publishing
+description: Phase-3 guide for publishing the KMP contest starter kit / publish to Play Store and App Store — icons, release signing (keys moved into CI secrets), store metadata + screenshots, App Store Connect + Google Play Console app creation, and the first build submitted for review. Use when the developer wants to publish / ship / release the app to the stores, or prepare store listings and signing.
+---
+
+# Phase 3 — Publishing (ship to Google Play + App Store)
+
+**Goal:** take the integrated app (from the `integrations` phase) to the stores — final app
+identity + icons, **release signing with keys moved out of the app into CI secrets**, store
+metadata + screenshots, App Store Connect and Google Play Console apps created, and the first
+signed build submitted for review.
+
+This is the **blueprint orchestrator** for the phase. Work the checklist top to bottom. Each
+step is tagged **Agent Action** (you do it), **User Action** (the developer does it in a
+console / Xcode), or **Validation** (prove it works). Steps compose the atomic skills — read
+the referenced skill before doing that step.
+
+Track progress in a copy of [`progress-template.md`](progress-template.md).
+
+## STOP rule (read verbatim)
+
+> When the next unchecked item is a **User Action**, stop and wait for the developer to
+> confirm they've done it before continuing. Never fabricate store listings, signing
+> identities, or review submissions.
+
+Store-console work (App Store Connect, Google Play Console) and Xcode signing are **User
+Actions** — you cannot create developer accounts, listings, certificates, or submit for
+review. Guide precisely, stage local files, then wait.
+
+## Security principle (read before signing)
+
+> Signing keys and secrets must never be committed. Move the keystore, `keystore.properties`,
+> the iOS `.p12` + ASC API key, and any embedded API keys **out of the app** into CI secrets
+> (GitHub Actions) or the backend. The starter kit's `.gitignore` already excludes
+> `keystore.jks`, `keystore.properties`, `*.aab`, `*.ipa`, and `local.properties` — keep them
+> there and put the CI-facing copies in **repo Settings → Secrets and variables → Actions**.
+
+## Checklist
+
+### 1. Lock the final app identity — `refactor-package`
+- **Agent Action** — If the app id / bundle id / display name aren't final yet, read the
+  `refactor-package` skill and run `./scripts/refactor_package.sh --app-id … --app-name …`
+  from `MobileApp/`. The Play package name binds permanently on first upload and the iOS
+  bundle id must match the ASC record — get it right **now**. Skip if already done in an
+  earlier phase.
+
+### 2. Generate app icons — `generate-app-icons`
+- **Agent Action** — Read the `generate-app-icons` skill. From one square source logo,
+  produce the iOS `AppIcon.appiconset` (all sizes + `Contents.json`) and the Android adaptive
+  mipmaps (5 density buckets + `ic_launcher_background` color), plus the native splash logo.
+- **User Action** — Supply the source logo (≥1024×1024 PNG) and confirm the generated icons
+  look right in the launcher / Xcode icon slots. **Stop and confirm.**
+- **Validation** — `./gradlew :androidApp:assembleDebug` succeeds and the launcher icon
+  renders crisp; Xcode shows a full icon set with no missing slots.
+
+### 3. Bump the release version — `bump-version`
+- **Agent Action** — Read the `bump-version` skill. Run `./scripts/update_version.sh`
+  (or `-v X.Y.Z`) from `MobileApp/` so Android `versionCode`/`versionName` and the iOS build
+  number / marketing version move together. Show the resulting versions.
+
+### 4. Set up release signing + move keys into CI — `setup-signing`
+- **Agent Action** — Read the `setup-signing` skill. Run
+  `./scripts/generate_android_keystore.sh "Name" "Org"` (or `keytool` manually) to create the
+  gitignored `keystore.jks` + `keystore.properties`. Confirm `androidApp/build.gradle.kts`
+  picks them up (it does automatically).
+- **User Action** — Create iOS certificates (Apple Development + Distribution → `Certificates.p12`)
+  and provisioning profiles, select them in Xcode. Add **all** signing secrets to GitHub
+  Actions: `SIGNING_KEY_STORE_FILE_BASE64`, `SIGNING_KEY_STORE_PROPERTIES_BASE64`,
+  `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `IOS_APP_CERTIFICATE_P12_BASE64` (+ password),
+  `APPSTORE_KEY_ID` / `APPSTORE_ISSUER_ID` / `APPSTORE_PRIVATE_KEY` / `APPSTORE_TEAM_ID`,
+  the two provision UUIDs, and `GRADLE_CACHE_ENCRYPTION_KEY`. **Back up the keystore + passwords.
+  Stop and confirm.**
+- **Validation** — `./gradlew :androidApp:bundleRelease` produces a **signed** AAB
+  (`keytool -printcert -jarfile <aab>` shows your cert, not the debug cert).
+
+### 5. Generate store screenshots — `store-screenshots`
+- **Agent Action** — Read the `store-screenshots` skill. Ensure `@StoreScreenshot` previews
+  exist for the key screens, then run `./scripts/generate_store_screenshots.sh`. Output lands
+  at `distribution/store_screenshots/<locale>/<device>/`.
+
+### 6. Set store URLs + contact in `Constants.kt`
+- **Agent Action** — In `shared/src/commonMain/.../util/Constants.kt` set
+  `URL_PRIVACY_POLICY`, `URL_TERMS_CONDITIONS`, and `CONTACT_EMAIL`. These must be **real,
+  reachable** pages — both stores reject placeholders. (`APPSTORE_APP_ID` is filled in step 7
+  once the ASC app exists.)
+- **User Action** — Confirm the privacy/terms pages are published (e.g. via the `Web/public`
+  landing-page template). **Stop and confirm.**
+
+### 7. Create the App Store Connect app — `setup-appstore-connect`
+- **Agent Action** — Read the `setup-appstore-connect` skill; walk the developer through it.
+- **User Action** — In https://appstoreconnect.apple.com create the app (bundle id, SKU,
+  primary language), the 1.0.0 version, categories, age-rating questionnaire, App Privacy /
+  data usage, App Review info, and localized metadata (subtitle / description / keywords /
+  what's-new / support + marketing URLs) with the generated screenshots + 1024 icon. Copy the
+  numeric **Apple ID** back into `Constants.APPSTORE_APP_ID`. **Stop and confirm.**
+
+### 8. Create the Google Play Console app — `setup-google-play`
+- **Agent Action** — Read the `setup-google-play` skill; walk the developer through it.
+- **User Action** — In https://play.google.com/console create the app; complete the main
+  store listing (title / short + full description / 512 icon / **1024×500 feature graphic** /
+  phone screenshots), the **Data safety** questionnaire, **content rating**, set up an
+  **internal testing** track, and create the Play **service account** JSON for CI. **Stop and
+  confirm.**
+
+### 9. Build + submit the first release — `publish-release`
+- **Agent Action** — Read the `publish-release` skill. Build the signed Android AAB
+  (`./gradlew :androidApp:bundleRelease` → `androidApp/build/outputs/bundle/release/androidApp-release.aab`)
+  and, for iOS, archive in Xcode or run the Fastlane `appstore_release` lane. First Play
+  upload is manual (`fastlane android first_time_build` → upload in console); afterwards
+  Fastlane `playstore_release` / TestFlight, or the tag-driven CI workflows
+  (`*-android` / `*-ios` tags).
+- **User Action** — Upload the first AAB to the Play **internal** track, upload the iOS build
+  to **TestFlight**, then **submit for review** on both. **Stop and confirm.**
+
+### 10. Validation gate
+- **Validation** — The signed release build **uploads to the Play internal track /
+  TestFlight and appears in the console**. Run the `run-quality-gates` skill before tagging a
+  release.
+
+## Done → next phase
+
+When the first signed build is in the Play internal track and TestFlight and submitted for
+review, the app is publishable. Proceed to the **`monetization`** phase to add subscriptions,
+credit-pack IAPs, the paywall, and ads (the store subscription/IAP products are created there,
+not here).

--- a/skills/publishing/progress-template.md
+++ b/skills/publishing/progress-template.md
@@ -1,0 +1,59 @@
+# Phase 3 — Publishing progress
+
+Copy this file and tick items as you go. Role labels: **[Agent]** you do it, **[User]** the developer
+does it in a console / Xcode, **[Validate]** prove it works.
+
+## 1. Lock final app identity — `refactor-package`
+- [ ] **[Agent]** App id / bundle id / display name are final (`./scripts/refactor_package.sh …`, or already done)
+
+## 2. App icons — `generate-app-icons`
+- [ ] **[User]** Provide square source logo (≥1024×1024 PNG)
+- [ ] **[Agent]** Generate iOS `AppIcon.appiconset` (all sizes + `Contents.json`)
+- [ ] **[Agent]** Generate Android adaptive mipmaps (5 buckets) + `ic_launcher_background` color
+- [ ] **[Agent]** Update native splash logo (iOS `ic_logo.imageset`, splash background colors)
+- [ ] **[Validate]** `:androidApp:assembleDebug` OK; launcher icon crisp; Xcode icon set complete
+
+## 3. Bump version — `bump-version`
+- [ ] **[Agent]** `./scripts/update_version.sh` (Android + iOS together); show versions
+
+## 4. Release signing + keys into CI — `setup-signing`
+- [ ] **[Agent]** Generate keystore (`generate_android_keystore.sh` or `keytool`) + gitignored `keystore.properties`
+- [ ] **[User]** iOS certificates (Dev + Distribution → `Certificates.p12`) + provisioning profiles, selected in Xcode
+- [ ] **[User]** Add Android CI secrets: `SIGNING_KEY_STORE_FILE_BASE64`, `SIGNING_KEY_STORE_PROPERTIES_BASE64`, `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+- [ ] **[User]** Add iOS CI secrets: `IOS_APP_CERTIFICATE_P12_BASE64` (+ password), `APPSTORE_KEY_ID`/`ISSUER_ID`/`PRIVATE_KEY`/`TEAM_ID`, both provision UUIDs
+- [ ] **[User]** Add `GRADLE_CACHE_ENCRYPTION_KEY`; back up keystore + passwords safely
+- [ ] **[Validate]** `:androidApp:bundleRelease` produces a signed AAB (`keytool -printcert -jarfile` = your cert)
+
+## 5. Store screenshots — `store-screenshots`
+- [ ] **[Agent]** `@StoreScreenshot` previews exist for key screens
+- [ ] **[Agent]** `./scripts/generate_store_screenshots.sh` → `distribution/store_screenshots/<locale>/<device>/`
+
+## 6. Store URLs + contact in `Constants.kt`
+- [ ] **[Agent]** Set `URL_PRIVACY_POLICY`, `URL_TERMS_CONDITIONS`, `CONTACT_EMAIL`
+- [ ] **[User]** Privacy + terms pages are published and reachable (no placeholders)
+
+## 7. App Store Connect app — `setup-appstore-connect`
+- [ ] **[User]** Create app (bundle id, SKU, primary language) + 1.0.0 version
+- [ ] **[User]** Categories, age rating, App Privacy / data usage, App Review info
+- [ ] **[User]** Metadata (subtitle/description/keywords/what's-new/support+marketing URLs) + screenshots + 1024 icon
+- [ ] **[User]** Copy numeric Apple ID → `Constants.APPSTORE_APP_ID`
+
+## 8. Google Play Console app — `setup-google-play`
+- [ ] **[User]** Create app
+- [ ] **[User]** Main store listing (title / short + full description / 512 icon / 1024×500 feature graphic / screenshots)
+- [ ] **[User]** Data safety questionnaire + content rating
+- [ ] **[User]** Internal testing track set up
+- [ ] **[User]** Play service-account JSON created for CI
+
+## 9. Build + submit first release — `publish-release`
+- [ ] **[Agent]** Build signed AAB (`:androidApp:bundleRelease`); iOS archive / Fastlane `appstore_release`
+- [ ] **[User]** Upload first AAB to Play internal track (manual first time)
+- [ ] **[User]** Upload iOS build to TestFlight
+- [ ] **[User]** Submit for review on both stores
+
+## 10. Validation gate
+- [ ] **[Validate]** Signed build uploads to Play internal track / TestFlight and appears in the console
+- [ ] **[Validate]** Run the `run-quality-gates` skill
+
+## Next
+- [ ] Proceed to the `monetization` phase

--- a/skills/refactor-package/SKILL.md
+++ b/skills/refactor-package/SKILL.md
@@ -30,3 +30,7 @@ Run from `MobileApp/`:
 
 1. Re-sync Gradle and rebuild (`./gradlew :androidApp:assembleDebug`) — see [run-quality-gates](../run-quality-gates/SKILL.md).
 2. If the app uses Firebase, replace `androidApp/google-services.json` and `iosApp/iosApp/GoogleService-Info.plist` with configs downloaded for the **new** app id (the script only rewrites the old id string inside the existing placeholders).
+
+---
+
+*Used for the Phase 1 rebrand in the [getting-started](../getting-started/SKILL.md) guide, and again in the Phase 3 [publishing](../publishing/SKILL.md) guide.*

--- a/skills/run-quality-gates/SKILL.md
+++ b/skills/run-quality-gates/SKILL.md
@@ -24,3 +24,7 @@ Rules:
 - Do NOT run iOS builds/tests for routine validation — they are slow. Only when the change is iOS-specific or the user asks.
 - Web check when web code changed: `./gradlew :shared:compileKotlinWasmJs :shared:compileKotlinJs`.
 - Quick iOS-code compile check without a full build: `./gradlew :shared:compileAppleMainKotlinMetadata`.
+
+---
+
+*Cross-phase — every guide's validation steps call this skill.*

--- a/skills/run-the-app/SKILL.md
+++ b/skills/run-the-app/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: run-the-app
+description: Build and run the app on Android, JVM Desktop, Web, or iOS from source. Use when getting the KMP starter kit running for the first time, or when the user asks to build, launch, or run the app on a device/emulator.
+---
+
+# Run the app
+
+All gradle commands run from `MobileApp/`.
+
+## Prerequisites
+
+- **JDK 17+** (first run also downloads the JetBrains JDK + Compose — expect a slow initial build).
+- **Android SDK** installed (Android Studio bundles it).
+- **`sdk.dir`** set in `MobileApp/local.properties`:
+  ```properties
+  sdk.dir=/Users/you/Library/Android/sdk
+  ```
+  Without this, any Android task fails immediately with "SDK location not found".
+- iOS also needs Xcode (macOS only).
+
+## Run per platform
+
+**Android** (emulator running or device connected):
+```bash
+./gradlew :androidApp:assembleDebug
+# APK: androidApp/build/outputs/apk/debug/androidApp-debug.apk
+# then install: ./gradlew :androidApp:installDebug
+# SHA1 (for Firebase later): ./gradlew :androidApp:signingReport
+```
+
+**JVM Desktop** (fastest way to see the app — no emulator/device):
+```bash
+./gradlew :desktopApp:run
+```
+
+**Web (Wasm/JS)** — dev server, opens in browser:
+```bash
+./gradlew :webApp:wasmJsBrowserDevelopmentRun
+```
+
+**iOS** (macOS only) — open the Xcode project and run from Xcode:
+```bash
+open iosApp/iosApp.xcodeproj
+```
+Do NOT run iOS builds for routine validation — they are slow. Only when the change is iOS-specific.
+
+## First-run failures
+
+- `SDK location not found` → `sdk.dir` missing/wrong in `MobileApp/local.properties`.
+- `Unsupported class file major version` / toolchain errors → JDK below 17; check `java -version`.
+- Android task with no device → start an emulator (or connect a device) before `installDebug`.
+- Slowest builds are the first one (dependency + JDK download) and iOS — this is expected.
+
+Desktop (`:desktopApp:run`) is the quickest sanity check that the app builds and shows the Home screen.

--- a/skills/save-preferences/SKILL.md
+++ b/skills/save-preferences/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: save-preferences
+description: Store a small typed flag/setting locally via the UserPreferences (DataStore) API. Use when the user wants to persist a simple key/value preference — a toggle, a counter, "onboarding shown", theme mode, etc. (structured data belongs in Room via new-local-model).
+---
+
+# Save a preference (DataStore)
+
+`UserPreferences` is a `suspend` key/value API backed by DataStore Preferences — file-based on
+Android/iOS/JVM, `localStorage` on web. Use it for small primitive flags and counters only. Structured
+data goes to Room (use the `new-local-model` skill).
+
+Files live in `shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/data/source/preferences/`:
+- `UserPreferences.kt` — the interface + `Keys` companion (add your key here).
+- `UserPreferencesImpl.kt` — DataStore implementation (usually no edits needed — string/int/long/boolean are all supported).
+- `PreferencesDataStoreProvider.kt` — platform storage location.
+
+## 1. Add a key
+
+In `UserPreferences.kt`, add a constant to the `Keys` companion:
+
+```kotlin
+companion object Keys {
+    const val KEY_IS_ONBOARD_SHOWN = "KEY_IS_ONBOARD_SHOWN"
+    const val KEY_DARK_MODE = "KEY_DARK_MODE"   // your new key
+}
+```
+
+## 2. Read / write it (from a coroutine)
+
+```kotlin
+userPreferences.putBoolean(UserPreferences.Keys.KEY_DARK_MODE, true)
+val dark = userPreferences.getBoolean(UserPreferences.Keys.KEY_DARK_MODE, defaultValue = false)
+```
+
+Available getters/setters: `getString/putString`, `getInt/putInt`, `getLong/putLong`,
+`getBoolean/putBoolean`, plus `remove(key)` and `clear()`. All are `suspend` — call from a
+`ViewModel`/repository coroutine scope.
+
+## Injecting it
+
+`UserPreferences` is already a Koin singleton (bound in `root/Di.kt` `dataModule`) — inject it into your
+ViewModel or repository constructor and Koin provides it. Note the `DataStore<Preferences>` instance
+itself is deliberately **not** a Koin binding (generic types collide); `UserPreferencesImpl` gets it via
+`PreferencesDataStoreProvider`. You don't touch that wiring — just inject `UserPreferences`.
+
+Validate with the `run-quality-gates` skill.

--- a/skills/setup-analytics/SKILL.md
+++ b/skills/setup-analytics/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: setup-analytics
+description: Enable Firebase Analytics, Crashlytics, and Remote Config feature flags in the KMP app — log events, add a flag, toggle it at runtime via Remote Config, and verify events in DebugView. Use when the developer wants analytics, crash reporting, or remote feature flags. Firebase must already be set up (integrations phase).
+---
+
+# Set up analytics, Crashlytics & feature flags
+
+All three ride on the **same Firebase project** wired in the `integrations` phase (Analytics,
+Crashlytics, and Remote Config are Firebase features — no new project). Enable each in the console,
+then use the app's existing abstractions.
+
+## 1. Enable in the Firebase Console
+
+Open https://console.firebase.google.com/ → your project:
+- **Analytics** — the Analytics dashboard (enabled with the project); confirm the Android/iOS apps
+  report.
+- **Crashlytics** — **Run & monitor → Crashlytics → Enable Crashlytics** (a first crash/report must
+  arrive before the dashboard populates).
+- **Remote Config** — **Run & monitor → Remote Config**; you'll add parameters in step 3.
+
+## 2. Log analytics events
+
+Events go through the `Analytics` interface — Firebase Analytics on mobile, no-op elsewhere:
+`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/analytics/Analytics.kt`.
+
+- `analytics.logEvent(event, params)` — custom event.
+- `analytics.logScreenView(screenName)` — the common screen-view event.
+
+Define new event/param names as constants in the `Analytics` companion (e.g. `EVENT_SCREEN_VIEW`,
+`EVENT_CLICKED_GENERATE`) rather than raw strings. Inject `Analytics` via Koin and log at your funnel
+points (screen entry, key conversions). Analytics is gated by the `IS_ANALYTICS_ENABLED` flag in
+`AppInitializer.initializeAnalytics()`.
+
+## 3. Feature flags via Remote Config
+
+Flags are read through `FeatureFlagManager`
+(`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/data/source/featureflag/FeatureFlagManager.kt`),
+backed by Firebase Remote Config on Android/iOS and a no-op elsewhere. `AppInitializer` calls
+`syncsFlagsAsync()` on startup; values fall back to `DEFAULT_VALUES` until fresh ones fetch.
+
+**Add a flag** in `FeatureFlagManager`:
+```kotlin
+object Keys {
+    const val IS_ADS_ENABLED = "is_ads_enabled"
+    const val IS_ANALYTICS_ENABLED = "is_analytics_enabled"
+    const val SHOW_REMOTE_PAYWALL = "show_remote_paywall"
+    const val MY_NEW_FLAG = "my_new_flag" // <- add
+}
+val DEFAULT_VALUES: Map<String, Comparable<Nothing>> = mapOf(
+    Keys.IS_ADS_ENABLED to false,
+    Keys.IS_ANALYTICS_ENABLED to true,
+    Keys.SHOW_REMOTE_PAYWALL to false,
+    Keys.MY_NEW_FLAG to false, // <- default until Remote Config fetches
+)
+```
+
+**Read it:** `featureFlagManager.getBoolean(FeatureFlagManager.Keys.MY_NEW_FLAG)` (also
+`getString` / `getLong` / `getDouble`).
+
+**Toggle it at runtime:** in the Firebase Console → **Remote Config**, **Add parameter** with the
+same key string (`my_new_flag`), set the value, and **Publish changes**. The next `syncsFlagsAsync()`
+(app start) picks it up — no app release needed. Publishing lets you enable/disable a feature or roll
+it out to a subset of users without shipping.
+
+## 4. Verify in DebugView
+
+Firebase **DebugView** shows events in near-real-time from a debug-enabled device:
+- Android: `adb shell setprop debug.firebase.analytics.app <applicationId>`
+- Then open **Firebase Console → Analytics → DebugView** and drive the app.
+
+Use `AppLogger`
+(`shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/logging/AppLogger.kt`,
+initialized in `AppInitializer`) for local `AppLogger.d(...)` traces alongside DebugView while
+confirming events fire.
+
+## Done
+An event appears in DebugView and a Remote Config parameter change flips your flag on next launch.
+This is the `setup-analytics` step of the `growth` phase.

--- a/skills/setup-appstore-connect/SKILL.md
+++ b/skills/setup-appstore-connect/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: setup-appstore-connect
+description: Manually create and configure the app in App Store Connect — bundle id, version, categories, age rating, privacy, review info, and localized metadata. Use when the user is setting up the App Store listing before an iOS release.
+---
+
+# Set up App Store Connect (manual)
+
+Create and configure the iOS app record in App Store Connect. This is **User Action**
+work in the web console — the agent guides and stages local metadata files; it cannot
+create listings. Console: https://appstoreconnect.apple.com
+
+Prerequisite: an active **Apple Developer Program** membership and the app's **bundle id**
+registered at https://developer.apple.com/account/resources/identifiers/list (must match
+the iOS `PRODUCT_BUNDLE_IDENTIFIER` in `iosApp/iosApp.xcodeproj/project.pbxproj`).
+
+## 1. Create the app
+
+App Store Connect → **My Apps → + → New App**:
+
+- **Platform:** iOS
+- **Name:** your public app name (unique across the App Store)
+- **Primary language**
+- **Bundle ID:** pick the registered identifier
+- **SKU:** any internal unique string (e.g. `yourapp-ios-001`)
+- **User access:** Full Access
+
+## 2. Create the 1.0.0 version
+
+In the app → **iOS App** sidebar, a **1.0.0 Prepare for Submission** version exists. Fill:
+
+- **Promotional text** (optional), **Description**, **Keywords** (100-char comma list),
+  **Support URL**, **Marketing URL** (optional)
+- **Subtitle** (30 chars, shown under the name)
+- **What's New in This Version** (release notes)
+- **Screenshots** — required per device size. Generate them with the `store-screenshots`
+  skill (outputs at `distribution/store_screenshots/<locale>/<device>/`), then drag into
+  the 6.9"/6.5" iPhone and 13" iPad slots.
+- **App Icon** — the 1024×1024 marketing icon (from the `generate-app-icons` skill).
+
+## 3. Categories, age rating, and pricing
+
+- **General → App Information:** Primary + Secondary **Category**, Content Rights, and the
+  **Age Rating** questionnaire (answer honestly — it derives the rating).
+- **Pricing and Availability:** set price tier (Free for most starter apps) and territories.
+
+## 4. App Privacy (data usage)
+
+**App Privacy → Get Started:** declare what data the app collects and how it's used (e.g.
+Firebase Analytics/Crashlytics → identifiers/usage data; auth → account). Provide your
+**Privacy Policy URL** — this must match `Constants.URL_PRIVACY_POLICY` and be a real,
+reachable page (Apple rejects placeholders). A terms/EULA URL goes in
+`Constants.URL_TERMS_CONDITIONS`.
+
+## 5. App Review Information
+
+At the bottom of the version page:
+
+- **Contact info** (first name, last name, phone, email — use `Constants.CONTACT_EMAIL`)
+- **Sign-in required?** The starter kit signs in **anonymously** by default, so usually no
+  demo account is needed; if you enabled gated social login, provide a demo account.
+- **Notes** to the reviewer if any feature needs explanation.
+
+## 6. Grab the numeric App ID → `Constants.kt`
+
+Once the app exists, its **Apple ID** (a numeric id, shown under *App Information → General
+Information → Apple ID*) goes into:
+
+```
+shared/src/commonMain/.../util/Constants.kt → APPSTORE_APP_ID = "1234567890"
+```
+
+Used by in-app "Rate us" / store deep-links.
+
+## Note — subscriptions / IAPs are deferred
+
+Do **not** create subscription groups or in-app purchase products here. Storefront
+monetization products are set up in the **`monetization`** phase (paywall + Adapty/
+RevenueCat + IAPs). This skill only creates the app record and its metadata so a first
+build can be submitted.
+
+## Validate
+
+The 1.0.0 version page shows no red "missing" indicators for metadata, screenshots, icon,
+age rating, and privacy. The app is ready to receive a build (via `publish-release`) and be
+submitted for review.

--- a/skills/setup-firebase/SKILL.md
+++ b/skills/setup-firebase/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: setup-firebase
+description: Create a Firebase project, register the Android + iOS apps, place google-services.json / GoogleService-Info.plist, and enable anonymous auth. Use when connecting the app to Firebase for the first time, or when the developer asks to set up Firebase / add the config files.
+---
+
+# Set up Firebase
+
+Firebase is the backend for auth, push notifications, and the AI Cloud Functions proxy. This skill
+covers the base project + app registration + anonymous auth. Social sign-in is a separate step —
+see `enable-auth`. The Cloud Functions deploy is `integrate-web-proxy`.
+
+Most of this happens in the browser at https://console.firebase.google.com/ — you (the agent) can
+prep identifiers and the SHA-1, but the developer performs the console clicks and file downloads.
+
+## 1. Prep the identifiers — Agent Action
+
+- **Android package** = the app's `applicationId` (in `MobileApp/androidApp/build.gradle.kts`).
+- **iOS bundle id** = `PRODUCT_BUNDLE_IDENTIFIER` in `MobileApp/iosApp/iosApp.xcodeproj/project.pbxproj`.
+- **Debug SHA-1** (required for Google sign-in on Android) — from `MobileApp/`:
+
+  ```bash
+  ./gradlew :androidApp:signingReport
+  ```
+
+  Copy the `SHA1` line under the `debug` variant for the developer to paste into Firebase.
+
+## 2. Create the project — User Action
+
+1. Open https://console.firebase.google.com/ → **Add project**, give it a name + unique project ID.
+2. **Upgrade to the Blaze (pay-as-you-go) plan** — Project Overview → Usage and billing → Details &
+   settings → Modify plan → **Blaze**. Required for Cloud Functions (`integrate-web-proxy`);
+   generous free tier, set a budget alert.
+
+## 3. Register the Android app + place config — User Action
+
+1. In the project, **Add app → Android**.
+2. **Package name** = the `applicationId` from step 1.
+3. Paste the **debug SHA-1** from step 1 (needed for Google sign-in).
+4. Download `google-services.json` and place it at:
+
+   ```
+   MobileApp/androidApp/google-services.json
+   ```
+
+## 4. Register the iOS app + place config — User Action
+
+1. **Add app → iOS**.
+2. **Bundle ID** = the iOS bundle id from step 1.
+3. Download `GoogleService-Info.plist` and place it at:
+
+   ```
+   MobileApp/iosApp/iosApp/GoogleService-Info.plist
+   ```
+
+## 5. Enable Anonymous auth — User Action
+
+Firebase Console → **Authentication → Sign-in method → Anonymous → Enable**. The app auto-signs in
+anonymously on first launch (`signInAnonymouslyIfNecessary()`), and the Cloud Functions gate on a
+Firebase ID token, so this is required even before social sign-in.
+
+## 6. Validate — Validation
+
+With the real `google-services.json` in place, from `MobileApp/`:
+
+```bash
+./gradlew :androidApp:assembleDebug
+```
+
+Run the app; the first launch should silently obtain an anonymous session.
+
+## Next
+
+- Enable Google/Apple sign-in → `enable-auth`.
+- Deploy the AI backend and wire live calls → `integrate-web-proxy`.
+- Whole phase orchestration → the `integrations` guide.

--- a/skills/setup-google-play/SKILL.md
+++ b/skills/setup-google-play/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: setup-google-play
+description: Manually create and configure the app in Google Play Console — store listing, graphics, data safety, content rating, an internal testing track, and the CI service account. Use when the user is setting up the Play Store listing before an Android release.
+---
+
+# Set up Google Play Console (manual)
+
+Create and configure the Android app in Google Play Console. This is **User Action** work
+in the web console — the agent guides and stages local assets; it cannot create listings.
+Console: https://play.google.com/console
+
+Prerequisite: a **Google Play Developer account** (one-time $25 registration).
+
+## 1. Create the app
+
+Play Console → **Create app**:
+
+- **App name** (your public name)
+- **Default language**
+- **App or game**, **Free or paid**
+- Accept the developer program + export-law declarations
+
+The Android **package name** (`applicationId` in `androidApp/build.gradle.kts`) is bound
+to the app on the **first AAB upload**, not at creation — it is permanent afterward, so make
+sure the app id is final (use the `refactor-package` skill first if not).
+
+## 2. Store listing (Grow → Store presence → Main store listing)
+
+- **App name** (30 chars), **Short description** (80 chars), **Full description** (4000)
+- **App icon** — 512×512 PNG (32-bit, from the `generate-app-icons` source)
+- **Feature graphic** — **1024×500** PNG/JPG (required)
+- **Phone screenshots** — 2–8, from the `store-screenshots` skill
+  (`distribution/store_screenshots/<locale>/<device>/`); add tablet screenshots if you ship
+  tablet support.
+
+Category, contact email (use `Constants.CONTACT_EMAIL`), and **Privacy Policy URL** (must
+match `Constants.URL_PRIVACY_POLICY` and be reachable) are set under **Store settings** /
+**App content**.
+
+## 3. App content (Policy → App content)
+
+Complete each required declaration:
+
+- **Privacy policy** — the reachable URL above.
+- **Data safety** — questionnaire: what data is collected/shared and why (Firebase
+  Analytics/Crashlytics → device/usage identifiers; auth → account). Answer honestly.
+- **Content rating** — IARC questionnaire (derives the rating).
+- **Target audience**, **Ads** (declare if AdMob is enabled), **Government apps**, etc.
+
+## 4. Internal testing track (Test and release → Testing → Internal testing)
+
+- Create the track, add tester emails (or a tester Google Group).
+- This is where the first AAB lands. Upload it via the `publish-release` skill / Fastlane
+  `playstore_release` (default `track:internal`), or manually **Create new release → upload
+  the AAB**. The **first upload must be done here in the console** — subsequent releases can
+  be automated.
+
+## 5. Service account for CI (automated releases)
+
+To let Fastlane / `publish_android_playstore.yml` upload without manual steps:
+
+1. In Play Console → **Users and permissions → Invite / API access**, or via Google Cloud
+   Console, create a **service account** and grant it Play Console access (Release manager).
+2. Download the service-account **JSON key**.
+3. Store it as the `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` GitHub secret (see `setup-signing`)
+   and, for local Fastlane, at `~/credentials/google-service-app-publisher.json`.
+
+Full steps: the
+[upload-google-play action docs](https://github.com/r0adkll/upload-google-play?tab=readme-ov-file#configure-access-via-service-account).
+
+## Note — subscriptions / IAPs are deferred
+
+Do **not** create subscription or in-app products here. Play billing products are set up in
+the **`monetization`** phase. This skill only creates the app, its listing, and the internal
+track so a first build can be uploaded.
+
+## Validate
+
+**App content** shows all required declarations complete (green), the store listing has no
+missing-asset warnings, and the internal testing track is ready to receive an AAB.

--- a/skills/setup-signing/SKILL.md
+++ b/skills/setup-signing/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: setup-signing
+description: Create the Android upload keystore + iOS signing identities and move all signing secrets out of the committed app into CI (GitHub Actions) secrets. Use when the user needs release signing, a keystore, provisioning profiles, or to secure signing keys before publishing.
+---
+
+# Set up release signing (and move keys out of the app)
+
+Release builds must be **signed**, and the signing material must **never** live in the
+committed repo. This skill (1) generates the Android upload keystore, (2) wires it via a
+gitignored properties file, (3) sets up iOS certificates + provisioning profiles, and
+(4) moves everything into GitHub Actions secrets so CI can sign without secrets on disk.
+
+> Security principle: the keystore `.jks`, `keystore.properties`, the iOS `.p12`, the App
+> Store Connect API key, and any embedded API keys must be **gitignored on disk** and stored
+> as **CI secrets** (or a backend) — never committed. The starter kit's `.gitignore` already
+> excludes `distribution/android/keystore/keystore.jks`, `keystore.properties`, `*.aab`,
+> `*.ipa`, and `local.properties`. Keep it that way.
+
+## Android — upload keystore
+
+### Option A — helper script (recommended)
+
+From `MobileApp/`:
+
+```bash
+./scripts/generate_android_keystore.sh "Your Name" "YourCompany"
+```
+
+It generates `distribution/android/keystore/keystore.jks` **and**
+`distribution/android/keystore/keystore.properties` with auto-generated secure passwords
+(alias defaults to `aliasKey`, validity 10000 days).
+
+### Option B — manual `keytool`
+
+```bash
+cd MobileApp/distribution/android/keystore
+keytool -genkeypair -v \
+  -keystore keystore.jks \
+  -alias aliasKey \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -storepass <STORE_PASSWORD> -keypass <KEY_PASSWORD> \
+  -dname "CN=Your Name, O=YourCompany, C=US"
+```
+
+Then create `distribution/android/keystore/keystore.properties` (copy the committed
+`keystore.example.properties` and fill it in — this file is **gitignored**):
+
+```properties
+keystorePassword=<STORE_PASSWORD>
+keyPassword=<KEY_PASSWORD>
+keyAlias=aliasKey
+storeFile=../distribution/android/keystore/keystore.jks
+```
+
+**Back up `keystore.jks` + its passwords somewhere safe (password manager).** Losing it
+means you can never update the app on Google Play under the same signing identity.
+
+### Wiring (already in place)
+
+`androidApp/build.gradle.kts` reads the properties automatically — no edit needed:
+
+```kotlin
+val keystorePropertiesFile = rootProject.file("distribution/android/keystore/keystore.properties")
+val isSigningKeyExists = keystorePropertiesFile.exists()
+// signingConfigs { create("release") { storeFile = file(keystoreProperties["storeFile"]) … } }
+// release { signingConfig = signingConfigs.getByName(if (isSigningKeyExists) "release" else "debug") }
+```
+
+When `keystore.properties` is present, `:androidApp:bundleRelease` signs with it;
+otherwise it falls back to the debug key. So the only thing you do is provide the two
+gitignored files.
+
+## iOS — certificates + provisioning profiles
+
+Do this in **Xcode / Apple Developer** (User Action — the agent can't create signing
+identities):
+
+1. **Certificates** — In Keychain Access → *Certificate Assistant → Request a Certificate
+   From a Certificate Authority* (save to disk). At
+   https://developer.apple.com/account/resources/certificates/list create an **Apple
+   Development** and an **Apple Distribution** certificate from that request. Download both,
+   import into Keychain, then select both under *My Certificates*, right-click → *Export 2
+   Items* as **`Certificates.p12`** with a password.
+2. **Provisioning profiles** — At
+   https://developer.apple.com/account/resources/profiles/add create an **iOS App
+   Development** profile and an **App Store Connect** (distribution) profile for the app's
+   bundle id. Download and double-click each to install in Xcode. Note each profile's
+   **UUID** (open the file, search `UUID`).
+3. **Xcode** — In the `iosApp` target → *Signing & Capabilities*, select the correct team
+   and profiles for Debug and Release.
+
+## Move all secrets into CI (GitHub Actions)
+
+Add these under **repo Settings → Secrets and variables → Actions**. This is what removes
+the keys from developer machines and lets `publish_android_playstore.yml` /
+`publish_ios_appstore.yml` sign in CI.
+
+**Android** (base64-encode the gitignored files):
+
+```bash
+# run from MobileApp/
+base64 -i distribution/android/keystore/keystore.jks | pbcopy        # → SIGNING_KEY_STORE_FILE_BASE64
+base64 -i distribution/android/keystore/keystore.properties | pbcopy # → SIGNING_KEY_STORE_PROPERTIES_BASE64
+```
+
+| Secret | Value |
+|--------|-------|
+| `SIGNING_KEY_STORE_FILE_BASE64` | base64 of `keystore.jks` |
+| `SIGNING_KEY_STORE_PROPERTIES_BASE64` | base64 of `keystore.properties` |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Play service-account JSON contents (see `setup-google-play`) |
+| `GRADLE_CACHE_ENCRYPTION_KEY` | `openssl rand -base64 16` |
+
+**iOS:**
+
+```bash
+base64 -i Certificates.p12 | pbcopy   # → IOS_APP_CERTIFICATE_P12_BASE64
+```
+
+| Secret | Value |
+|--------|-------|
+| `IOS_APP_CERTIFICATE_P12_BASE64` | base64 of `Certificates.p12` |
+| `IOS_APP_CERTIFICATE_P12_PASSWORD` | password you set when exporting the p12 |
+| `APPSTORE_KEY_ID` | App Store Connect API **Key ID** |
+| `APPSTORE_ISSUER_ID` | App Store Connect API **Issuer ID** |
+| `APPSTORE_PRIVATE_KEY` | contents of the downloaded `AuthKey_*.p8` |
+| `APPSTORE_TEAM_ID` | App Store Connect Team ID |
+| `IOS_APP_DEVELOPMENT_PROVISION_UUID` | UUID of the development profile |
+| `IOS_APP_DISTRIBUTION_PROVISION_UUID` | UUID of the distribution profile |
+
+Create the ASC API key at App Store Connect → **Users and Access → Integrations → API Keys**
+(role *App Manager*); the Issuer ID and Key ID show there, and the `.p8` downloads once.
+
+## Other embedded secrets — out of the app too
+
+Runtime API keys (`GOOGLE_WEB_CLIENT_ID`, subscription provider keys, AdMob IDs, etc.) live
+in gitignored `MobileApp/local.properties` on disk and as GitHub secrets for CI — never in
+committed source. Server-side keys (OpenAI/Replicate) stay in the backend / Secret Manager,
+never in the app binary.
+
+## Validate
+
+- Android: `./gradlew :androidApp:bundleRelease` from `MobileApp/` produces a **signed** AAB
+  at `androidApp/build/outputs/bundle/release/androidApp-release.aab`. Verify the signer:
+  `keytool -printcert -jarfile <aab>` shows your certificate (not the Android debug cert).
+- CI: confirm the required secrets exist in repo settings; a tagged release build
+  (see `publish-release`) signs and uploads without any keys committed.

--- a/skills/setup-subscriptions/SKILL.md
+++ b/skills/setup-subscriptions/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: setup-subscriptions
+description: >-
+  Wire up in-app subscriptions in KMPStarterKit — pick the provider (Adapty default or RevenueCat)
+  via one gradle property, add the two SDK keys, create store products with aligned IDs, and map
+  them to the Premium entitlement + paywall placement in the provider dashboard. Use when the user
+  wants to add subscriptions / recurring in-app purchases / a premium tier, or configure Adapty or
+  RevenueCat. Part of the `monetization` phase.
+---
+
+# Set up subscriptions
+
+KMPStarterKit ships two interchangeable billing backends behind the `subscription-api` contracts:
+**Adapty (default)** and **RevenueCat**. Exactly one is linked per build. Everything below is manual —
+provider dashboards + store consoles + a few config edits. All Gradle commands run from `MobileApp/`.
+
+## 1. Pick the provider (one switch)
+
+Set `SUBSCRIPTION_PROVIDER` in `MobileApp/gradle.properties` — `ADAPTY` (default) or `REVENUECAT`:
+
+```properties
+# Possible options for SUBSCRIPTION_PROVIDER: ADAPTY, REVENUECAT
+SUBSCRIPTION_PROVIDER=ADAPTY
+```
+
+That property does two things: (a) `shared/build.gradle.kts` puts only the matching provider module
+on the classpath (`libs/subscription/subscription-adapty` or `subscription-revenuecat`), and (b)
+`Constants.subscriptionProviderFactory` delegates to `activeSubscriptionProviderFactory` — the single
+symbol each provider module exposes in package `com.kotlinfoundation.kmpstarterkit.subscription.config`.
+
+- **Never hardcode a provider in `Constants`.** `Constants` must stay provider-agnostic; the property
+  resolves it so build + app code can't drift.
+- **Both `ADAPTY` and `REVENUECAT` builds must compile.** If you touch subscription code, flip the
+  property to the other value and rebuild before declaring done.
+
+## 2. SDK API keys → `local.properties`
+
+Same property names for both providers (`MobileApp/local.properties`, not committed):
+
+```properties
+SUBSCRIPTION_PROVIDER_ANDROID_API_KEY=<provider Android SDK key>
+SUBSCRIPTION_PROVIDER_IOS_API_KEY=<provider iOS SDK key>
+```
+
+- Adapty keys: [app.adapty.io](https://app.adapty.io/) → App settings → API keys (public SDK keys).
+- RevenueCat keys: [app.revenuecat.com](https://app.revenuecat.com/) → Project → API keys (public
+  Android / iOS app-specific keys).
+
+## 3. Create products in the stores (User Action)
+
+Products are created in the store consoles — **the store app records must already exist** (from the
+`publishing` phase).
+
+- **App Store Connect** → your app → **Features → In-App Purchases / Subscriptions**. iOS also needs
+  the **In-App Purchase** capability enabled on the target in Xcode (Signing & Capabilities → +).
+- **Google Play Console** → your app → **Monetize → Products → Subscriptions**.
+
+**Align product IDs across platforms** (e.g. `premium_monthly`, `premium_annual`) so the provider can
+treat them as one offering. Use the prices you locked in `design-paywall` /
+`AiGuidelines/project/paywall.md`. Enable **purchasing-power parity (PPP) / regional pricing** in each
+store so prices adjust per region — the `PaywallUiStateMapper` renders whatever localized price the
+provider returns.
+
+## 4. Map to entitlements + placements (User Action)
+
+In the provider dashboard (Adapty or RevenueCat):
+
+1. Link the store products you just created.
+2. Map them to an **entitlement / access level** whose key matches
+   `Constants.PAYWALL_PREMIUM_ACCESS` (default `"Premium"`). To use a different key or multiple tiers,
+   edit `PAYWALL_PREMIUM_ACCESS` in
+   `shared/src/commonMain/kotlin/com/kotlinfoundation/kmpstarterkit/util/Constants.kt`; the repo checks
+   access via `subscriptionRepository.hasPremiumAccess()` (and `hasEntitlementAccess(key)` for
+   multi-tier).
+3. Configure the **paywall placement(s)** the app requests. The custom subscription paywall uses the
+   default placement.
+
+## Custom vs. remote paywall
+
+By default the app renders its **own** custom paywall (`SHOW_REMOTE_PAYWALL = false` in
+`data/source/featureflag/FeatureFlagManager.kt`) — full design control, purchase + restore handled per
+store guidelines. Flip `SHOW_REMOTE_PAYWALL` to `true` (or via Firebase Remote Config, key
+`show_remote_paywall`) to render the provider's remotely-managed paywall instead. Author the custom
+paywall's offer/copy via the **`design-paywall`** skill.
+
+## Validation
+
+- `./gradlew :androidApp:assembleDebug` builds.
+- Run the app, open the paywall — real products fetched from the provider appear.
+- A **sandbox** purchase (App Store sandbox tester / Play internal-test / license tester) completes and
+  `hasPremiumAccess()` becomes true (paywall dismisses).
+- Run the `run-quality-gates` skill before committing.
+
+## Related skills
+
+`design-paywall` (author the offer first) · `enable-credits` (credit-pack IAPs) ·
+`enable-ads` · `monetization` (the phase guide that orders these).

--- a/skills/store-screenshots/SKILL.md
+++ b/skills/store-screenshots/SKILL.md
@@ -33,3 +33,7 @@ Rules:
 - Leave `device =` unset unless the user explicitly asks for a specific device (the default is `StoreDevice.IPHONE_6_5`).
 - `@StoreScreenshot` previews are excluded from regression screenshot tests and only render when the script sets `-PgenerateStoreScreenshots=true` — don't try to run them via the normal test tasks.
 - The annotation + `StoreDevice` enum live at `shared/src/commonMain/.../util/StoreScreenshot.kt`.
+
+---
+
+*Phase 3 · Publication — part of the [publishing](../publishing/SKILL.md) guide.*


### PR DESCRIPTION
## What & why

The repo shipped **7 atomic skills** that each wrap one `MobileApp/scripts/*.sh` helper. They're good at "do one mechanical thing" but they don't teach a developer how to go from a cloned template to a running app — let alone to the store or to revenue. That knowledge lived **outside** the skills, in `Documentation/docs/**` and an external CLI.

This PR delivers everything the boilerplate + docs + CLI provide, but **through skills**, structured as a phase-by-phase developer journey. Skills are **dual-audience**: an AI agent executes them reliably, and a developer who doesn't want AI can walk them manually — real commands, real paths, real console URLs. **No external CLI is referenced anywhere.**

## The 5-phase journey (one guide per phase)

| Phase | Guide | You end with |
|---|---|---|
| 1 · First Run | `getting-started` | App **running on your own device**, rebranded, driven purely locally (screen, Room, preference, network call, permission) — **no cloud** |
| 2 · Integrations | `integrations` | Firebase + auth + web-proxy backend wired; real remote calls work |
| 3 · Publication | `publishing` | Icons, release signing (**keys moved into CI, not the app**), store listings, first build in review |
| 4 · Monetization | `monetization` | Subscriptions + credit-pack IAPs + paywall + ads |
| 5 · Growth | `growth` | Analytics/Crashlytics/RemoteConfig, push, onboarding, virality loops |

Phase 1 is kept **strictly local** — Firebase/auth/backend integration is its own Phase 2, so first run stays far from any service setup.


## Changes

- **5 new guide skills** (`SKILL.md` + `progress-template.md` each).
- **21 new atomic skills** encoding manual steps previously only in docs/CLI: `run-the-app`, `add-api-service`, `save-preferences`, `add-permission`, `configure-environment`, `setup-firebase`, `enable-auth`, `integrate-web-proxy`, `generate-app-icons`, `setup-signing`, `setup-appstore-connect`, `setup-google-play`, `publish-release`, `setup-subscriptions`, `enable-credits`, `enable-ads`, `design-paywall`, `setup-analytics`, `enable-notifications`, `design-onboarding`, `add-virality-loop`.
- **7 existing skills refreshed** with phase/guide cross-reference footers (no script behavior change).
- **`skills/README.md`** and **`AGENTS.md`** (→ `CLAUDE.md` symlink) gain the two-layer index + 5-phase journey map.

## Verification

- 33 `SKILL.md` (26 new + 7 existing) + 5 `progress-template.md`; all frontmatter valid.
- Every skill-name and relative-link cross-reference resolves to a real skill.
- No KAppMaker-CLI references (only the standard `firebase-tools` CLI, which is legitimate).
- Specifics grounded in real repo files (gradle tasks, `local.properties`/`gradle.properties` keys, `Constants.kt` fields, `FeatureFlagManager`, paywall layer, CI secret names) — not invented.
