### PR TITLE
feat(skills): two-window developer flow + progress tracking

### DIFF
--- a/.agents/skills/koko-getting-started/SKILL.md
+++ b/.agents/skills/koko-getting-started/SKILL.md
@@ -22,7 +22,7 @@ To work effectively with this monorepo, we recommend the Two-Window Approach in 
 
 > [!IMPORTANT]
 > **CRITICAL AGENT INSTRUCTION**: Whenever a developer says "please proceed with koko-getting-started", "getting started", or asks to start Phase 1, the agent's very first step and response MUST explicitly instruct the developer to open a new Android Studio window for the `MobileApp/` directory. The agent must state this clearly:
-> *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open `/Users/mattdyor/koko/MobileApp` in a new window and type 'Run @koko-skills' there to get the mobile environment loaded!"*
+> *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open the `MobileApp/` directory (at the repository root) in a new window and type 'Run @koko-skills' there to get the mobile environment loaded!"*
 
 
 ---

--- a/.agents/skills/koko-getting-started/SKILL.md
+++ b/.agents/skills/koko-getting-started/SKILL.md
@@ -20,6 +20,11 @@ To work effectively with this monorepo, we recommend the Two-Window Approach in 
     * **Features**: Compose Previews, Android/iOS/Desktop/Web targets, and mobile-specific debugging.
     * **Getting Started**: Open the `MobileApp/` directory in a new Android Studio window and type "Run @koko-skills" to load [**koko-skills**](../../../MobileApp/.agents/skills/koko-skills/SKILL.md) — environment setup plus the full index of mobile development skills.
 
+> [!IMPORTANT]
+> **CRITICAL AGENT INSTRUCTION**: Whenever a developer says "please proceed with koko-getting-started", "getting started", or asks to start Phase 1, the agent's very first step and response MUST explicitly instruct the developer to open a new Android Studio window for the `MobileApp/` directory. The agent must state this clearly:
+> *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open `/Users/mattdyor/koko/MobileApp` in a new window and type 'Run @koko-skills' there to get the mobile environment loaded!"*
+
+
 ---
 
 ## 🚀 Skill Discovery

--- a/MobileApp/.agents/skills/koko-mobileapp-getting-started/SKILL.md
+++ b/MobileApp/.agents/skills/koko-mobileapp-getting-started/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: koko-mobileapp-getting-started
+description: Phase 1 developer journey guide for the MobileApp directory. Use this skill when the developer asks to proceed with getting started or to run koko-mobileapp-getting-started. It sets up Phase 1 progress tracking in the root folder and guides you through building the local app loops.
+---
+
+# Koko MobileApp Getting Started (Phase 1)
+
+This skill coordinates the local-only development loop (Phase 1) within the `MobileApp/` project window.
+
+## Elegant Two-Window Flow Overview
+
+This repository uses a two-window approach:
+1. **Root Window:** The developer opens the root repository directory. This is where high-level orchestration, the backend `Web/` proxy, and Phase 2 (`integrations`) / Phase 3 (`publishing`) tasks are run.
+2. **MobileApp Window:** The developer opens the `MobileApp/` directory. This is where local-only app development (Phase 1) takes place.
+
+---
+
+## Agent Instructions
+
+When the user asks to "proceed with koko-mobileapp-getting-started" or "get started" inside the `MobileApp/` workspace, perform the following steps:
+
+1. **Activate the Central Getting-Started Checklist:**
+   Read and load the root-level getting-started blueprint located at:
+   `../../../../skills/getting-started/SKILL.md`
+
+2. **Initialize Phase 1 Progress Tracker:**
+   Copy the progress template from the root-level `../../../../skills/getting-started/progress-template.md` to:
+   `../../PROGRESS_P1_GETTING_STARTED.md` (which maps to the root-level `/PROGRESS_P1_GETTING_STARTED.md`).
+   This ensures that progress is saved in the root folder alongside any other phase trackers.
+
+3. **Drive Phase 1 Implementation:**
+   - Review `PROGRESS_P1_GETTING_STARTED.md` and build out the local loops (Room, Preferences, API service, permissions, etc.).
+   - Follow the **STOP rule**: stop and wait for confirmation whenever a step is a **User Action**.
+   - Keep `PROGRESS_P1_GETTING_STARTED.md` updated as you complete tasks.
+
+4. **Phase 1 Hand-Off:**
+   Once all Phase 1 tasks are complete and verified, present a clear next-step message to the developer:
+   > *"Phase 1 is officially complete! Your local loop is fully verified. To continue with Phase 2 (Integrations) or Phase 3 (Publishing), please switch back to your root directory Android Studio window and invoke the respective root-level skill there."*

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -13,14 +13,19 @@ permission. Prove the loop end-to-end before adding any cloud services.
 - Firebase (Analytics, Messaging, Crashlytics, RemoteConfig), authentication, backend / web-proxy → the **`integrations`** guide.
 - App Store / Play Store, signing for release, subscriptions/monetization → the **`publishing`** guide.
 
-## STOP rule
+## Two-Window Flow & STOP rule
 
-> When the next unchecked item is a **User Action**, stop and wait for the developer to confirm they've
-> done it before continuing. Never fabricate device state or credentials.
+> **Two-Window Developer Flow:**
+> This repository uses an elegant Two-Window setup for seamless multi-environment management:
+> 1. **Root Window:** Opened at the repository root. This window manages root-level configurations, the Node.js backend proxy (`Web/`), and Phase 2 (`integrations`) and Phase 3 (`publishing`) progress.
+> 2. **MobileApp Window:** Opened at the `MobileApp/` directory. This window isolates the Android/iOS/Desktop/Web client environment and drives Phase 1 development.
 
 > [!IMPORTANT]
-> **CRITICAL AGENT INSTRUCTION**: The very first step of getting started with this repo is to instruct the developer to open a new Android Studio window pointing to the `MobileApp/` directory. You must explicitly request this before suggesting or starting any plan:
-> *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open `/Users/mattdyor/koko/MobileApp` in a new window and type 'Run @koko-skills' there to get the mobile environment loaded!"*
+> **CRITICAL AGENT INSTRUCTION (TWO-WINDOW TRANSITION)**:
+> If this skill is executed from the **Root Window**, the very first step is to instruct the developer to open a new Android Studio window pointing to the `MobileApp/` directory:
+> *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open `/Users/mattdyor/koko/MobileApp` in a new window and type 'Run @koko-mobileapp-getting-started' there to load the client environment and begin building the local loop!"*
+
+> **STOP rule:** When the next unchecked item is a **User Action**, stop and wait for the developer to confirm they've done it before continuing. Never fabricate device state or credentials.
 
 ## Role labels
 
@@ -71,7 +76,6 @@ permission. Prove the loop end-to-end before adding any cloud services.
 
 > **App launches on at least one platform and shows the Home screen; quality gates pass.**
 
-Once green, move on to the **`integrations`** guide (Firebase, auth, backend/web-proxy), then
-**`publishing`**.
+Once green, switch back to the **Root Window** to proceed to the **`integrations`** guide (Firebase, auth, backend/web-proxy), then **`publishing`**.
 
-Track your progress by copying `progress-template.md` (next to this file) into your repo.
+Progress is tracked in `PROGRESS_P1_GETTING_STARTED.md` at the root folder.

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -23,7 +23,7 @@ permission. Prove the loop end-to-end before adding any cloud services.
 > [!IMPORTANT]
 > **CRITICAL AGENT INSTRUCTION (TWO-WINDOW TRANSITION)**:
 > If this skill is executed from the **Root Window**, the very first step is to instruct the developer to open a new Android Studio window pointing to the `MobileApp/` directory:
-> *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open `/Users/mattdyor/koko/MobileApp` in a new window and type 'Run @koko-mobileapp-getting-started' there to load the client environment and begin building the local loop!"*
+> *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open the `MobileApp/` directory (at the repository root) in a new window and type 'Run @koko-mobileapp-getting-started' there to load the client environment and begin building the local loop!"*
 
 > **STOP rule:** When the next unchecked item is a **User Action**, stop and wait for the developer to confirm they've done it before continuing. Never fabricate device state or credentials.
 

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -18,6 +18,10 @@ permission. Prove the loop end-to-end before adding any cloud services.
 > When the next unchecked item is a **User Action**, stop and wait for the developer to confirm they've
 > done it before continuing. Never fabricate device state or credentials.
 
+> [!IMPORTANT]
+> **CRITICAL AGENT INSTRUCTION**: The very first step of getting started with this repo is to instruct the developer to open a new Android Studio window pointing to the `MobileApp/` directory. You must explicitly request this before suggesting or starting any plan:
+> *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open `/Users/mattdyor/koko/MobileApp` in a new window and type 'Run @koko-skills' there to get the mobile environment loaded!"*
+
 ## Role labels
 
 - **Agent Action** — an AI agent (or dev) can do it directly: edit code, run a script/gradle.

--- a/skills/getting-started/progress-template.md
+++ b/skills/getting-started/progress-template.md
@@ -1,8 +1,15 @@
-# Phase 1 progress — First Run (LOCAL-ONLY)
+# Phase 1 Progress — First Run (LOCAL-ONLY)
 
-Copy this file into your repo (e.g. `PROGRESS.md`) and tick items as you go. Full instructions are in
-the `getting-started` skill. Role labels: **User** = human-only, **Agent** = AI/dev can do it,
-**Validation** = a gate. Stop at any unchecked **User** item and wait for confirmation.
+> [!NOTE]
+> **Setup Instruction:** Copy this template file to the root of your repository and rename it to **`PROGRESS_P1_GETTING_STARTED.md`**.
+> Use this file to tick items as you go. Full instructions are in the `getting-started` skill.
+>
+> **Role Labels:**
+> - **User:** Human-only actions.
+> - **Agent:** AI/developer can execute (edit code, run gradle, etc.).
+> - **Validation:** A verification gate.
+>
+> *STOP RULE:* Stop at any unchecked **User** item and wait for confirmation before proceeding.
 
 ## A. Prerequisites & first run
 - [ ] **User** — Install JDK 17+ and Android Studio (Android SDK). macOS/iOS: install Xcode.

--- a/skills/growth/progress-template.md
+++ b/skills/growth/progress-template.md
@@ -1,7 +1,15 @@
-# Phase 5 — Growth progress
+# Phase 5 Progress — Growth
 
-Copy this file and tick items as you go. Role labels: **[Agent]** you do it, **[User]** the developer
-does it in a browser/console, **[Validate]** prove it works.
+> [!NOTE]
+> **Setup Instruction:** Copy this template file to the root of your repository and rename it to **`PROGRESS_P5_GROWTH.md`**.
+> Use this file to tick items as you go. Full instructions are in the `growth` skill.
+>
+> **Role Labels:**
+> - **[User]:** Developer does it in a browser/console.
+> - **[Agent]:** AI/developer can execute directly (edit code, write configurations).
+> - **[Validate]:** A verification gate.
+>
+> *STOP RULE:* Stop at any unchecked **[User]** item and wait for confirmation before proceeding.
 
 ## 1. Instrument the app — `setup-analytics`
 - [ ] **[Agent]** Add analytics events at funnel points (`Analytics.logScreenView`, key conversions)

--- a/skills/integrations/progress-template.md
+++ b/skills/integrations/progress-template.md
@@ -1,7 +1,15 @@
-# Phase 2 — Integrations progress
+# Phase 2 Progress — Integrations
 
-Copy this file and tick items as you go. Role labels: **[Agent]** you do it, **[User]** the developer
-does it in a browser/console, **[Validate]** prove it works.
+> [!NOTE]
+> **Setup Instruction:** Copy this template file to the root of your repository and rename it to **`PROGRESS_P2_INTEGRATIONS.md`**.
+> Use this file to tick items as you go. Full instructions are in the `integrations` skill.
+>
+> **Role Labels:**
+> - **[User]:** Developer does it in a browser/console.
+> - **[Agent]:** AI/developer can execute directly (edit code, write configurations).
+> - **[Validate]:** A verification gate.
+>
+> *STOP RULE:* Stop at any unchecked **[User]** item and wait for confirmation before proceeding.
 
 ## 1. Key catalog — `configure-environment`
 - [ ] **[Agent]** Walk through `local.properties` keys, `gradle.properties` `SUBSCRIPTION_PROVIDER`, `Constants.kt` fields

--- a/skills/monetization/progress-template.md
+++ b/skills/monetization/progress-template.md
@@ -1,4 +1,14 @@
-# Monetization progress
+# Phase 4 Progress — Monetization
+
+> [!NOTE]
+> **Setup Instruction:** Copy this template file to the root of your repository and rename it to **`PROGRESS_P4_MONETIZATION.md`**.
+> Use this file to tick items as you go. Full instructions are in the `monetization` skill.
+>
+> **Role Labels:**
+> - **(User):** Developer does it in a store / provider console.
+> - **(Agent):** AI/developer can execute directly (edit gradle/config, run scripts).
+>
+> *STOP RULE:* Stop at any unchecked **(User)** item and wait for confirmation before proceeding.
 
 ## 1. Design the offer
 - [ ] (Agent) Run `design-paywall` — hand over designer prompt + paywall template

--- a/skills/publishing/progress-template.md
+++ b/skills/publishing/progress-template.md
@@ -1,7 +1,15 @@
-# Phase 3 — Publishing progress
+# Phase 3 Progress — Publishing
 
-Copy this file and tick items as you go. Role labels: **[Agent]** you do it, **[User]** the developer
-does it in a console / Xcode, **[Validate]** prove it works.
+> [!NOTE]
+> **Setup Instruction:** Copy this template file to the root of your repository and rename it to **`PROGRESS_P3_PUBLISHING.md`**.
+> Use this file to tick items as you go. Full instructions are in the `publishing` skill.
+>
+> **Role Labels:**
+> - **[User]:** Developer does it in a console / Xcode / developer portal.
+> - **[Agent]:** AI/developer can execute directly (edit build files, generate assets, run scripts).
+> - **[Validate]:** A verification gate.
+>
+> *STOP RULE:* Stop at any unchecked **[User]** item and wait for confirmation before proceeding.
 
 ## 1. Lock final app identity — `refactor-package`
 - [ ] **[Agent]** App id / bundle id / display name are final (`./scripts/refactor_package.sh …`, or already done)


### PR DESCRIPTION
Work to make the agent understand the "two window" flow - where the root is used for the overall project and the Web app, and the second Android Studio window is opened on the MobileApp directory (which is the KMP root). This flow works reasonably well now - but we will want to iterate on it a bit to make sure the agent does not get confused. 