### PR TITLE
Direct AI mode (no-Firebase prototyping) + publishing readiness gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,24 @@ interface JobApiService {
 }
 ```
 
+**AI transport (proxy vs direct).** The OpenAI/Replicate services route every call through
+`AiTransport` (`data/source/remote/apiservices/ai/AiTransport.kt`) instead of hitting the Ktor client
+directly. It picks between two backends and adapts the response so the DTOs + `AiGenerationProvider`s +
+`AiApiBaseResponse.handleAsResult` never change:
+- **Proxy (production, default):** call `${Constants.CLOUD_FUNCTIONS_URL}/…` via the Firebase-interceptor
+  client; the body already is the `{statusCode, errorMessage, data}` envelope.
+- **Direct (prototyping):** call the provider URL (`api.openai.com` / `api.replicate.com`) via a second
+  client with **no** Firebase interceptor, sending `Authorization: Bearer <OPENAI_API_KEY|REPLICATE_API_KEY>`
+  (from `BuildConfig`/`local.properties`) + Replicate's `Prefer: wait`. The raw provider JSON is re-wrapped
+  into a synthetic `AiApiBaseResponse`.
+- **Selection:** auto — direct when `Constants.CLOUD_FUNCTIONS_URL` is blank AND the provider key is set;
+  `Constants.USE_AI_PROXY_SERVER` (`Boolean?`; `true`=proxy, `false`=direct, `null`=auto) overrides.
+  Prototyping only — direct-mode keys ship in the app
+  binary; production keeps the proxy (keys in Secret Manager). `AiTransport` is **provider-agnostic**: each
+  service supplies its own `directUrl` + headers + key-readiness, so a new provider needs no `AiTransport`
+  change. Text→image is fully Firebase-free; image-editing still hosts the input image via
+  `KMPStorage`/Firebase Storage (an ImgBB host swap is the follow-up).
+
 ### Repositories
 - **Prefer concrete classes** — no interface unless swapping implementations at runtime
 - **BackgroundExecutor** for all async operations:

--- a/MobileApp/local.properties.example
+++ b/MobileApp/local.properties.example
@@ -47,5 +47,13 @@ ADMOB_REWARDED_AD_ID_IOS=
 # Image hosting token, only if you use image upload. Get it from https://api.imgbb.com/
 IMGBB_TOKEN=
 
-# Note: OpenAI / Replicate keys do NOT go here. The app calls them only through the Cloud Functions
-# web-proxy, which reads them from Google Cloud Secret Manager — see the integrate-web-proxy skill.
+# --- Direct AI (no-Firebase prototyping) -------------------------------------------------------
+# By default the app calls OpenAI/Replicate through the Cloud Functions web-proxy, which reads these
+# keys from Google Cloud Secret Manager (production-safe — keys never on device).
+# For a QUICK no-Firebase prototype, set a key here AND leave CLOUD_FUNCTIONS_URL blank in Constants.kt:
+# the app then calls the provider directly from the device.
+# WARNING: the key is compiled into the app binary — prototyping only. For production, deploy the
+# web-proxy and clear these (see the integrate-web-proxy skill).
+# OpenAI:    https://platform.openai.com/   Replicate: https://replicate.com/account/api-tokens
+OPENAI_API_KEY=
+REPLICATE_API_KEY=

--- a/MobileApp/scripts/check_env.sh
+++ b/MobileApp/scripts/check_env.sh
@@ -91,6 +91,19 @@ flag_default_bool() {
   grep -E "Keys\.$key[[:space:]]+to[[:space:]]+" "$FEATURE_FLAGS" | tail -1 | grep -qE 'to[[:space:]]+true' && echo "true" || echo "false"
 }
 
+# Read a nullable Boolean const from Constants.kt → prints "true" | "false" | "null".
+const_tristate() {
+  local name="$1" line
+  [ -f "$CONSTANTS" ] || { echo "null"; return 0; }
+  line="$(grep -E "val[[:space:]]+$name\b" "$CONSTANTS" | tail -1)"
+  echo "$line" | grep -qE '=[[:space:]]*true' && { echo "true"; return 0; }
+  echo "$line" | grep -qE '=[[:space:]]*false' && { echo "false"; return 0; }
+  echo "null"
+}
+
+# A local.properties value is a real (usable) key: non-empty and not the "testValue" placeholder.
+key_is_set() { local v="$1"; [ -n "$v" ] && [ "$v" != "testValue" ]; }
+
 # ---------------------------------------------------------------------------- state
 SOCIAL_AUTH="$(const_bool AUTH_SOCIAL_LOGIN_ENABLED)"
 ADS_ENABLED="$(flag_default_bool IS_ADS_ENABLED)"
@@ -100,6 +113,11 @@ TERMS_URL="$(const_string URL_TERMS_CONDITIONS)"
 CONTACT_EMAIL="$(const_string CONTACT_EMAIL)"
 APPSTORE_ID="$(const_string APPSTORE_APP_ID)"
 PROVIDER="$(prop "$GRADLE_PROPS" SUBSCRIPTION_PROVIDER)"; PROVIDER="${PROVIDER:-ADAPTY}"
+USE_AI_PROXY="$(const_tristate USE_AI_PROXY_SERVER)"
+OPENAI_KEY="$(prop "$LOCAL_PROPS" OPENAI_API_KEY)"
+REPLICATE_KEY="$(prop "$LOCAL_PROPS" REPLICATE_API_KEY)"
+SUB_ANDROID_KEY="$(prop "$LOCAL_PROPS" SUBSCRIPTION_PROVIDER_ANDROID_API_KEY)"
+SUB_IOS_KEY="$(prop "$LOCAL_PROPS" SUBSCRIPTION_PROVIDER_IOS_API_KEY)"
 
 WARN_COUNT=0
 phase_active() { [ "$PHASE" = "all" ] || [ "$PHASE" = "$1" ]; }
@@ -184,6 +202,27 @@ if phase_active publishing; then
   if [ -z "$APPSTORE_ID" ]; then
     row optional "Constants.APPSTORE_APP_ID" "not set" "numeric App Store id for rate/review + manage-subscription deep links; set it after App Store Connect creates the app"
   else row ok "Constants.APPSTORE_APP_ID" "set"; fi
+
+  # AI backend — production must use the Firebase proxy so provider keys aren't compiled into the binary.
+  ai_direct_key_set=false
+  { key_is_set "$OPENAI_KEY" || key_is_set "$REPLICATE_KEY"; } && ai_direct_key_set=true
+  if [ "$USE_AI_PROXY" = "false" ]; then
+    row required "AI backend" "forced DIRECT" "Constants.USE_AI_PROXY_SERVER=false ships the API key in the app — set it to null/true and use the web-proxy for production (integrate-web-proxy)"
+  elif [ -z "$CLOUD_URL" ] && [ "$ai_direct_key_set" = true ]; then
+    row required "AI backend" "DIRECT (key on device)" "no CLOUD_FUNCTIONS_URL + a direct key set → providers are called directly with the key in the binary. Deploy the proxy + set CLOUD_FUNCTIONS_URL"
+  elif [ "$ai_direct_key_set" = true ]; then
+    row optional "AI backend" "direct key present" "proxy is active, but OPENAI/REPLICATE_API_KEY still compiles into the binary — clear it from local.properties for release builds"
+  else
+    row ok "AI backend" "proxy / none"
+  fi
+
+  # Subscriptions — real provider keys (not the demo mock) are needed to process purchases.
+  if key_is_set "$SUB_ANDROID_KEY" || key_is_set "$SUB_IOS_KEY"; then
+    row ok "subscription keys" "set"
+  else
+    row optional "subscription keys" "mock (unset)" "$PROVIDER SDK keys not set → the paywall runs the demo mock; set real keys before selling subscriptions/IAPs (setup-subscriptions)"
+  fi
+
   row optional "signing / CI secrets" "not checked here" "keystore + store credentials live in GitHub Actions secrets — see the setup-signing skill"
   echo
 fi

--- a/MobileApp/shared/build.gradle.kts
+++ b/MobileApp/shared/build.gradle.kts
@@ -259,6 +259,12 @@ buildConfig {
     )
     buildConfigField("IMGBB_TOKEN", getRequiredProperty(key = "IMGBB_TOKEN", defaultValue = "testValue"))
 
+    // Direct-AI (no-Firebase) provider keys. Empty by default → the app uses the Cloud Functions proxy.
+    // Setting one (with a blank CLOUD_FUNCTIONS_URL) makes AiTransport call the provider directly.
+    // Prototyping only — the key ships in the app binary; production should keep the proxy.
+    buildConfigField("OPENAI_API_KEY", getRequiredProperty(key = "OPENAI_API_KEY", defaultValue = ""))
+    buildConfigField("REPLICATE_API_KEY", getRequiredProperty(key = "REPLICATE_API_KEY", defaultValue = ""))
+
     // Adapty or RevenueCat Api key
     buildConfigField(
         "SUBSCRIPTION_PROVIDER_ANDROID_API_KEY",

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/HttpClientFactory.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/HttpClientFactory.kt
@@ -18,9 +18,26 @@ import kotlinx.serialization.json.Json
 
 /** Builds the app's shared Ktor [HttpClient] — JSON, timeouts, logging, and a bearer-token interceptor. */
 object HttpClientFactory {
-    fun default(authServiceProvider: AuthServiceProvider) = HttpClient {
+    /** The app/proxy client: attaches the Firebase ID token as a bearer to every request. */
+    fun default(authServiceProvider: AuthServiceProvider) = baseClient().also {
+        it.plugin(HttpSend).intercept { request ->
+            // For all requests you can send user token here, for example
+            val userToken = authServiceProvider.getCurrentUserToken(forceRefresh = true)
+            request.header("Authorization", "Bearer $userToken")
+            execute(request)
+        }
+    }
+
+    /**
+     * Client for DIRECT provider calls (OpenAI/Replicate) — deliberately WITHOUT the Firebase bearer
+     * interceptor. The provider `Authorization` header (the on-device API key) is set per request by
+     * [com.kotlinfoundation.koko.data.source.remote.apiservices.ai.AiTransport].
+     */
+    fun direct() = baseClient()
+
+    private fun baseClient() = HttpClient {
         defaultRequest {
-            url("BASE_URL") // TODO replace with your API base URL
+            url("BASE_URL") // TODO replace with your API base URL (AI calls pass absolute URLs)
             header(HttpHeaders.ContentType, "application/json")
         }
         install(HttpTimeout) {
@@ -46,13 +63,6 @@ object HttpClientFactory {
                     explicitNulls = false
                 },
             )
-        }
-    }.also {
-        it.plugin(HttpSend).intercept { request ->
-            // For all requests you can send user token here, for example
-            val userToken = authServiceProvider.getCurrentUserToken(forceRefresh = true)
-            request.header("Authorization", "Bearer $userToken")
-            execute(request)
         }
     }
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/AiTransport.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/AiTransport.kt
@@ -1,0 +1,135 @@
+package com.kotlinfoundation.koko.data.source.remote.apiservices.ai
+
+import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseResponse
+import com.kotlinfoundation.koko.util.Constants
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+enum class AiMode { PROXY, DIRECT }
+
+/**
+ * Everything the direct (no-proxy) path needs for one provider call: the provider [url] and the on-device
+ * [apiKey]. The key both drives auto-detection (direct only when it's set) and becomes the
+ * `Authorization: Bearer <key>` header — the transport builds that, so callers pass the key once. Add
+ * provider extras like Replicate's `Prefer: wait` via [extraHeaders].
+ */
+class AiDirectSpec(
+    val url: String,
+    val apiKey: String,
+    val extraHeaders: Map<String, String> = emptyMap(),
+)
+
+/**
+ * Routes an AI HTTP call to either the Firebase Cloud Functions **proxy** (production — key in Secret
+ * Manager, never on device) or **directly** to the provider API (prototyping — key from
+ * `local.properties`, no Firebase). Both API services ([OpenAiApiService], [ReplicateApiService]) call
+ * [execute].
+ *
+ * The transport is deliberately **provider-agnostic** — like the proxy, adding a new provider needs no
+ * change here: the calling service supplies its own [AiDirectSpec] (provider url + key + headers). The
+ * transport only decides the mode and adapts the response.
+ *
+ * The trick that keeps DTOs + generation providers + [AiApiBaseResponse.handleAsResult] untouched: in
+ * PROXY mode the HTTP body already IS the `{statusCode, errorMessage, data}` envelope; in DIRECT mode it
+ * is the raw provider object — which is exactly what `data` holds — so we parse the body as `T` and wrap
+ * it in a synthetic [AiApiBaseResponse]. Same `T`, same downstream code.
+ *
+ * DIRECT is auto-selected when [Constants.CLOUD_FUNCTIONS_URL] is blank AND the provider key is set
+ * ([AiDirectSpec.apiKey] set); [Constants.USE_AI_PROXY_SERVER] overrides. Prototyping only — the key ships in the binary.
+ */
+class AiTransport(
+    @PublishedApi internal val proxyClient: HttpClient, // carries the Firebase bearer-token interceptor
+    @PublishedApi internal val directClient: HttpClient, // no interceptor; provider auth set per-request
+) {
+
+    /**
+     * One generic call behind every AI endpoint.
+     *
+     * @param proxyUrl full Cloud Functions URL (proxy mode).
+     * @param direct the provider URL + key + headers for the direct path (see [AiDirectSpec]).
+     * @param proxyQueryParams query params sent in proxy mode only (direct URLs carry owner/name/id in the path).
+     */
+    suspend inline fun <reified T> execute(
+        method: HttpMethod,
+        proxyUrl: String,
+        direct: AiDirectSpec,
+        proxyQueryParams: Map<String, String> = emptyMap(),
+        body: Any? = null,
+    ): AiApiBaseResponse<T> {
+        val mode = resolveMode(hasAiApiKey = direct.apiKey.isNotBlank())
+        val response = rawExecute(mode, method, proxyUrl, direct, proxyQueryParams, body)
+        return when (mode) {
+            AiMode.PROXY -> response.body()
+
+            // body already is AiApiBaseResponse<T>
+            AiMode.DIRECT ->
+                if (response.status.isSuccess()) {
+                    AiApiBaseResponse(statusCode = response.status.value, data = response.body<T>())
+                } else {
+                    AiApiBaseResponse(
+                        statusCode = response.status.value,
+                        errorMessage = extractDirectError(response.bodyAsText()),
+                    )
+                }
+        }
+    }
+
+    @PublishedApi
+    internal suspend fun rawExecute(
+        mode: AiMode,
+        method: HttpMethod,
+        proxyUrl: String,
+        direct: AiDirectSpec,
+        proxyQueryParams: Map<String, String>,
+        body: Any?,
+    ): HttpResponse {
+        val client = if (mode == AiMode.PROXY) proxyClient else directClient
+        val url = if (mode == AiMode.PROXY) proxyUrl else direct.url
+        return client.request(url) {
+            this.method = method
+            if (mode == AiMode.PROXY) proxyQueryParams.forEach { (k, v) -> parameter(k, v) }
+            if (mode == AiMode.DIRECT) {
+                header(HttpHeaders.Authorization, "Bearer ${direct.apiKey}")
+                direct.extraHeaders.forEach { (k, v) -> header(k, v) }
+            }
+            if (body != null && method != HttpMethod.Get) setBody(body)
+        }
+    }
+
+    @PublishedApi
+    internal fun resolveMode(hasAiApiKey: Boolean): AiMode {
+        Constants.USE_AI_PROXY_SERVER?.let { return if (it) AiMode.PROXY else AiMode.DIRECT }
+        return if (Constants.CLOUD_FUNCTIONS_URL.isBlank() && hasAiApiKey) AiMode.DIRECT else AiMode.PROXY
+    }
+
+    /**
+     * Best-effort human message from a NON-2xx provider error body. OpenAI uses `{"error":{"message":…}}`;
+     * some errors use a top-level `error`/`detail` string. Falls back to the raw body if none match.
+     *
+     * Note: a Replicate *prediction failure* is NOT an HTTP error — it returns HTTP 2xx with
+     * `{"status":"failed","error":"…"}` in the prediction object, so it's read from
+     * `ReplicatePredictionResponse.error`/`status`, not here.
+     */
+    @PublishedApi
+    internal fun extractDirectError(rawBody: String): String = runCatching {
+        val obj = Json.parseToJsonElement(rawBody) as? JsonObject ?: return@runCatching rawBody
+        (obj["error"] as? JsonObject)?.get("message")?.jsonPrimitive?.contentOrNull // OpenAI {error:{message}}
+            ?: (obj["error"] as? JsonPrimitive)?.contentOrNull // top-level error string
+            ?: (obj["detail"] as? JsonPrimitive)?.contentOrNull // some 4xx bodies
+            ?: rawBody
+    }.getOrDefault(rawBody)
+}

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/OpenAiApiService.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/OpenAiApiService.kt
@@ -1,5 +1,6 @@
 package com.kotlinfoundation.koko.data.source.remote.apiservices.ai
 
+import com.kotlinfoundation.koko.common.BuildConfig
 import com.kotlinfoundation.koko.data.source.remote.request.ai.openai.OpenAiCreateChatRequest
 import com.kotlinfoundation.koko.data.source.remote.request.ai.openai.OpenAiCreateChatRequestBuilder
 import com.kotlinfoundation.koko.data.source.remote.request.ai.openai.OpenAiCreateImageRequest
@@ -7,12 +8,11 @@ import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseRespons
 import com.kotlinfoundation.koko.data.source.remote.response.ai.openai.OpenAiCreateChatResponse
 import com.kotlinfoundation.koko.data.source.remote.response.ai.openai.OpenAiCreateImageResponse
 import com.kotlinfoundation.koko.util.Constants
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
+import io.ktor.http.HttpMethod
 
-class OpenAiApiService(private val httpClient: HttpClient) {
+class OpenAiApiService(private val aiTransport: AiTransport) {
+
+    private fun directSpec(url: String) = AiDirectSpec(url = url, apiKey = BuildConfig.OPENAI_API_KEY)
 
     /**
      * Creates a chat completion using the OpenAI API.
@@ -43,9 +43,12 @@ class OpenAiApiService(private val httpClient: HttpClient) {
      * @param requestBody The request data for the chat completion.
      * @return The response from the OpenAI API as an [AiApiBaseResponse] containing [OpenAiCreateChatResponse].
      */
-    suspend fun createChat(requestBody: OpenAiCreateChatRequest): AiApiBaseResponse<OpenAiCreateChatResponse> = httpClient.post("${Constants.CLOUD_FUNCTIONS_URL}/openAiCreateTextCompletion") {
-        setBody(requestBody)
-    }.body()
+    suspend fun createChat(requestBody: OpenAiCreateChatRequest): AiApiBaseResponse<OpenAiCreateChatResponse> = aiTransport.execute(
+        method = HttpMethod.Post,
+        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/openAiCreateTextCompletion",
+        direct = directSpec("https://api.openai.com/v1/chat/completions"),
+        body = requestBody,
+    )
 
     /**
      * Creates an image using the OpenAI API with DALL-E.
@@ -53,7 +56,10 @@ class OpenAiApiService(private val httpClient: HttpClient) {
      * @param requestBody of [OpenAiCreateImageRequest] The request data for image generation.
      * @return The response from the OpenAI API as an [AiApiBaseResponse] containing [OpenAiCreateImageResponse].
      */
-    suspend fun createImage(requestBody: OpenAiCreateImageRequest): AiApiBaseResponse<OpenAiCreateImageResponse> = httpClient.post("${Constants.CLOUD_FUNCTIONS_URL}/openAiCreateImage") {
-        setBody(requestBody)
-    }.body()
+    suspend fun createImage(requestBody: OpenAiCreateImageRequest): AiApiBaseResponse<OpenAiCreateImageResponse> = aiTransport.execute(
+        method = HttpMethod.Post,
+        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/openAiCreateImage",
+        direct = directSpec("https://api.openai.com/v1/images/generations"),
+        body = requestBody,
+    )
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/ReplicateApiService.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/ReplicateApiService.kt
@@ -1,23 +1,25 @@
 package com.kotlinfoundation.koko.data.source.remote.apiservices.ai
 
+import com.kotlinfoundation.koko.common.BuildConfig
 import com.kotlinfoundation.koko.data.source.remote.request.ai.replicate.ReplicatePredictionRequest
 import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseResponse
 import com.kotlinfoundation.koko.data.source.remote.response.ai.replicate.ReplicatePredictionResponse
 import com.kotlinfoundation.koko.util.Constants
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.request.parameter
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.utils.io.core.Input
+import io.ktor.http.HttpMethod
 
 /**
  * A service class for interacting with the Replicate API.
  * You can check different models on Replicate from [here](https://replicate.com/explore).
  *
  */
-class ReplicateApiService(val httpClient: HttpClient) {
+class ReplicateApiService(val aiTransport: AiTransport) {
+
+    @PublishedApi
+    internal fun directSpec(url: String) = AiDirectSpec(
+        url = url,
+        apiKey = BuildConfig.REPLICATE_API_KEY,
+        extraHeaders = mapOf("Prefer" to "wait"),
+    )
 
     /**
      * Creates a prediction request for a specific model using the Replicate API.
@@ -54,11 +56,13 @@ class ReplicateApiService(val httpClient: HttpClient) {
         modelOwner: String,
         modelName: String,
         requestBody: ReplicatePredictionRequest<Input>,
-    ): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = httpClient.post("${Constants.CLOUD_FUNCTIONS_URL}/replicateCreateModelPrediction") {
-        parameter("model_owner", modelOwner)
-        parameter("model_name", modelName)
-        setBody(requestBody)
-    }.body()
+    ): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
+        method = HttpMethod.Post,
+        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/replicateCreateModelPrediction",
+        direct = directSpec("https://api.replicate.com/v1/models/$modelOwner/$modelName/predictions"),
+        proxyQueryParams = mapOf("model_owner" to modelOwner, "model_name" to modelName),
+        body = requestBody,
+    )
 
     /**
      * Creates a prediction request for non-official models, using the Replicate API, that has version
@@ -79,9 +83,12 @@ class ReplicateApiService(val httpClient: HttpClient) {
      * @param requestBody The body of the request, containing the model version and input parameters.
      * @return The response from the Replicate API as an [AiApiBaseResponse] containing [ReplicatePredictionResponse].
      */
-    suspend inline fun <reified Input> createPrediction(requestBody: ReplicatePredictionRequest<Input>): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = httpClient.post("${Constants.CLOUD_FUNCTIONS_URL}/replicateCreatePrediction") {
-        setBody(requestBody)
-    }.body()
+    suspend inline fun <reified Input> createPrediction(requestBody: ReplicatePredictionRequest<Input>): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
+        method = HttpMethod.Post,
+        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/replicateCreatePrediction",
+        direct = directSpec("https://api.replicate.com/v1/predictions"),
+        body = requestBody,
+    )
 
     /**
      * Retrieves the status of an existing prediction using the Replicate API.
@@ -97,9 +104,12 @@ class ReplicateApiService(val httpClient: HttpClient) {
      * )
      * ```
      */
-    suspend inline fun <reified Input> getPredictionStatus(id: String): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = httpClient.get("${Constants.CLOUD_FUNCTIONS_URL}/replicateGetPredictionStatus") {
-        parameter("id", id)
-    }.body()
+    suspend inline fun <reified Input> getPredictionStatus(id: String): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
+        method = HttpMethod.Get,
+        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/replicateGetPredictionStatus",
+        direct = directSpec("https://api.replicate.com/v1/predictions/$id"),
+        proxyQueryParams = mapOf("id" to id),
+    )
 
     /**
      * Cancels existing prediction
@@ -115,7 +125,10 @@ class ReplicateApiService(val httpClient: HttpClient) {
      * )
      * ```
      */
-    suspend inline fun <reified Input> cancelPrediction(id: String): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = httpClient.post("${Constants.CLOUD_FUNCTIONS_URL}/replicateCancelPrediction") {
-        parameter("id", id)
-    }.body()
+    suspend inline fun <reified Input> cancelPrediction(id: String): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
+        method = HttpMethod.Post,
+        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/replicateCancelPrediction",
+        direct = directSpec("https://api.replicate.com/v1/predictions/$id/cancel"),
+        proxyQueryParams = mapOf("id" to id),
+    )
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/Di.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/Di.kt
@@ -15,6 +15,7 @@ import com.kotlinfoundation.koko.data.source.preferences.UserPreferences
 import com.kotlinfoundation.koko.data.source.preferences.UserPreferencesImpl
 import com.kotlinfoundation.koko.data.source.remote.HttpClientFactory
 import com.kotlinfoundation.koko.data.source.remote.apiservices.ApiService
+import com.kotlinfoundation.koko.data.source.remote.apiservices.ai.AiTransport
 import com.kotlinfoundation.koko.data.source.remote.apiservices.ai.OpenAiApiService
 import com.kotlinfoundation.koko.data.source.remote.apiservices.ai.ReplicateApiService
 import com.kotlinfoundation.koko.domain.model.credit.creditSystemConfig
@@ -47,6 +48,7 @@ import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import kotlin.coroutines.CoroutineContext
@@ -75,9 +77,10 @@ private val dataModule = module {
 
     // Remote source
     single { HttpClientFactory.default(get()) }
-    factoryOf(::ApiService)
+    single(named("aiDirectClient")) { HttpClientFactory.direct() }
+    single { AiTransport(proxyClient = get(), directClient = get(named("aiDirectClient"))) }
 
-    // AI API services
+    factoryOf(::ApiService)
     factoryOf(::OpenAiApiService)
     factoryOf(::ReplicateApiService)
 

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
@@ -96,6 +96,19 @@ object Constants {
      */
     const val CLOUD_FUNCTIONS_URL = ""
 
+    /**
+     * How AI (OpenAI/Replicate) calls are routed.
+     *
+     * - `null` (AUTO, default): use the Cloud Functions proxy, unless [CLOUD_FUNCTIONS_URL] is blank AND a
+     *   provider key is set in `local.properties` — then call the provider directly from the device.
+     * - `true`: always use the proxy.
+     * - `false`: always call the provider directly.
+     *
+     * Keep the proxy for production so API keys stay in Secret Manager, never in the app binary. Direct
+     * mode is a no-Firebase prototyping shortcut (the key ships in the app) — see `integrate-web-proxy`.
+     */
+    val USE_AI_PROXY_SERVER: Boolean? = null
+
     const val LOCAL_DB_STORAGE_NAME = "local_storage.db"
 
     // DataStore requires the file name to end with ".preferences_pb"

--- a/skills/add-api-service/SKILL.md
+++ b/skills/add-api-service/SKILL.md
@@ -10,6 +10,14 @@ DTOs → API service → repository (`Result` wrapping) → ViewModel.
 
 Paths below are under `shared/src/commonMain/kotlin/com/kotlinfoundation/koko/`.
 
+> **AI services are special.** The OpenAI/Replicate services route through `AiTransport` (proxy vs direct
+> mode) rather than calling the client directly. In **proxy** mode the response is the
+> `{statusCode, errorMessage, data}` envelope (`AiApiBaseResponse<T>`); in **direct** mode the provider
+> returns its **raw body at the top level** and `AiTransport` re-wraps it into the same envelope — so the
+> DTOs (`T`) stay identical. If you add a new AI provider, mirror this: pass your `directUrl` + auth
+> headers + key-readiness to `AiTransport.execute`. Non-AI services just use the Ktor client directly, as
+> below.
+
 ## 1. DTOs — `data/source/remote/request/` and `data/source/remote/response/`
 
 `*Request` / `*Response` suffixes are required. All DTOs `@Serializable` + `@SerialName`. Response DTOs

--- a/skills/configure-environment/SKILL.md
+++ b/skills/configure-environment/SKILL.md
@@ -41,15 +41,21 @@ credentials, IDs, and toggles.
 | `ADMOB_INTERSTITIAL_AD_ID_IOS` | Interstitial ad unit (iOS) | AdMob console | monetization |
 | `ADMOB_REWARDED_AD_ID_IOS` | Rewarded ad unit (iOS) | AdMob console | monetization |
 | `IMGBB_TOKEN` | Image hosting/upload token | https://api.imgbb.com/ account | when using image upload |
+| `OPENAI_API_KEY` | Direct OpenAI calls (no proxy) | https://platform.openai.com/ | integrations (direct/dev — see note) |
+| `REPLICATE_API_KEY` | Direct Replicate calls (no proxy) | https://replicate.com/account/api-tokens | integrations (direct/dev — see note) |
 
 > **Subscription mock:** while the two subscription keys are unset, the app runs a built-in mock
 > provider so the paywall/purchase/unlock/cancel flow works with zero keys (a red "Demo paywall" banner
 > marks it). Setting a real key auto-switches to the real provider — see `setup-subscriptions`.
 
+> **Direct AI mode (prototyping):** `OPENAI_API_KEY` / `REPLICATE_API_KEY` in `local.properties` are used
+> only for the **direct** (no-Firebase) AI path — the app calls the provider straight from the device when
+> `Constants.CLOUD_FUNCTIONS_URL` is blank and a key is set (`Constants.USE_AI_PROXY_SERVER` overrides). The key
+> ships in the app binary, so this is prototyping only. In **production** the app calls the web-proxy and
+> the keys live in **Google Cloud Secret Manager**, not on device — see `integrate-web-proxy`.
+
 > The AdMob and `ADMOB_APP_ID_ANDROID` value is also consumed in `androidApp/build.gradle.kts`
-> (manifest placeholder). Production Cloud Functions read `OPENAI_API_KEY` / `REPLICATE_API_KEY`
-> from **Google Cloud Secret Manager**, not from `local.properties` — see the `integrate-web-proxy`
-> skill.
+> (manifest placeholder).
 
 Full template with placeholders, where-to-get URLs, and per-phase comments lives in the committed
 **`MobileApp/local.properties.example`** — copy it to `local.properties` and fill what you need:

--- a/skills/integrate-web-proxy/SKILL.md
+++ b/skills/integrate-web-proxy/SKILL.md
@@ -11,6 +11,16 @@ reads the real API key from **Google Cloud Secret Manager**, forwards the reques
 uniform envelope. Requires a Blaze-plan Firebase project (`setup-firebase`) and auth
 (`enable-auth` / anonymous).
 
+> **Prototyping shortcut — Direct AI mode (no Firebase).** To try AI generation *before* deploying this
+> proxy: put an `OPENAI_API_KEY` / `REPLICATE_API_KEY` in `local.properties` and leave
+> `Constants.CLOUD_FUNCTIONS_URL` blank. The app's `AiTransport` then calls the provider **directly** from
+> the device (auto-detected; `Constants.USE_AI_PROXY_SERVER` overrides — `true`=proxy, `false`=direct).
+> **Not for production** — the key is
+> compiled into the app binary. Deploy this proxy and clear those keys before shipping. Note: text→image
+> is fully Firebase-free; image-*editing* still uploads the reference image via `KMPStorage`/Firebase
+> Storage. Direct calls return the provider's raw JSON (no `{statusCode,errorMessage,data}` envelope) —
+> `AiTransport` adapts it, so the DTOs and generation providers are unchanged.
+
 ## What's in `Web/functions`
 
 - `index.js` — exports the enabled functions (`replicate*`, `openAi*`), gated by `AI_PROVIDERS`
@@ -35,7 +45,9 @@ Every function returns the same JSON shape (`utils/utils.js` → `sendApiRespons
 - `errorMessage` — non-null only on error (e.g. `403 "Missing Authorization header..."`).
 - `data` — the provider's raw response object on success.
 
-Model your response DTO on this envelope with a nested `data` payload.
+This envelope is already modeled as `AiApiBaseResponse<T>` (with `handleAsResult`) — reuse it; the
+provider payload is the nested `data: T`. (In direct mode the provider returns `T` at the top level and
+`AiTransport` re-wraps it into the same `AiApiBaseResponse<T>`, so nothing downstream changes.)
 
 ## Prerequisites
 
@@ -112,16 +124,26 @@ Point `CLOUD_FUNCTIONS_URL` at the emulator host while iterating, then switch ba
 
 ## 5. Call it from the app — Agent Action
 
-Follow the `add-api-service` skill to build the Ktor client end-to-end (request/response DTOs, API
-service, repository, ViewModel call). Two specifics for this backend:
+The OpenAI/Replicate calls are **already wired** — `OpenAiApiService` / `ReplicateApiService` route
+through `AiTransport`, and the proxy `HttpClient` (`HttpClientFactory.default`) attaches the Firebase ID
+token to every request automatically. So once `CLOUD_FUNCTIONS_URL` is set (and no direct key is set /
+`USE_AI_PROXY_SERVER` isn't forcing direct), the existing generation flow uses the proxy with **no code
+change**.
 
-- **Base URL** = `Constants.CLOUD_FUNCTIONS_URL`; the path is the function name
-  (e.g. `/openAiCreateTextCompletion`). Most endpoints are `POST`.
-- **Auth header** — attach the current Firebase ID token as
-  `Authorization: Bearer <token>` (the same token from the anonymous/social session). Without it,
-  auth-gated endpoints return `403` in `errorMessage`.
-- **Response** — parse the `{ statusCode, errorMessage, data }` envelope; on non-null `errorMessage`,
-  surface it as a failure in the repository's `Result`.
+To add a **new** endpoint:
+- **AI provider call** — add a method to the AI service that calls
+  `aiTransport.execute(method, proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/<functionName>", direct = directSpec("<providerUrl>"), proxyQueryParams = …, body = …)`.
+  `AiTransport` picks proxy vs direct and adapts the response — the DTOs and `handleAsResult` don't change.
+- **Other backend call** — follow `add-api-service` (Ktor service + DTOs + repository `Result`).
+
+Specifics for this backend:
+- **Base URL** = `Constants.CLOUD_FUNCTIONS_URL`; the path is the function **name**
+  (e.g. `/openAiCreateTextCompletion`). Most endpoints are `POST`; dynamic values go as **query params**
+  (the functions read `req.query`, not path segments).
+- **Auth** — the proxy client attaches `Authorization: Bearer <Firebase ID token>` automatically; you
+  don't set it per call. Auth-gated endpoints return `403` in `errorMessage` without a signed-in user.
+- **Response** — the `{ statusCode, errorMessage, data }` envelope is parsed by `AiApiBaseResponse` /
+  `handleAsResult`; a non-null `errorMessage` becomes a `Result` failure.
 
 ## 6. Validate — Validation
 

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -91,6 +91,9 @@ the SDK **credentials** early if they want them.
 ### 5. Deploy the web proxy + point the client at it — `integrate-web-proxy`
 - **Agent Action** — Read the `integrate-web-proxy` skill. Explain the `Web/functions` backend, the
   `{statusCode, errorMessage, data}` response shape, and the `requireAuth` Firebase-token gate.
+- **Prototyping shortcut** — to try AI *without* deploying the proxy, set `OPENAI_API_KEY`/`REPLICATE_API_KEY`
+  in `local.properties` and leave `CLOUD_FUNCTIONS_URL` blank → the app calls the provider directly
+  (key on device, prototyping only). See `integrate-web-proxy` for the caveats.
 - **User Action** — Set Secret Manager secrets `OPENAI_API_KEY` / `REPLICATE_API_KEY`
   (https://console.cloud.google.com/security/secret-manager), then from `Web/` run
   `firebase deploy --only functions`. Copy the printed base URL

--- a/skills/integrations/progress-template.md
+++ b/skills/integrations/progress-template.md
@@ -42,8 +42,8 @@
 - [ ] **[Agent]** Explain `Web/functions`, `{statusCode, errorMessage, data}` shape, `requireAuth`
 - [ ] **[User]** Set Secret Manager `OPENAI_API_KEY` / `REPLICATE_API_KEY`
 - [ ] **[User]** `firebase deploy --only functions` from `Web/`
-- [ ] **[User]** Paste base URL into `Constants.CLOUD_FUNCTIONS_URL`
-- [ ] **[Agent]** Wire a client (Ktor + Firebase Bearer token) per the `add-api-service` pattern
+- [ ] **[User]** Paste base URL into `Constants.CLOUD_FUNCTIONS_URL` → existing AI flow now uses the proxy (no code change; the proxy client attaches the Firebase token). Hand-wire only for a NEW endpoint.
+- [ ] **[Agent]** *(prototyping alt)* Skip the proxy: set `OPENAI_API_KEY`/`REPLICATE_API_KEY` in `local.properties`, leave `CLOUD_FUNCTIONS_URL` blank → direct provider calls (key on device — not for production)
 
 ## 6. Validation gate
 - [ ] **[Validate]** `./scripts/check_env.sh --phase integrations` — clean for the anonymous-only path once real Firebase config is in place

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: publishing
-description: Phase-3 guide for publishing the KMP contest starter kit / publish to Play Store and App Store — icons, release signing (keys moved into CI secrets), store metadata + screenshots, App Store Connect + Google Play Console app creation, and the first build submitted for review. Use when the developer wants to publish / ship / release the app to the stores, or prepare store listings and signing.
+description: Phase-3 guide for publishing the KMP contest starter kit / publish to Play Store and App Store — icons, release signing (keys moved into CI secrets), store metadata + screenshots, App Store Connect + Google Play Console app creation, and the first build submitted for review. Use when the developer wants to publish / ship / release the app to the stores, prepare store listings and signing, or asks "is my app ready to publish / release?" (run the Release readiness gate below).
 ---
 
 # Phase 3 — Publishing (ship to Google Play + App Store)
@@ -16,6 +16,37 @@ console / Xcode), or **Validation** (prove it works). Steps compose the atomic s
 the referenced skill before doing that step.
 
 Track progress in a copy of [`progress-template.md`](progress-template.md).
+
+## Release readiness gate — run this when asked "is my app ready to publish?"
+
+Don't answer from memory — **run the checks and report what's unmet**, then point at the step/skill that fixes each. Two parts:
+
+**A. Automated config check.** From `MobileApp/`:
+```bash
+./scripts/check_env.sh --phase publishing
+```
+Every `⚠️` must be resolved before release. It covers:
+- `Constants.URL_PRIVACY_POLICY` / `URL_TERMS_CONDITIONS` set to **live, reachable** pages (stores reject placeholders).
+- `Constants.CONTACT_EMAIL` is your own (not the `support@example.com` boilerplate).
+- **AI backend uses the proxy, not on-device keys** — flags `USE_AI_PROXY_SERVER=false`, or a blank
+  `CLOUD_FUNCTIONS_URL` with a direct `OPENAI_API_KEY`/`REPLICATE_API_KEY` (key would ship in the binary).
+  Production must deploy the web-proxy (`integrate-web-proxy`) and clear direct keys.
+- **Subscription keys are real, not the demo mock** — if you sell subscriptions/IAPs, set the real
+  Adapty/RevenueCat SDK keys (`setup-subscriptions`); otherwise the paywall runs the client-only mock.
+- `Constants.APPSTORE_APP_ID` (set once App Store Connect assigns it).
+
+**B. Human-only readiness (can't be auto-checked)** — confirm each, sending the developer to the step/skill:
+- Package / applicationId / bundle id + display name **locked** (`refactor-package`, step 1).
+- Final **app icons** generated (`generate-app-icons`, step 2).
+- **Release signing keys moved into CI secrets**, keystore backed up (`setup-signing`, step 4) — never in the app.
+- **Version** bumped for both platforms (`bump-version`, step 3).
+- **Store listings** created + metadata/graphics/data-safety/content-rating filled: App Store Connect
+  (`setup-appstore-connect`) and Google Play Console (`setup-google-play`), steps 7–8.
+- **Store screenshots** generated (`store-screenshots`, step 5).
+- `run-quality-gates` passes.
+
+The published docs mirror this: **`Documentation/docs/production/pre-publishing-checklist.md`**. If any item
+is unmet, walk the developer through the matching numbered step below.
 
 ## STOP rule (read verbatim)
 

--- a/skills/publishing/progress-template.md
+++ b/skills/publishing/progress-template.md
@@ -11,6 +11,12 @@
 >
 > *STOP RULE:* Stop at any unchecked **[User]** item and wait for confirmation before proceeding.
 
+## 0. Release readiness gate ("is my app ready to publish?")
+- [ ] **[Validate]** `./scripts/check_env.sh --phase publishing` — no `⚠️` (privacy/terms URLs, CONTACT_EMAIL, AI backend on the proxy not on-device keys, real subscription keys)
+- [ ] **[Validate]** AI uses the **web-proxy** in production — `CLOUD_FUNCTIONS_URL` set, no direct `OPENAI_API_KEY`/`REPLICATE_API_KEY` shipping, `USE_AI_PROXY_SERVER` not forced to direct
+- [ ] **[Validate]** Real subscription keys set (not the demo mock) if the app sells subscriptions/IAPs
+- [ ] **[Validate]** All items 1–10 below complete; `run-quality-gates` passes
+
 ## 1. Lock final app identity — `refactor-package`
 - [ ] **[Agent]** App id / bundle id / display name are final (`./scripts/refactor_package.sh …`, or already done)
 


### PR DESCRIPTION
Two related additions in the easy-first spirit: try AI generation with **zero Firebase**, and a real **"is my app ready to publish?"** gate that catches the prototyping shortcuts before release.

## Direct AI mode (feat)
Call OpenAI/Replicate **directly from the device** (key in `local.properties`) instead of the Cloud Functions proxy — no Firebase/backend needed to try AI.
- **`AiTransport`** routes each call to the proxy (default) or the provider (direct). In direct mode it re-wraps the raw provider JSON into the same `AiApiBaseResponse` envelope, so **DTOs, generation providers and `handleAsResult` are unchanged**. Provider-agnostic — each service passes an `AiDirectSpec(url, apiKey, extraHeaders)`; a new provider needs no `AiTransport` change.
- **Selection:** auto — direct when `CLOUD_FUNCTIONS_URL` is blank AND a provider key is set; `Constants.USE_AI_PROXY_SERVER` (`Boolean?`) overrides.
- **`HttpClientFactory.direct()`** — a second Ktor client with no Firebase interceptor; the provider bearer is set per request.
- New `OPENAI_API_KEY` / `REPLICATE_API_KEY` BuildConfig (default empty). **Prototyping only** — the key ships in the binary; production keeps the proxy (keys in Secret Manager).
- Text→image is fully Firebase-free; image-editing still hosts the input image via KMPStorage/Firebase Storage (ImgBB host swap = follow-up).

## Publishing readiness gate (feat)
So "is my app ready to publish?" is answered by checks, not memory.
- **`check_env.sh --phase publishing`** now also flags: AI running in **direct mode / shipping on-device keys** (should use the proxy), and **subscription keys still the demo mock**. (Already covered: privacy/terms URLs, boilerplate contact email, APPSTORE_APP_ID.)
- **`publishing` skill** — a *Release readiness gate* (run check_env + a human-only checklist, each item pointing at its step/skill) and a description trigger for *"is my app ready to publish/release?"*.
- **`publishing` progress-template** — a `0. Release readiness gate` block.

## Docs / skills
- `integrate-web-proxy` rewritten where stale (the AI services already route through `AiTransport`; the proxy client attaches the Firebase token automatically), `add-api-service`, `configure-environment`, `integrations`, AGENTS/CLAUDE.
- Documentation submodule bumped: direct-mode section in AI Integration + AI-proxy item in the pre-publishing checklist ([KAppMaker-Docs#15](https://github.com/KAppMaker/KAppMaker-Docs/pull/15)).

## Verification
`./gradlew spotlessCheck :shared:jvmTest :shared:testAndroidHostTest :androidApp:assembleDebug` — all green. Manual: with `OPENAI_API_KEY` set + blank `CLOUD_FUNCTIONS_URL`, network logs show calls to `api.openai.com` with the provider bearer (no Firebase token); `check_env --phase publishing` flags it as a release risk.