### PR TITLE
Make the agent reliably ask for required keys (env reliability + easiest-first auth)

### DIFF
--- a/MobileApp/local.properties.example
+++ b/MobileApp/local.properties.example
@@ -1,0 +1,48 @@
+# local.properties.example — template for MobileApp/local.properties
+#
+# local.properties is gitignored (it holds machine paths + secret API keys) and never ships in the
+# repo. Copy this file to `local.properties` and fill the values you need for your current phase:
+#
+#     cp local.properties.example local.properties
+#
+# Keys are read at build time by shared/build.gradle.kts via getRequiredProperty(...). Most keys have
+# a placeholder default ("testValue" or empty), so the app still BUILDS without them — but the
+# matching feature will not work. Run `./scripts/check_env.sh --phase <phase>` to see which keys are
+# still placeholders for the phase you are in.
+#
+# Legend:  [P1] getting-started  [P2] integrations  [P3] publishing  [P4] monetization  [P5] growth
+
+# --- [P1] Required to build & run locally ------------------------------------------------------
+# Android SDK location on your machine (the one value everyone must set).
+sdk.dir=/Users/you/Library/Android/sdk
+
+# --- [P2] Social sign-in (OPTIONAL) ------------------------------------------------------------
+# Only needed if you turn on Google/Apple sign-in (Constants.AUTH_SOCIAL_LOGIN_ENABLED = true).
+# The recommended easy path is Firebase + Anonymous auth, which needs NONE of these.
+# Get it from: Firebase Console -> Authentication -> Google provider -> Web client ID.
+GOOGLE_WEB_CLIENT_ID=
+
+# --- [P4] Subscriptions (Adapty default, or RevenueCat) ----------------------------------------
+# Public SDK keys for the billing provider selected by SUBSCRIPTION_PROVIDER in gradle.properties.
+# Adapty:     https://app.adapty.io/      -> App settings -> API keys (public SDK keys)
+# RevenueCat: https://app.revenuecat.com/ -> Project -> API keys (public app-specific keys)
+SUBSCRIPTION_PROVIDER_ANDROID_API_KEY=
+SUBSCRIPTION_PROVIDER_IOS_API_KEY=
+
+# --- [P4] AdMob (OPTIONAL — only if you enable ads) --------------------------------------------
+# Needed only when ads are on (FeatureFlagManager IS_ADS_ENABLED = true). Get them from the
+# Google AdMob console: https://apps.admob.com/
+ADMOB_APP_ID_ANDROID=
+ADMOB_BANNER_AD_ID_ANDROID=
+ADMOB_INTERSTITIAL_AD_ID_ANDROID=
+ADMOB_REWARDED_AD_ID_ANDROID=
+ADMOB_BANNER_AD_ID_IOS=
+ADMOB_INTERSTITIAL_AD_ID_IOS=
+ADMOB_REWARDED_AD_ID_IOS=
+
+# --- Optional / conditional --------------------------------------------------------------------
+# Image hosting token, only if you use image upload. Get it from https://api.imgbb.com/
+IMGBB_TOKEN=
+# Local/dev OpenAI calls only. Production keys live in Google Cloud Secret Manager (see the
+# integrate-web-proxy skill), NOT here. Get a key from https://platform.openai.com/
+OPENAI_API_KEY=

--- a/MobileApp/local.properties.example
+++ b/MobileApp/local.properties.example
@@ -43,6 +43,6 @@ ADMOB_REWARDED_AD_ID_IOS=
 # --- Optional / conditional --------------------------------------------------------------------
 # Image hosting token, only if you use image upload. Get it from https://api.imgbb.com/
 IMGBB_TOKEN=
-# Local/dev OpenAI calls only. Production keys live in Google Cloud Secret Manager (see the
-# integrate-web-proxy skill), NOT here. Get a key from https://platform.openai.com/
-OPENAI_API_KEY=
+
+# Note: OpenAI / Replicate keys do NOT go here. The app calls them only through the Cloud Functions
+# web-proxy, which reads them from Google Cloud Secret Manager — see the integrate-web-proxy skill.

--- a/MobileApp/scripts/check_env.sh
+++ b/MobileApp/scripts/check_env.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# check_env.sh — report which environment keys/secrets are still placeholders for a given phase.
+#
+# The build deliberately does NOT fail on missing keys (getRequiredProperty substitutes "testValue"
+# so the local app keeps building fast). That means a missing cloud key is invisible to an agent
+# driving the build. This script makes it VISIBLE: it reads local.properties + gradle.properties +
+# the relevant Constants.kt / FeatureFlagManager.kt flags and reports, per phase, which required keys
+# are still placeholders — so the agent knows to stop and ask the developer.
+#
+# Usage (run from MobileApp/):
+#   ./scripts/check_env.sh [--phase <name>] [--strict]
+#
+#   --phase <name>   getting-started | integrations | publishing | monetization | growth | all
+#                    (default: all). A key is flagged ⚠️ only if REQUIRED by that phase.
+#   --strict         exit non-zero when any required key is still a placeholder (default: exit 0).
+#   -h, --help       show this help.
+#
+# Classification per key:
+#   ✅ set            — a real value is present
+#   ⚠️  MISSING       — required for this phase but still a placeholder ("testValue"/empty/boilerplate)
+#   ⚪ optional/n-a   — not required for this phase (or only needed if you opt into a feature)
+#
+# Exit code is 0 unless --strict is passed and at least one ⚠️ was printed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+LOCAL_PROPS="$MOBILE_DIR/local.properties"
+GRADLE_PROPS="$MOBILE_DIR/gradle.properties"
+CONSTANTS="$MOBILE_DIR/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt"
+FEATURE_FLAGS="$MOBILE_DIR/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/featureflag/FeatureFlagManager.kt"
+GOOGLE_SERVICES="$MOBILE_DIR/androidApp/google-services.json"
+GOOGLE_PLIST="$MOBILE_DIR/iosApp/iosApp/GoogleService-Info.plist"
+
+PHASE="all"
+STRICT=false
+
+usage() { awk 'NR>1 && /^#/{sub(/^# ?/,""); print; next} NR>1{exit}' "${BASH_SOURCE[0]}"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --phase) PHASE="${2:-}"; shift 2 ;;
+    --strict) STRICT=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+case "$PHASE" in
+  getting-started|integrations|publishing|monetization|growth|all) ;;
+  *) echo "Invalid --phase '$PHASE'. Use: getting-started|integrations|publishing|monetization|growth|all" >&2; exit 2 ;;
+esac
+
+# ---------------------------------------------------------------------------- readers
+# Read a key's value from a properties file (last assignment wins, trims surrounding whitespace).
+prop() {
+  local file="$1" key="$2" line
+  [ -f "$file" ] || return 0
+  line="$(grep -E "^[[:space:]]*$key[[:space:]]*=" "$file" | tail -1 || true)"
+  [ -n "$line" ] || return 0
+  printf '%s' "${line#*=}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+# A local.properties value counts as a placeholder if it is empty or the sentinel "testValue".
+is_placeholder() {
+  local v="$1"
+  [ -z "$v" ] || [ "$v" = "testValue" ]
+}
+
+# Read a `const val NAME = "..."` string literal from Constants.kt.
+const_string() {
+  local name="$1"
+  [ -f "$CONSTANTS" ] || return 0
+  grep -E "val[[:space:]]+$name[[:space:]]*=" "$CONSTANTS" | tail -1 | sed -E 's/.*=[[:space:]]*"([^"]*)".*/\1/' || true
+}
+
+# Read a `const val NAME = true|false` boolean from Constants.kt.
+const_bool() {
+  local name="$1"
+  [ -f "$CONSTANTS" ] || { echo "false"; return 0; }
+  grep -E "val[[:space:]]+$name[[:space:]]*=" "$CONSTANTS" | tail -1 | grep -qE '=[[:space:]]*true' && echo "true" || echo "false"
+}
+
+# Read a FeatureFlagManager DEFAULT_VALUES boolean (e.g. Keys.IS_ADS_ENABLED to true).
+flag_default_bool() {
+  local key="$1"
+  [ -f "$FEATURE_FLAGS" ] || { echo "false"; return 0; }
+  grep -E "Keys\.$key[[:space:]]+to[[:space:]]+" "$FEATURE_FLAGS" | tail -1 | grep -qE 'to[[:space:]]+true' && echo "true" || echo "false"
+}
+
+# ---------------------------------------------------------------------------- state
+SOCIAL_AUTH="$(const_bool AUTH_SOCIAL_LOGIN_ENABLED)"
+ADS_ENABLED="$(flag_default_bool IS_ADS_ENABLED)"
+CLOUD_URL="$(const_string CLOUD_FUNCTIONS_URL)"
+PRIVACY_URL="$(const_string URL_PRIVACY_POLICY)"
+TERMS_URL="$(const_string URL_TERMS_CONDITIONS)"
+PROVIDER="$(prop "$GRADLE_PROPS" SUBSCRIPTION_PROVIDER)"; PROVIDER="${PROVIDER:-ADAPTY}"
+
+WARN_COUNT=0
+phase_active() { [ "$PHASE" = "all" ] || [ "$PHASE" = "$1" ]; }
+
+# Emit one line. $1 = tier (required|optional|na), $2 = label, $3 = state text, $4 = hint
+row() {
+  local tier="$1" label="$2" state="$3" hint="${4:-}"
+  case "$tier" in
+    required) printf '  ⚠️  %-34s %s\n' "$label" "$state"; [ -n "$hint" ] && printf '        ↳ %s\n' "$hint"; WARN_COUNT=$((WARN_COUNT+1)) ;;
+    ok)       printf '  ✅ %-34s %s\n' "$label" "$state" ;;
+    optional) printf '  ⚪ %-34s %s\n' "$label" "$state"; [ -n "$hint" ] && printf '        ↳ %s\n' "$hint" ;;
+  esac
+}
+
+# Check a local.properties key that is REQUIRED for the active phase.
+check_required_prop() {
+  local key="$1" where="$2" v; v="$(prop "$LOCAL_PROPS" "$key")"
+  if is_placeholder "$v"; then row required "$key" "MISSING (placeholder)" "get it from: $where"
+  else row ok "$key" "set"; fi
+}
+
+# Check a local.properties key that is OPTIONAL for the active phase.
+check_optional_prop() {
+  local key="$1" note="$2" v; v="$(prop "$LOCAL_PROPS" "$key")"
+  if is_placeholder "$v"; then row optional "$key" "not set" "$note"
+  else row ok "$key" "set"; fi
+}
+
+echo "Environment check — phase: $PHASE"
+echo
+
+# ============================================================================ P1 getting-started
+if phase_active getting-started; then
+  echo "[P1] getting-started"
+  check_required_prop sdk.dir "your machine's Android SDK path (~/Library/Android/sdk)"
+  echo
+fi
+
+# ============================================================================ P2 integrations
+if phase_active integrations; then
+  echo "[P2] integrations"
+  # Firebase config files — required (the committed ones are boilerplate: project_id == PROJECT_ID).
+  if [ ! -f "$GOOGLE_SERVICES" ] || grep -q '"project_id": *"PROJECT_ID"' "$GOOGLE_SERVICES" 2>/dev/null; then
+    row required "google-services.json" "MISSING/boilerplate" "download YOUR Firebase Android config -> androidApp/google-services.json"
+  else
+    row ok "google-services.json" "set"
+  fi
+  if [ ! -f "$GOOGLE_PLIST" ] || grep -q "PROJECT_ID" "$GOOGLE_PLIST" 2>/dev/null; then
+    row required "GoogleService-Info.plist" "MISSING/boilerplate" "download YOUR Firebase iOS config -> iosApp/iosApp/GoogleService-Info.plist"
+  else
+    row ok "GoogleService-Info.plist" "set"
+  fi
+  # Social sign-in is opt-in. Required only when AUTH_SOCIAL_LOGIN_ENABLED = true.
+  if [ "$SOCIAL_AUTH" = "true" ]; then
+    check_required_prop GOOGLE_WEB_CLIENT_ID "Firebase -> Auth -> Google provider -> Web client ID"
+    echo "        ↳ social auth is ON — also verify iOS Info.plist client IDs + the Xcode 'Sign In with Apple' capability"
+  else
+    row optional "GOOGLE_WEB_CLIENT_ID" "not needed" "anonymous auth is the default; set AUTH_SOCIAL_LOGIN_ENABLED = true to add Google/Apple"
+  fi
+  # AI web-proxy — optional unless you use it.
+  if [ -z "$CLOUD_URL" ]; then
+    row optional "CLOUD_FUNCTIONS_URL" "not set" "only if you use the AI web-proxy; set in Constants.kt after 'firebase deploy' (integrate-web-proxy)"
+  else
+    row ok "CLOUD_FUNCTIONS_URL" "set"
+  fi
+  # Subscriptions — optional commercial step in P2 (mandatory in P4).
+  check_optional_prop SUBSCRIPTION_PROVIDER_ANDROID_API_KEY "optional now; required in monetization ($PROVIDER dashboard)"
+  check_optional_prop SUBSCRIPTION_PROVIDER_IOS_API_KEY "optional now; required in monetization ($PROVIDER dashboard)"
+  echo
+fi
+
+# ============================================================================ P3 publishing
+if phase_active publishing; then
+  echo "[P3] publishing"
+  if [ -z "$PRIVACY_URL" ]; then row required "Constants.URL_PRIVACY_POLICY" "empty" "publish a privacy policy URL and set it in Constants.kt"; else row ok "Constants.URL_PRIVACY_POLICY" "set"; fi
+  if [ -z "$TERMS_URL" ]; then row required "Constants.URL_TERMS_CONDITIONS" "empty" "publish a terms URL and set it in Constants.kt"; else row ok "Constants.URL_TERMS_CONDITIONS" "set"; fi
+  row optional "signing / CI secrets" "not checked here" "keystore + store credentials live in GitHub Actions secrets — see the setup-signing skill"
+  echo
+fi
+
+# ============================================================================ P4 monetization
+if phase_active monetization; then
+  echo "[P4] monetization (provider: $PROVIDER)"
+  check_required_prop SUBSCRIPTION_PROVIDER_ANDROID_API_KEY "$PROVIDER dashboard -> API keys (public SDK key)"
+  check_required_prop SUBSCRIPTION_PROVIDER_IOS_API_KEY "$PROVIDER dashboard -> API keys (public SDK key)"
+  if [ "$ADS_ENABLED" = "true" ]; then
+    check_required_prop ADMOB_APP_ID_ANDROID "Google AdMob console (https://apps.admob.com/)"
+    for k in ADMOB_BANNER_AD_ID_ANDROID ADMOB_INTERSTITIAL_AD_ID_ANDROID ADMOB_REWARDED_AD_ID_ANDROID \
+             ADMOB_BANNER_AD_ID_IOS ADMOB_INTERSTITIAL_AD_ID_IOS ADMOB_REWARDED_AD_ID_IOS; do
+      check_required_prop "$k" "Google AdMob console"
+    done
+  else
+    row optional "ADMOB_* ad ids" "ads off" "enable via FeatureFlagManager IS_ADS_ENABLED = true, then add AdMob ids (enable-ads)"
+  fi
+  echo
+fi
+
+# ============================================================================ P5 growth
+if phase_active growth; then
+  echo "[P5] growth"
+  row optional "analytics / push" "no local keys" "Analytics/Crashlytics/RemoteConfig reuse the Firebase project; push needs APNs .p8 in the Firebase console (enable-notifications)"
+  echo
+fi
+
+# ---------------------------------------------------------------------------- summary
+if [ "$WARN_COUNT" -gt 0 ]; then
+  echo "⚠️  $WARN_COUNT required key(s) still placeholder for phase '$PHASE' — ask the developer to supply them before continuing."
+  $STRICT && exit 1 || exit 0
+else
+  echo "✅ All keys required for phase '$PHASE' are set."
+fi

--- a/MobileApp/scripts/check_env.sh
+++ b/MobileApp/scripts/check_env.sh
@@ -97,6 +97,8 @@ ADS_ENABLED="$(flag_default_bool IS_ADS_ENABLED)"
 CLOUD_URL="$(const_string CLOUD_FUNCTIONS_URL)"
 PRIVACY_URL="$(const_string URL_PRIVACY_POLICY)"
 TERMS_URL="$(const_string URL_TERMS_CONDITIONS)"
+CONTACT_EMAIL="$(const_string CONTACT_EMAIL)"
+APPSTORE_ID="$(const_string APPSTORE_APP_ID)"
 PROVIDER="$(prop "$GRADLE_PROPS" SUBSCRIPTION_PROVIDER)"; PROVIDER="${PROVIDER:-ADAPTY}"
 
 WARN_COUNT=0
@@ -174,6 +176,14 @@ if phase_active publishing; then
   echo "[P3] publishing"
   if [ -z "$PRIVACY_URL" ]; then row required "Constants.URL_PRIVACY_POLICY" "empty" "publish a privacy policy URL and set it in Constants.kt"; else row ok "Constants.URL_PRIVACY_POLICY" "set"; fi
   if [ -z "$TERMS_URL" ]; then row required "Constants.URL_TERMS_CONDITIONS" "empty" "publish a terms URL and set it in Constants.kt"; else row ok "Constants.URL_TERMS_CONDITIONS" "set"; fi
+  # CONTACT_EMAIL ships as the boilerplate team@measify.com — flag until it's your own.
+  if [ -z "$CONTACT_EMAIL" ] || [ "$CONTACT_EMAIL" = "team@measify.com" ]; then
+    row required "Constants.CONTACT_EMAIL" "boilerplate/empty" "set your own support email in Constants.kt (still $CONTACT_EMAIL)"
+  else row ok "Constants.CONTACT_EMAIL" "set"; fi
+  # APPSTORE_APP_ID is assigned by App Store Connect — only knowable once the iOS app record exists.
+  if [ -z "$APPSTORE_ID" ]; then
+    row optional "Constants.APPSTORE_APP_ID" "not set" "numeric App Store id for rate/review + manage-subscription deep links; set it after App Store Connect creates the app"
+  else row ok "Constants.APPSTORE_APP_ID" "set"; fi
   row optional "signing / CI secrets" "not checked here" "keystore + store credentials live in GitHub Actions secrets — see the setup-signing skill"
   echo
 fi

--- a/MobileApp/scripts/check_env.sh
+++ b/MobileApp/scripts/check_env.sh
@@ -176,8 +176,8 @@ if phase_active publishing; then
   echo "[P3] publishing"
   if [ -z "$PRIVACY_URL" ]; then row required "Constants.URL_PRIVACY_POLICY" "empty" "publish a privacy policy URL and set it in Constants.kt"; else row ok "Constants.URL_PRIVACY_POLICY" "set"; fi
   if [ -z "$TERMS_URL" ]; then row required "Constants.URL_TERMS_CONDITIONS" "empty" "publish a terms URL and set it in Constants.kt"; else row ok "Constants.URL_TERMS_CONDITIONS" "set"; fi
-  # CONTACT_EMAIL ships as the boilerplate team@measify.com — flag until it's your own.
-  if [ -z "$CONTACT_EMAIL" ] || [ "$CONTACT_EMAIL" = "team@measify.com" ]; then
+  # CONTACT_EMAIL ships as the boilerplate support@example.com — flag until it's your own.
+  if [ -z "$CONTACT_EMAIL" ] || [ "$CONTACT_EMAIL" = "support@example.com" ]; then
     row required "Constants.CONTACT_EMAIL" "boilerplate/empty" "set your own support email in Constants.kt (still $CONTACT_EMAIL)"
   else row ok "Constants.CONTACT_EMAIL" "set"; fi
   # APPSTORE_APP_ID is assigned by App Store Connect — only knowable once the iOS app record exists.

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
@@ -7,7 +7,7 @@ import com.kotlinfoundation.koko.subscription.config.activeSubscriptionProviderF
 object Constants {
     const val URL_PRIVACY_POLICY = ""
     const val URL_TERMS_CONDITIONS = ""
-    const val CONTACT_EMAIL = "team@measify.com"
+    const val CONTACT_EMAIL = "support@example.com"
     const val APPSTORE_APP_ID = ""
 
     // Enables Apple and Google sign-in. If false, only anonymous login is supported.

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
@@ -11,7 +11,10 @@ object Constants {
     const val APPSTORE_APP_ID = ""
 
     // Enables Apple and Google sign-in. If false, only anonymous login is supported.
-    const val AUTH_SOCIAL_LOGIN_ENABLED = true
+    // Default false — anonymous auth is the easiest path to a working app (just Firebase +
+    // Anonymous sign-in). Flip to true to add Google/Apple (see the enable-auth skill for the
+    // extra config: GOOGLE_WEB_CLIENT_ID, iOS Info.plist client IDs, Sign In with Apple capability).
+    const val AUTH_SOCIAL_LOGIN_ENABLED = false
 
     /**
      * The subscription provider is chosen in ONE place — the `SUBSCRIPTION_PROVIDER`

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This project is set up to be AI-ready out of the box — coding agents (Claude C
 - **`skills/`** — A phase-by-phase **developer journey** as agent-agnostic skills (open `SKILL.md` format): five guides — getting-started → integrations → publishing → monetization → growth — plus the one-job task skills they compose (run the app, new screen/model, Firebase, auth, signing, subscriptions, ads, notifications, …). Each is followable by an AI agent or by hand. Index: [`skills/README.md`](skills/README.md). Claude Code discovers them via the `.claude/skills` symlink; other agents via the Skills section in `AGENTS.md` (Gemini/Cursor/Copilot pointer files included)
 - **Build & test workflows** — All quality gates an agent needs are documented in `AGENTS.md` (Spotless, JVM/Android tests, debug build) and enforced in `.github/workflows/pr_checks.yml`
 - **Scaffolding scripts** — `MobileApp/scripts/generate_screen.sh` and `MobileApp/scripts/make_local.sh` keep agent-generated code consistent with project conventions
+- **Environment config** — copy `MobileApp/local.properties.example` → `local.properties`; `MobileApp/scripts/check_env.sh --phase <phase>` reports which required service keys are still placeholders so the agent can ask for them (the build otherwise defaults them and stays green)
 
 ## License
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -30,6 +30,18 @@ guide's `progress-template.md` into your repo to track where you are.
 
 **Task skills** do one job each and are usable standalone. The guides call them by name.
 
+## Environment keys (don't get silently skipped)
+
+Service keys (Firebase, social sign-in, Adapty/RevenueCat, AdMob) live in the gitignored
+`MobileApp/local.properties`. The build defaults missing keys to `"testValue"`/empty and stays green,
+so a forgotten key is invisible in the build. Two tools make it visible:
+
+- **`MobileApp/local.properties.example`** — committed template of every key, with placeholder,
+  where-to-get URL, and owning phase. Copy it to `local.properties` and fill what your phase needs.
+- **`MobileApp/scripts/check_env.sh --phase <phase>`** — reports which keys required by that phase are
+  still placeholders (✅ / ⚠️ / ⚪). Non-breaking; wired into `run-quality-gates` and every guide's
+  validation gate. Feature-aware, so the easy first-run path (anonymous auth, no ads) is never nagged.
+
 ## The journey (5 phases)
 
 | Phase | Guide | You end with |

--- a/skills/configure-environment/SKILL.md
+++ b/skills/configure-environment/SKILL.md
@@ -14,11 +14,16 @@ credentials, IDs, and toggles.
 | `MobileApp/gradle.properties` | subscription-provider toggle | Yes |
 | `shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt` | URLs, emails, feature flags, Cloud Functions URL | Yes |
 
-> `MobileApp/local.properties` is gitignored (`MobileApp/.gitignore`), so it never ships in the
-> template — you always create/fill it yourself. Keys are read at build time by
-> `shared/build.gradle.kts` via `getRequiredProperty(...)`; missing keys with no default fail the
-> build with `Make sure you added \`<KEY>\` in local.properties`. Most keys have a `defaultValue`
-> ("testValue" or "") so the app still builds without them, but the corresponding feature won't work.
+> `MobileApp/local.properties` is gitignored (`MobileApp/.gitignore`), so it never ships filled — copy
+> it from the committed **`MobileApp/local.properties.example`** and fill what your phase needs. Keys
+> are read at build time by `shared/build.gradle.kts` via `getRequiredProperty(...)`; missing keys with
+> no default fail the build with `Make sure you added \`<KEY>\` in local.properties`. Most keys have a
+> `defaultValue` ("testValue" or "") so the app still builds without them, but the corresponding
+> feature won't work — which means a missing key is invisible in the build.
+>
+> **Make it visible:** run `./scripts/check_env.sh --phase <phase>` from `MobileApp/` to list which
+> keys required by that phase are still placeholders (✅ / ⚠️ / ⚪). It's non-breaking and is wired into
+> `run-quality-gates` and every phase's validation gate.
 
 ## `MobileApp/local.properties` — key catalog
 
@@ -26,8 +31,8 @@ credentials, IDs, and toggles.
 |-----|-----|-----------------|-----------------|
 | `sdk.dir` | Android SDK location | Your machine's SDK path (`/Users/<you>/Library/Android/sdk`) | getting-started |
 | `GOOGLE_WEB_CLIENT_ID` | Google sign-in (Android + iOS) | Firebase → Auth → Google provider → **Web client ID** | integrations (`enable-auth`) |
-| `SUBSCRIPTION_PROVIDER_ANDROID_API_KEY` | Billing SDK public key (Android) | Adapty or RevenueCat dashboard | publishing / monetization |
-| `SUBSCRIPTION_PROVIDER_IOS_API_KEY` | Billing SDK public key (iOS) | Adapty or RevenueCat dashboard | publishing / monetization |
+| `SUBSCRIPTION_PROVIDER_ANDROID_API_KEY` | Billing SDK public key (Android) | Adapty or RevenueCat dashboard | integrations (opt-in) / monetization |
+| `SUBSCRIPTION_PROVIDER_IOS_API_KEY` | Billing SDK public key (iOS) | Adapty or RevenueCat dashboard | integrations (opt-in) / monetization |
 | `ADMOB_APP_ID_ANDROID` | AdMob app id (Android) | Google AdMob console | monetization (ads) |
 | `ADMOB_BANNER_AD_ID_ANDROID` | Banner ad unit (Android) | AdMob console | monetization |
 | `ADMOB_INTERSTITIAL_AD_ID_ANDROID` | Interstitial ad unit (Android) | AdMob console | monetization |
@@ -43,16 +48,15 @@ credentials, IDs, and toggles.
 > from **Google Cloud Secret Manager**, not from `local.properties` — see the `integrate-web-proxy`
 > skill.
 
-Example `MobileApp/local.properties`:
+Full template with placeholders, where-to-get URLs, and per-phase comments lives in the committed
+**`MobileApp/local.properties.example`** — copy it to `local.properties` and fill what you need:
 
-```properties
-sdk.dir=/Users/you/Library/Android/sdk
-GOOGLE_WEB_CLIENT_ID=1234567890-abcdef.apps.googleusercontent.com
-SUBSCRIPTION_PROVIDER_ANDROID_API_KEY=
-SUBSCRIPTION_PROVIDER_IOS_API_KEY=
-ADMOB_APP_ID_ANDROID=
-IMGBB_TOKEN=
+```bash
+cp MobileApp/local.properties.example MobileApp/local.properties   # then edit
 ```
+
+For the easy first-run path you only need `sdk.dir`. Everything else is filled as you reach the phase
+that needs it (and `check_env.sh` tells you when).
 
 ## `MobileApp/gradle.properties` — subscription provider toggle
 
@@ -74,7 +78,7 @@ Never hardcode a concrete provider in `Constants.kt`.
 | Field | Purpose |
 |-------|---------|
 | `CLOUD_FUNCTIONS_URL` | Base URL of the deployed web proxy — `https://REGION-PROJECT_ID.cloudfunctions.net` (default region `us-central1`). Set in the `integrate-web-proxy` skill. |
-| `AUTH_SOCIAL_LOGIN_ENABLED` | `true` = show Apple + Google sign-in; `false` = anonymous only. |
+| `AUTH_SOCIAL_LOGIN_ENABLED` | `false` (default) = anonymous auth only, the easy path; `true` = also show Apple + Google sign-in (needs `GOOGLE_WEB_CLIENT_ID` + iOS config — see `enable-auth`). |
 | `URL_PRIVACY_POLICY` | Privacy policy URL (needed before store publishing). |
 | `URL_TERMS_CONDITIONS` | Terms & conditions URL. |
 | `CONTACT_EMAIL` | Support/contact email shown in-app. |

--- a/skills/configure-environment/SKILL.md
+++ b/skills/configure-environment/SKILL.md
@@ -41,7 +41,6 @@ credentials, IDs, and toggles.
 | `ADMOB_INTERSTITIAL_AD_ID_IOS` | Interstitial ad unit (iOS) | AdMob console | monetization |
 | `ADMOB_REWARDED_AD_ID_IOS` | Rewarded ad unit (iOS) | AdMob console | monetization |
 | `IMGBB_TOKEN` | Image hosting/upload token | https://api.imgbb.com/ account | when using image upload |
-| `OPENAI_API_KEY` | Local/dev OpenAI calls | https://platform.openai.com/ | integrations (dev only — prod keys live in Secret Manager, see `integrate-web-proxy`) |
 
 > The AdMob and `ADMOB_APP_ID_ANDROID` value is also consumed in `androidApp/build.gradle.kts`
 > (manifest placeholder). Production Cloud Functions read `OPENAI_API_KEY` / `REPLICATE_API_KEY`

--- a/skills/enable-ads/SKILL.md
+++ b/skills/enable-ads/SKILL.md
@@ -19,9 +19,11 @@ flag, so you can also toggle it remotely via **Firebase Remote Config** (key `is
 shipping a build. While ads are disabled, `rememberInterstitialAdDisplayer()` /
 `rememberRewardedAdDisplayer()` return `null` — that's expected.
 
-## 2. Ad-unit IDs → `local.properties`
+## 2. Ad-unit IDs → `local.properties` (User Action)
 
-Add the IDs for the platforms + ad types you want (`MobileApp/local.properties`):
+These come from the AdMob console — ask the developer to create the app + ad units and paste the IDs;
+they can't be generated locally. **Stop and confirm** (or use Google's test ad unit IDs to try the UI
+first). Add the IDs for the platforms + ad types you want (`MobileApp/local.properties`):
 
 ```properties
 # Android

--- a/skills/enable-auth/SKILL.md
+++ b/skills/enable-auth/SKILL.md
@@ -5,13 +5,17 @@ description: Enable Google and Apple social sign-in on top of Firebase Auth — 
 
 # Enable social auth (Google + Apple)
 
+**This is an opt-in upgrade.** The easiest path to a working app is **anonymous auth only** — just
+Firebase + Anonymous sign-in (done in `setup-firebase`), which needs none of the keys below. Only run
+this skill if the developer explicitly wants Google/Apple sign-in.
+
 Adds Google and Apple sign-in on top of the base Firebase project. Requires `setup-firebase` done
 first (project + registered apps + anonymous auth). Auth is implemented via the `libs/auth/` module
 (`auth-api` contracts + `auth-firebase` implementation, using KMPAuth); `UserRepository` exposes
 `continueAsGuest()`, `logOut()`, `deleteAccount()`, and `currentUser`. `SignInScreen` already wires
 the UI — you're supplying credentials, not writing auth code.
 
-## 1. Confirm the feature flag — Agent Action
+## 1. Turn on the feature flag — Agent Action
 
 In `shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt`:
 
@@ -19,8 +23,8 @@ In `shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt`:
 const val AUTH_SOCIAL_LOGIN_ENABLED = true
 ```
 
-`true` (default) shows Apple + Google buttons; `false` = anonymous/guest only. Leave `true` for this
-skill.
+Default is `false` (anonymous/guest only — the social buttons are hidden). Set it to `true` to show
+the Apple + Google buttons, then complete steps 2–4 to supply the credentials they need.
 
 ## 2. Enable providers in Firebase — User Action
 

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -35,6 +35,14 @@ permission. Prove the loop end-to-end before adding any cloud services.
 
 ---
 
+## Keys / secrets you'll need
+
+Just one — this phase is local-only, no cloud, no accounts:
+- **`sdk.dir`** (required) — your machine's Android SDK path. Copy
+  `MobileApp/local.properties.example` → `local.properties` and set it.
+
+Verify: `./scripts/check_env.sh --phase getting-started`.
+
 ## Checklist (ordered)
 
 ### A. Prerequisites & first run

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -84,9 +84,14 @@ Verify: `./scripts/check_env.sh --phase getting-started`.
 
 > **App launches on at least one platform and shows the Home screen; quality gates pass.**
 
-Once green, switch back to the **Root Window** to proceed to the **`integrations`** guide (Firebase, auth, backend/web-proxy), then **`publishing`**.
-
 Progress is tracked in `PROGRESS_P1_GETTING_STARTED.md` at the root folder.
+
+## Done → next phase
+
+Once green, switch back to the **Root Window** and start Phase 2. **Trigger it explicitly** — tell
+your agent **"start the integrations phase"** (or run the `integrations` skill). That connects the
+app to real services: Firebase + anonymous auth, optional social sign-in, and the web-proxy backend.
+Then **`publishing`**. Don't stop here assuming the next phase auto-starts — name the phase to begin it.
 
 ---
 

--- a/skills/growth/SKILL.md
+++ b/skills/growth/SKILL.md
@@ -31,6 +31,14 @@ Crashlytics, Remote Config, and Cloud Messaging are all **the same Firebase proj
 Console work (upload the APNs `.p8` key, add Remote Config parameters, send a test push, read
 DebugView) is **User Action** — you cannot do it. Guide, then wait.
 
+## Keys / secrets you'll need
+
+No new `local.properties` keys. Analytics / Crashlytics / Remote Config reuse the existing Firebase
+project; push notifications need an **APNs `.p8`** uploaded in the Firebase console (see
+`enable-notifications`).
+
+Verify: `./scripts/check_env.sh --phase growth`.
+
 ## Checklist
 
 ### 1. Instrument the app — `setup-analytics`

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -25,6 +25,17 @@ Most of this phase is heavy **User Action** work — creating a Firebase project
 downloading `google-services.json` / `GoogleService-Info.plist`, enabling providers, setting Secret
 Manager keys, pasting API keys into `local.properties`. You cannot do these; guide, then wait.
 
+## Keys / secrets you'll need
+
+- **Firebase config files** (required) — your own `google-services.json` + `GoogleService-Info.plist`
+  (the committed ones are boilerplate: `project_id = PROJECT_ID`).
+- **`GOOGLE_WEB_CLIENT_ID`** (opt-in) — only if you add Google/Apple sign-in.
+- **Subscription SDK keys** (opt-in) — only if you set up monetization now.
+- **`CLOUD_FUNCTIONS_URL` + Secret Manager keys** (opt-in) — only if you use the AI web-proxy.
+
+The recommended anonymous-only path needs just the Firebase config. Verify:
+`./scripts/check_env.sh --phase integrations`.
+
 ## Checklist
 
 ### 1. Lay out the key catalog — `configure-environment`

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -111,5 +111,6 @@ the SDK **credentials** early if they want them.
 
 ## Done → next phase
 
-When authentication works and a live Cloud Function returns data, the app is connected. Proceed to
-the **`publishing`** phase to prepare store listings, signing, and release builds.
+When authentication works and a live Cloud Function returns data, the app is connected. **Trigger the
+next phase explicitly** — tell your agent **"start the publishing phase"** (or run the `publishing`
+skill) to prepare icons, release signing, store listings, and the first review build.

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -32,8 +32,10 @@ Manager keys, pasting API keys into `local.properties`. You cannot do these; gui
   catalog of `MobileApp/local.properties` keys, the `MobileApp/gradle.properties`
   `SUBSCRIPTION_PROVIDER` toggle, and the `Constants.kt` fields. Establish which values this phase
   needs (`GOOGLE_WEB_CLIENT_ID`, `CLOUD_FUNCTIONS_URL`) vs. later phases.
-- **User Action** — Ensure `MobileApp/local.properties` exists with at least `sdk.dir`. It is
-  gitignored, so it never came from the template. **Stop and confirm.**
+- **User Action** — Ensure `MobileApp/local.properties` exists with at least `sdk.dir` (copy it from
+  the committed `MobileApp/local.properties.example` if needed). It is gitignored, so it never came
+  from the template. Run `./scripts/check_env.sh --phase integrations` to see which keys this phase
+  will need. **Stop and confirm.**
 
 ### 2. Create the Firebase project + apps + anonymous auth — `setup-firebase`
 - **Agent Action** — Read the `setup-firebase` skill. Read the app's `applicationId` /
@@ -47,15 +49,35 @@ Manager keys, pasting API keys into `local.properties`. You cannot do these; gui
 - **Validation** — `./gradlew :androidApp:assembleDebug` succeeds with the real
   `google-services.json` in place.
 
-### 3. Enable social sign-in (Google / Apple) — `enable-auth`
-- **Agent Action** — Read the `enable-auth` skill. Confirm `Constants.AUTH_SOCIAL_LOGIN_ENABLED = true`
-  (default). Point the developer at the **Web client ID** they'll copy from Firebase.
-- **User Action** — In Firebase Auth → Sign-in method, enable **Google** and **Apple**; copy the
-  **Web client ID** into `GOOGLE_WEB_CLIENT_ID` in `MobileApp/local.properties`; wire iOS
-  `Info.plist` client IDs and (for Apple on iOS) add the **Sign In with Apple** capability in Xcode.
-  **Stop and confirm.**
+### 3. Authentication — anonymous first, social opt-in — `enable-auth`
+Easiest-first: the recommended path is **Firebase + Anonymous auth only** — the app already has
+working authentication (`continueAsGuest()`), no extra keys, no social config. `setup-firebase`
+(step 2) already enables Anonymous, so **by default this step is done** — `AUTH_SOCIAL_LOGIN_ENABLED`
+defaults to `false`, so the Google/Apple buttons are hidden and `GOOGLE_WEB_CLIENT_ID` is not needed.
 
-### 4. Deploy the web proxy + point the client at it — `integrate-web-proxy`
+- **Agent Action** — **Ask the developer: "do you also want Google / Apple sign-in?"**
+  - **No** (recommended for a first app) → nothing to do; anonymous auth works. Skip to step 4.
+  - **Yes** → read the `enable-auth` skill and proceed with the User Action below.
+- **User Action** (only if they said yes) — Set `Constants.AUTH_SOCIAL_LOGIN_ENABLED = true`, then in
+  Firebase Auth → Sign-in method enable **Google** and **Apple** (re-download **both**
+  `google-services.json` and `GoogleService-Info.plist`); copy the **Web client ID** into
+  `GOOGLE_WEB_CLIENT_ID` in `MobileApp/local.properties`; fill the iOS `Info.plist` client IDs
+  (`GIDServerClientID` / `GIDClientID` / `CFBundleURLSchemes`); add the **Sign In with Apple**
+  capability in Xcode; and for Apple-on-Android complete the Apple Developer `.p8` + Service ID web
+  flow. The `enable-auth` skill lists each of these. **Stop and confirm each.**
+
+### 4. Subscriptions — OPTIONAL commercial step (opt-in) — `setup-subscriptions`
+Not required for a working app — skip it unless the developer is setting up monetization now. Full
+product / entitlement / paywall dashboard wiring lives in Phase 4 (`monetization`); here we only grab
+the SDK **credentials** early if they want them.
+
+- **Agent Action** — **Ask: "are you setting up subscriptions/monetization now?"** If no, skip to
+  step 5 — the app still works fully.
+- **User Action** (only if yes) — Log into Adapty (default) or RevenueCat, copy both **public SDK
+  keys**, and paste them into `MobileApp/local.properties` (`SUBSCRIPTION_PROVIDER_ANDROID_API_KEY`,
+  `SUBSCRIPTION_PROVIDER_IOS_API_KEY`). **Stop and confirm.**
+
+### 5. Deploy the web proxy + point the client at it — `integrate-web-proxy`
 - **Agent Action** — Read the `integrate-web-proxy` skill. Explain the `Web/functions` backend, the
   `{statusCode, errorMessage, data}` response shape, and the `requireAuth` Firebase-token gate.
 - **User Action** — Set Secret Manager secrets `OPENAI_API_KEY` / `REPLICATE_API_KEY`
@@ -67,7 +89,11 @@ Manager keys, pasting API keys into `local.properties`. You cannot do these; gui
   wraps in `Result`). Optionally test the backend locally first with
   `firebase emulators:start --only functions` from `Web/`.
 
-### 5. Validation gate
+### 6. Validation gate
+- **Validation** — Run `./scripts/check_env.sh --phase integrations` from `MobileApp/`. For the
+  recommended anonymous-only path it should report clean once your real Firebase config is in place
+  (`GOOGLE_WEB_CLIENT_ID` and the subscription keys stay `⚪` unless you opted in above). Any `⚠️` is
+  a key to go get.
 - **Validation** — The app authenticates (anonymous **or** social) and a **live remote call**
   (e.g. one of the Cloud Functions) returns data on a real device/emulator. Run the
   `run-quality-gates` skill.

--- a/skills/integrations/progress-template.md
+++ b/skills/integrations/progress-template.md
@@ -13,7 +13,8 @@
 
 ## 1. Key catalog — `configure-environment`
 - [ ] **[Agent]** Walk through `local.properties` keys, `gradle.properties` `SUBSCRIPTION_PROVIDER`, `Constants.kt` fields
-- [ ] **[User]** `MobileApp/local.properties` exists with `sdk.dir` (gitignored — confirm)
+- [ ] **[User]** `MobileApp/local.properties` exists with `sdk.dir` (copy from `local.properties.example`; gitignored — confirm)
+- [ ] **[Agent]** Run `./scripts/check_env.sh --phase integrations` to see which keys this phase needs
 
 ## 2. Firebase project + apps + anonymous auth — `setup-firebase`
 - [ ] **[Agent]** Read `applicationId` / iOS bundle id; run `./gradlew :androidApp:signingReport` for the SHA-1
@@ -26,20 +27,26 @@
 - [ ] **[User]** Upgrade to Blaze plan (needed for Cloud Functions)
 - [ ] **[Validate]** `./gradlew :androidApp:assembleDebug` succeeds with real `google-services.json`
 
-## 3. Social sign-in (Google / Apple) — `enable-auth`
-- [ ] **[Agent]** Confirm `Constants.AUTH_SOCIAL_LOGIN_ENABLED = true`
-- [ ] **[User]** Enable Google + Apple providers in Firebase Auth
-- [ ] **[User]** Copy Web client ID → `GOOGLE_WEB_CLIENT_ID` in `local.properties`
-- [ ] **[User]** Wire iOS `Info.plist` client IDs + add "Sign In with Apple" capability in Xcode
+## 3. Authentication — anonymous first, social opt-in — `enable-auth`
+- [ ] **[Agent]** Anonymous auth already works (enabled in step 2, `AUTH_SOCIAL_LOGIN_ENABLED = false`) — nothing needed for the easy path
+- [ ] **[Agent]** Ask the developer: "do you also want Google / Apple sign-in?" (skip the rest if no)
+- [ ] **[User]** *(opt-in)* Set `AUTH_SOCIAL_LOGIN_ENABLED = true`; enable Google + Apple providers in Firebase Auth (re-download both config files)
+- [ ] **[User]** *(opt-in)* Copy Web client ID → `GOOGLE_WEB_CLIENT_ID` in `local.properties`
+- [ ] **[User]** *(opt-in)* Fill iOS `Info.plist` client IDs + add "Sign In with Apple" capability in Xcode (+ Apple `.p8`/Service ID for Android web flow)
 
-## 4. Web proxy deploy + client wiring — `integrate-web-proxy`
+## 4. Subscriptions — OPTIONAL commercial step (opt-in) — `setup-subscriptions`
+- [ ] **[Agent]** Ask: "are you setting up subscriptions/monetization now?" (skip if no — the app still works)
+- [ ] **[User]** *(opt-in)* Copy Adapty/RevenueCat public SDK keys → `SUBSCRIPTION_PROVIDER_ANDROID_API_KEY` / `_IOS_API_KEY` in `local.properties`
+
+## 5. Web proxy deploy + client wiring — `integrate-web-proxy`
 - [ ] **[Agent]** Explain `Web/functions`, `{statusCode, errorMessage, data}` shape, `requireAuth`
 - [ ] **[User]** Set Secret Manager `OPENAI_API_KEY` / `REPLICATE_API_KEY`
 - [ ] **[User]** `firebase deploy --only functions` from `Web/`
 - [ ] **[User]** Paste base URL into `Constants.CLOUD_FUNCTIONS_URL`
 - [ ] **[Agent]** Wire a client (Ktor + Firebase Bearer token) per the `add-api-service` pattern
 
-## 5. Validation gate
+## 6. Validation gate
+- [ ] **[Validate]** `./scripts/check_env.sh --phase integrations` — clean for the anonymous-only path once real Firebase config is in place
 - [ ] **[Validate]** App authenticates (anonymous or social) AND a live Cloud Function returns data
 - [ ] **[Validate]** Run the `run-quality-gates` skill
 

--- a/skills/monetization/SKILL.md
+++ b/skills/monetization/SKILL.md
@@ -37,6 +37,14 @@ they've done it before continuing. Never fabricate product IDs, entitlements, or
 Copy `skills/monetization/progress-template.md` into the working area at the start and tick items as
 you go. Each line is labelled with who owns it (Agent / User).
 
+## Keys / secrets you'll need
+
+- **Subscription SDK keys** (required) — `SUBSCRIPTION_PROVIDER_ANDROID_API_KEY` / `_IOS_API_KEY`
+  from the Adapty (default) or RevenueCat dashboard.
+- **AdMob ids** (opt-in) — only if you enable ads (`FeatureFlagManager` `IS_ADS_ENABLED`).
+
+Verify: `./scripts/check_env.sh --phase monetization`.
+
 ## Ordered checklist
 
 ### 1. Design the offer

--- a/skills/monetization/SKILL.md
+++ b/skills/monetization/SKILL.md
@@ -98,5 +98,6 @@ phase done.
 
 ## Next phase
 
-Once revenue plumbing works end-to-end, move on to the **`growth`** phase (analytics, retention,
-virality — see `AiGuidelines/project/virality_loops.md`).
+Once revenue plumbing works end-to-end, **trigger the next phase explicitly** — tell your agent
+**"start the growth phase"** (or run the `growth` skill) for analytics, retention, and virality
+(see `AiGuidelines/project/virality_loops.md`).

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -37,12 +37,16 @@ review. Guide precisely, stage local files, then wait.
 
 ## Keys / secrets you'll need
 
-- **`Constants.URL_PRIVACY_POLICY` + `URL_TERMS_CONDITIONS`** (required) — published URLs.
+- **`Constants.kt` fields** (required) — set these before you ship:
+  - `URL_PRIVACY_POLICY` + `URL_TERMS_CONDITIONS` — your published legal URLs.
+  - `CONTACT_EMAIL` — your own support email (ships as boilerplate `team@measify.com`).
+  - `APPSTORE_APP_ID` — numeric App Store id for rate/review + manage-subscription deep links; set it
+    once App Store Connect assigns it (`setup-appstore-connect`).
 - **Signing + store credentials** (required — CI secrets, not local files) — upload keystore, App
   Store Connect API key, provisioning profiles, Play service account. All move into **GitHub Actions
   secrets**, never committed — see `setup-signing`.
 
-Verify local config: `./scripts/check_env.sh --phase publishing`.
+Verify Constants config: `./scripts/check_env.sh --phase publishing`.
 
 ## Checklist
 
@@ -122,6 +126,9 @@ Verify local config: `./scripts/check_env.sh --phase publishing`.
   to **TestFlight**, then **submit for review** on both. **Stop and confirm.**
 
 ### 10. Validation gate
+- **Validation** — Run `./scripts/check_env.sh --phase publishing` from `MobileApp/` — the
+  `Constants.kt` legal URLs + `CONTACT_EMAIL` must be set (no `⚠️`), `APPSTORE_APP_ID` once ASC
+  assigned it.
 - **Validation** — The signed release build **uploads to the Play internal track /
   TestFlight and appears in the console**. Run the `run-quality-gates` skill before tagging a
   release.

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -136,6 +136,6 @@ Verify Constants config: `./scripts/check_env.sh --phase publishing`.
 ## Done → next phase
 
 When the first signed build is in the Play internal track and TestFlight and submitted for
-review, the app is publishable. Proceed to the **`monetization`** phase to add subscriptions,
-credit-pack IAPs, the paywall, and ads (the store subscription/IAP products are created there,
-not here).
+review, the app is publishable. **Trigger the next phase explicitly** — tell your agent **"start the
+monetization phase"** (or run the `monetization` skill) to add subscriptions, credit-pack IAPs, the
+paywall, and ads (the store subscription/IAP products are created there, not here).

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -35,6 +35,15 @@ review. Guide precisely, stage local files, then wait.
 > `keystore.jks`, `keystore.properties`, `*.aab`, `*.ipa`, and `local.properties` — keep them
 > there and put the CI-facing copies in **repo Settings → Secrets and variables → Actions**.
 
+## Keys / secrets you'll need
+
+- **`Constants.URL_PRIVACY_POLICY` + `URL_TERMS_CONDITIONS`** (required) — published URLs.
+- **Signing + store credentials** (required — CI secrets, not local files) — upload keystore, App
+  Store Connect API key, provisioning profiles, Play service account. All move into **GitHub Actions
+  secrets**, never committed — see `setup-signing`.
+
+Verify local config: `./scripts/check_env.sh --phase publishing`.
+
 ## Checklist
 
 ### 1. Lock the final app identity — `refactor-package`

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -39,7 +39,7 @@ review. Guide precisely, stage local files, then wait.
 
 - **`Constants.kt` fields** (required) — set these before you ship:
   - `URL_PRIVACY_POLICY` + `URL_TERMS_CONDITIONS` — your published legal URLs.
-  - `CONTACT_EMAIL` — your own support email (ships as boilerplate `team@measify.com`).
+  - `CONTACT_EMAIL` — your own support email (ships as boilerplate `support@example.com`).
   - `APPSTORE_APP_ID` — numeric App Store id for rate/review + manage-subscription deep links; set it
     once App Store Connect assigns it (`setup-appstore-connect`).
 - **Signing + store credentials** (required — CI secrets, not local files) — upload keystore, App

--- a/skills/publishing/progress-template.md
+++ b/skills/publishing/progress-template.md
@@ -60,6 +60,7 @@
 - [ ] **[User]** Submit for review on both stores
 
 ## 10. Validation gate
+- [ ] **[Validate]** `./scripts/check_env.sh --phase publishing` — Constants legal URLs + `CONTACT_EMAIL` set
 - [ ] **[Validate]** Signed build uploads to Play internal track / TestFlight and appears in the console
 - [ ] **[Validate]** Run the `run-quality-gates` skill
 

--- a/skills/run-quality-gates/SKILL.md
+++ b/skills/run-quality-gates/SKILL.md
@@ -5,7 +5,21 @@ description: Run the same lint, test, screenshot, and build checks as CI. Use be
 
 # Run quality gates
 
-All commands run from `MobileApp/`. Same gates as `.github/workflows/pr_checks.yml`, in order:
+All commands run from `MobileApp/`. Same gates as `.github/workflows/pr_checks.yml`, in order.
+
+## 0. Environment keys (agent-visible signal)
+
+The build defaults missing keys to `"testValue"`/empty and stays **green**, so a missing cloud key
+never fails a gate. Run this first so you can SEE what's still a placeholder:
+
+```bash
+# Pass the current phase; omit --phase to check every phase.
+./scripts/check_env.sh --phase <getting-started|integrations|publishing|monetization|growth>
+```
+
+It's non-breaking (exit 0). If it prints any `⚠️` line for a key **required by the current phase**,
+**STOP and ask the developer** to supply that key before declaring the gates green — the compile
+gates below will pass regardless.
 
 ```bash
 # 1. Formatting / lint (auto-fix first, then verify)

--- a/skills/setup-subscriptions/SKILL.md
+++ b/skills/setup-subscriptions/SKILL.md
@@ -33,9 +33,10 @@ symbol each provider module exposes in package `com.kotlinfoundation.koko.subscr
 - **Both `ADAPTY` and `REVENUECAT` builds must compile.** If you touch subscription code, flip the
   property to the other value and rebuild before declaring done.
 
-## 2. SDK API keys → `local.properties`
+## 2. SDK API keys → `local.properties` (User Action)
 
-Same property names for both providers (`MobileApp/local.properties`, not committed):
+Ask the developer to log into the provider dashboard and copy the two **public SDK keys**, then paste
+them into `MobileApp/local.properties` (not committed). Same property names for both providers:
 
 ```properties
 SUBSCRIPTION_PROVIDER_ANDROID_API_KEY=<provider Android SDK key>
@@ -45,6 +46,10 @@ SUBSCRIPTION_PROVIDER_IOS_API_KEY=<provider iOS SDK key>
 - Adapty keys: [app.adapty.io](https://app.adapty.io/) → App settings → API keys (public SDK keys).
 - RevenueCat keys: [app.revenuecat.com](https://app.revenuecat.com/) → Project → API keys (public
   Android / iOS app-specific keys).
+
+> **STOP — these keys can't be generated locally.** Without them the paywall silently falls back to
+> `"testValue"` and fetches no products (the build still passes). Wait for the developer to paste both
+> keys and confirm. Verify with `./scripts/check_env.sh --phase monetization`.
 
 ## 3. Create products in the stores (User Action)
 


### PR DESCRIPTION
## Why
Goal: an agent should walk a developer from first prompt to a working Koko app **≥90%** of the time — i.e. it fails to ask for a required manual step (API key, secret, config file, console setting) **≤10%** of the time. Two forces to balance: commercial-ready (needs real keys) vs super-fast/easy first run.

**Root cause of silent skips:** `getRequiredProperty(key, defaultValue = "testValue")` defaults missing keys to fake values, so `assembleDebug` / `run-quality-gates` stay **green** with every cloud key absent. The agent's only stop-signal (a red build) never fires; the failure is visible only to a human running the app.

## What this does
Every required manual step now has all three: a **template entry**, a **(User Action)-tagged guide step with STOP**, and an **agent-visible check** at the phase's validation gate.

**1 · `MobileApp/local.properties.example`** — committed template of every key: placeholder + where-to-get URL + owning phase. Copy to `local.properties`.

**2 · `MobileApp/scripts/check_env.sh --phase <phase>`** — phase- and feature-flag-aware report of which required keys are still placeholders (✅ / ⚠️ / ⚪). Non-breaking (exit 0 unless `--strict`). Detects boilerplate `google-services.json` (`project_id == PROJECT_ID`) and honors `AUTH_SOCIAL_LOGIN_ENABLED` / `IS_ADS_ENABLED`, so the easy first-run path is never nagged. Wired into `run-quality-gates` and every guide's validation gate.

**3 · Easiest-first auth** — `Constants.AUTH_SOCIAL_LOGIN_ENABLED` default `true → false`. A fresh app has working auth with just **Firebase + Anonymous** — no `GOOGLE_WEB_CLIENT_ID`, no social config. Social sign-in and subscription keys become explicit **opt-ins** in the integrations guide (agent asks first). The `enable-auth` skill spells out the full opt-in surface when a dev says yes (flag, re-download both Firebase configs, `GOOGLE_WEB_CLIENT_ID`, iOS Info.plist client IDs, Xcode Sign In with Apple capability, Apple `.p8`/Service ID for the Android web flow).

**4 · Gating fixes** — `setup-subscriptions` §2 and `enable-ads` §2 SDK/AdMob key steps now tagged `(User Action)` with STOP. A 'Keys / secrets you'll need' block added to all five phase guides, front-loading required vs opt-in keys.

## Commits
1. `feat(scripts)` — template + check_env.sh
2. `feat(skills)` — anonymous-first auth + env-check in the integrations flow
3. `docs(skills)` — key-step tagging + per-phase prerequisites + catalog/index

## Verification
- `check_env.sh --phase getting-started` on a fresh `local.properties` (only `sdk.dir`) → **clean**; the fast local build is untouched.
- `--phase integrations` flags boilerplate Firebase config; `GOOGLE_WEB_CLIENT_ID` shows `⚪ not needed` under the new anonymous default, flips to `⚠️` when social auth is turned on.
- `--phase monetization --strict` exits 1 with placeholder subscription keys; `getting-started --strict` exits 0.
- `./gradlew spotlessCheck :androidApp:assembleDebug` — **BUILD SUCCESSFUL**.