### PR TITLE
Extract per-app config into root/AppConfiguration (refactor)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,14 +176,14 @@ interface JobApiService {
 `AiTransport` (`data/source/remote/apiservices/ai/AiTransport.kt`) instead of hitting the Ktor client
 directly. It picks between two backends and adapts the response so the DTOs + `AiGenerationProvider`s +
 `AiApiBaseResponse.handleAsResult` never change:
-- **Proxy (production, default):** call `${Constants.CLOUD_FUNCTIONS_URL}/…` via the Firebase-interceptor
+- **Proxy (production, default):** call `${AppConfiguration.CLOUD_FUNCTIONS_URL}/…` via the Firebase-interceptor
   client; the body already is the `{statusCode, errorMessage, data}` envelope.
 - **Direct (prototyping):** call the provider URL (`api.openai.com` / `api.replicate.com`) via a second
   client with **no** Firebase interceptor, sending `Authorization: Bearer <OPENAI_API_KEY|REPLICATE_API_KEY>`
   (from `BuildConfig`/`local.properties`) + Replicate's `Prefer: wait`. The raw provider JSON is re-wrapped
   into a synthetic `AiApiBaseResponse`.
-- **Selection:** auto — direct when `Constants.CLOUD_FUNCTIONS_URL` is blank AND the provider key is set;
-  `Constants.USE_AI_PROXY_SERVER` (`Boolean?`; `true`=proxy, `false`=direct, `null`=auto) overrides.
+- **Selection:** auto — direct when `AppConfiguration.CLOUD_FUNCTIONS_URL` is blank AND the provider key is set;
+  `AppConfiguration.USE_AI_PROXY_SERVER` (`Boolean?`; `true`=proxy, `false`=direct, `null`=auto) overrides.
   Prototyping only — direct-mode keys ship in the app
   binary; production keeps the proxy (keys in Secret Manager). `AiTransport` is **provider-agnostic**: each
   service supplies its own `directUrl` + headers + key-readiness, so a new provider needs no `AiTransport`
@@ -273,6 +273,9 @@ sealed interface HomeUiEvent {
   - `factoryOf()` / `viewModelOf()` → ViewModels, validators, screen-scoped services
   - `bind` → only when multiple implementations exist
 - Initialization: `root/AppInitializer.kt` is the bootstrap — `startKoin { … modules(appModules) … }` (loaded from `Di.kt`) plus one-time startup side effects (logging, analytics, notifications, billing, ads, anonymous sign-in). Each platform entry point calls `AppInitializer.initialize { }` once.
+
+### App configuration
+Per-app compile-time config lives in **`root/AppConfiguration.kt`** (`object AppConfiguration`) — the toggles/values a developer sets when spinning up an app: `CLOUD_FUNCTIONS_URL`, `USE_AI_PROXY_SERVER`, `AUTH_SOCIAL_LOGIN_ENABLED`, legal URLs, `CONTACT_EMAIL`, `APPSTORE_APP_ID`, and the `subscriptionProviderFactory` / `authServiceProviderFactory` selectors. Distinct from **`util/Constants.kt`** (framework detail — paywall entitlement/placement ids, `CREDIT_PACK_PRODUCT_ID_PREFIX`, DB/prefs file names) and from **`FeatureFlagManager`** (runtime, Firebase Remote Config). `scripts/check_env.sh` reads `AppConfiguration.kt` for the URLs/AI/auth values it verifies.
 
 ### Coroutines
 - `backgroundScope`: `CoroutineScope(SupervisorJob() + Dispatchers.IO)` for repo/data work
@@ -420,11 +423,11 @@ Two interchangeable billing backends live under `libs/subscription/` behind the
 - **One switch, one place.** The provider is chosen by the `SUBSCRIPTION_PROVIDER`
   gradle property in `gradle.properties` (`ADAPTY` default, or `REVENUECAT`). That
   property both (a) selects which module `shared/build.gradle.kts` puts on the classpath
-  and (b) drives `Constants.subscriptionProviderFactory`, which delegates to
+  and (b) drives `AppConfiguration.subscriptionProviderFactory`, which delegates to
   `activeSubscriptionProviderFactory` — a single symbol each provider module exposes in
   package `com.kotlinfoundation.koko.subscription.config`. Exactly one provider module is ever
-  linked, so `Constants` never names a concrete provider. **Do not hardcode a provider in
-  `Constants`.**
+  linked, so `AppConfiguration` never names a concrete provider. **Do not hardcode a provider in
+  `AppConfiguration`.**
 - Switching providers = change the gradle property only (plus the provider's API keys in
   `local.properties`). Both `ADAPTY` and `REVENUECAT` builds must compile.
 - **Mock provider (zero-config demo).** When the active-platform subscription SDK key is still a

--- a/MobileApp/scripts/check_env.sh
+++ b/MobileApp/scripts/check_env.sh
@@ -5,7 +5,7 @@
 # The build deliberately does NOT fail on missing keys (getRequiredProperty substitutes "testValue"
 # so the local app keeps building fast). That means a missing cloud key is invisible to an agent
 # driving the build. This script makes it VISIBLE: it reads local.properties + gradle.properties +
-# the relevant Constants.kt / FeatureFlagManager.kt flags and reports, per phase, which required keys
+# the relevant AppConfiguration.kt / FeatureFlagManager.kt flags and reports, per phase, which required keys
 # are still placeholders — so the agent knows to stop and ask the developer.
 #
 # Usage (run from MobileApp/):
@@ -30,7 +30,8 @@ MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 LOCAL_PROPS="$MOBILE_DIR/local.properties"
 GRADLE_PROPS="$MOBILE_DIR/gradle.properties"
-CONSTANTS="$MOBILE_DIR/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt"
+# Per-app config (URLs, contact, AI routing, auth toggle) lives in root/AppConfiguration.kt.
+APP_CONFIG="$MOBILE_DIR/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/AppConfiguration.kt"
 FEATURE_FLAGS="$MOBILE_DIR/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/featureflag/FeatureFlagManager.kt"
 GOOGLE_SERVICES="$MOBILE_DIR/androidApp/google-services.json"
 GOOGLE_PLIST="$MOBILE_DIR/iosApp/iosApp/GoogleService-Info.plist"
@@ -70,18 +71,18 @@ is_placeholder() {
   [ -z "$v" ] || [ "$v" = "testValue" ]
 }
 
-# Read a `const val NAME = "..."` string literal from Constants.kt.
+# Read a `const val NAME = "..."` string literal from AppConfiguration.kt.
 const_string() {
   local name="$1"
-  [ -f "$CONSTANTS" ] || return 0
-  grep -E "val[[:space:]]+$name[[:space:]]*=" "$CONSTANTS" | tail -1 | sed -E 's/.*=[[:space:]]*"([^"]*)".*/\1/' || true
+  [ -f "$APP_CONFIG" ] || return 0
+  grep -E "val[[:space:]]+$name[[:space:]]*=" "$APP_CONFIG" | tail -1 | sed -E 's/.*=[[:space:]]*"([^"]*)".*/\1/' || true
 }
 
-# Read a `const val NAME = true|false` boolean from Constants.kt.
+# Read a `const val NAME = true|false` boolean from AppConfiguration.kt.
 const_bool() {
   local name="$1"
-  [ -f "$CONSTANTS" ] || { echo "false"; return 0; }
-  grep -E "val[[:space:]]+$name[[:space:]]*=" "$CONSTANTS" | tail -1 | grep -qE '=[[:space:]]*true' && echo "true" || echo "false"
+  [ -f "$APP_CONFIG" ] || { echo "false"; return 0; }
+  grep -E "val[[:space:]]+$name[[:space:]]*=" "$APP_CONFIG" | tail -1 | grep -qE '=[[:space:]]*true' && echo "true" || echo "false"
 }
 
 # Read a FeatureFlagManager DEFAULT_VALUES boolean (e.g. Keys.IS_ADS_ENABLED to true).
@@ -91,11 +92,11 @@ flag_default_bool() {
   grep -E "Keys\.$key[[:space:]]+to[[:space:]]+" "$FEATURE_FLAGS" | tail -1 | grep -qE 'to[[:space:]]+true' && echo "true" || echo "false"
 }
 
-# Read a nullable Boolean const from Constants.kt → prints "true" | "false" | "null".
+# Read a nullable Boolean const from AppConfiguration.kt → prints "true" | "false" | "null".
 const_tristate() {
   local name="$1" line
-  [ -f "$CONSTANTS" ] || { echo "null"; return 0; }
-  line="$(grep -E "val[[:space:]]+$name\b" "$CONSTANTS" | tail -1)"
+  [ -f "$APP_CONFIG" ] || { echo "null"; return 0; }
+  line="$(grep -E "val[[:space:]]+$name\b" "$APP_CONFIG" | tail -1)"
   echo "$line" | grep -qE '=[[:space:]]*true' && { echo "true"; return 0; }
   echo "$line" | grep -qE '=[[:space:]]*false' && { echo "false"; return 0; }
   echo "null"
@@ -179,7 +180,7 @@ if phase_active integrations; then
   fi
   # AI web-proxy — optional unless you use it.
   if [ -z "$CLOUD_URL" ]; then
-    row optional "CLOUD_FUNCTIONS_URL" "not set" "only if you use the AI web-proxy; set in Constants.kt after 'firebase deploy' (integrate-web-proxy)"
+    row optional "CLOUD_FUNCTIONS_URL" "not set" "only if you use the AI web-proxy; set in AppConfiguration.kt after 'firebase deploy' (integrate-web-proxy)"
   else
     row ok "CLOUD_FUNCTIONS_URL" "set"
   fi
@@ -192,22 +193,22 @@ fi
 # ============================================================================ P3 publishing
 if phase_active publishing; then
   echo "[P3] publishing"
-  if [ -z "$PRIVACY_URL" ]; then row required "Constants.URL_PRIVACY_POLICY" "empty" "publish a privacy policy URL and set it in Constants.kt"; else row ok "Constants.URL_PRIVACY_POLICY" "set"; fi
-  if [ -z "$TERMS_URL" ]; then row required "Constants.URL_TERMS_CONDITIONS" "empty" "publish a terms URL and set it in Constants.kt"; else row ok "Constants.URL_TERMS_CONDITIONS" "set"; fi
+  if [ -z "$PRIVACY_URL" ]; then row required "AppConfiguration.URL_PRIVACY_POLICY" "empty" "publish a privacy policy URL and set it in AppConfiguration.kt"; else row ok "AppConfiguration.URL_PRIVACY_POLICY" "set"; fi
+  if [ -z "$TERMS_URL" ]; then row required "AppConfiguration.URL_TERMS_CONDITIONS" "empty" "publish a terms URL and set it in AppConfiguration.kt"; else row ok "AppConfiguration.URL_TERMS_CONDITIONS" "set"; fi
   # CONTACT_EMAIL ships as the boilerplate support@example.com — flag until it's your own.
   if [ -z "$CONTACT_EMAIL" ] || [ "$CONTACT_EMAIL" = "support@example.com" ]; then
-    row required "Constants.CONTACT_EMAIL" "boilerplate/empty" "set your own support email in Constants.kt (still $CONTACT_EMAIL)"
-  else row ok "Constants.CONTACT_EMAIL" "set"; fi
+    row required "AppConfiguration.CONTACT_EMAIL" "boilerplate/empty" "set your own support email in AppConfiguration.kt (still $CONTACT_EMAIL)"
+  else row ok "AppConfiguration.CONTACT_EMAIL" "set"; fi
   # APPSTORE_APP_ID is assigned by App Store Connect — only knowable once the iOS app record exists.
   if [ -z "$APPSTORE_ID" ]; then
-    row optional "Constants.APPSTORE_APP_ID" "not set" "numeric App Store id for rate/review + manage-subscription deep links; set it after App Store Connect creates the app"
-  else row ok "Constants.APPSTORE_APP_ID" "set"; fi
+    row optional "AppConfiguration.APPSTORE_APP_ID" "not set" "numeric App Store id for rate/review + manage-subscription deep links; set it after App Store Connect creates the app"
+  else row ok "AppConfiguration.APPSTORE_APP_ID" "set"; fi
 
   # AI backend — production must use the Firebase proxy so provider keys aren't compiled into the binary.
   ai_direct_key_set=false
   { key_is_set "$OPENAI_KEY" || key_is_set "$REPLICATE_KEY"; } && ai_direct_key_set=true
   if [ "$USE_AI_PROXY" = "false" ]; then
-    row required "AI backend" "forced DIRECT" "Constants.USE_AI_PROXY_SERVER=false ships the API key in the app — set it to null/true and use the web-proxy for production (integrate-web-proxy)"
+    row required "AI backend" "forced DIRECT" "AppConfiguration.USE_AI_PROXY_SERVER=false ships the API key in the app — set it to null/true and use the web-proxy for production (integrate-web-proxy)"
   elif [ -z "$CLOUD_URL" ] && [ "$ai_direct_key_set" = true ]; then
     row required "AI backend" "DIRECT (key on device)" "no CLOUD_FUNCTIONS_URL + a direct key set → providers are called directly with the key in the binary. Deploy the proxy + set CLOUD_FUNCTIONS_URL"
   elif [ "$ai_direct_key_set" = true ]; then

--- a/MobileApp/shared/src/androidMain/kotlin/com/kotlinfoundation/koko/util/AppUtilImpl.android.kt
+++ b/MobileApp/shared/src/androidMain/kotlin/com/kotlinfoundation/koko/util/AppUtilImpl.android.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.core.content.pm.PackageInfoCompat
+import com.kotlinfoundation.koko.root.AppConfiguration
 import com.kotlinfoundation.koko.util.logging.AppLogger
 
 class AppUtilImpl(private val context: Context) : AppUtil {
@@ -35,10 +36,10 @@ class AppUtilImpl(private val context: Context) : AppUtil {
             val appName = getAppName()
             val subject = "$appName Feedback/Bug Report"
             val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
-                putExtra(Intent.EXTRA_EMAIL, arrayOf(Constants.CONTACT_EMAIL))
+                putExtra(Intent.EXTRA_EMAIL, arrayOf(AppConfiguration.CONTACT_EMAIL))
                 putExtra(Intent.EXTRA_SUBJECT, subject)
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                data = Uri.parse("mailto:${Constants.CONTACT_EMAIL}?subject=${Uri.encode(subject)}")
+                data = Uri.parse("mailto:${AppConfiguration.CONTACT_EMAIL}?subject=${Uri.encode(subject)}")
             }
             context.startActivity(emailIntent)
         } catch (e: ActivityNotFoundException) {

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/AiTransport.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/AiTransport.kt
@@ -1,7 +1,7 @@
 package com.kotlinfoundation.koko.data.source.remote.apiservices.ai
 
 import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseResponse
-import com.kotlinfoundation.koko.util.Constants
+import com.kotlinfoundation.koko.root.AppConfiguration
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.header
@@ -48,8 +48,8 @@ class AiDirectSpec(
  * is the raw provider object — which is exactly what `data` holds — so we parse the body as `T` and wrap
  * it in a synthetic [AiApiBaseResponse]. Same `T`, same downstream code.
  *
- * DIRECT is auto-selected when [Constants.CLOUD_FUNCTIONS_URL] is blank AND the provider key is set
- * ([AiDirectSpec.apiKey] set); [Constants.USE_AI_PROXY_SERVER] overrides. Prototyping only — the key ships in the binary.
+ * DIRECT is auto-selected when [AppConfiguration.CLOUD_FUNCTIONS_URL] is blank AND the provider key is set
+ * ([AiDirectSpec.apiKey] set); [AppConfiguration.USE_AI_PROXY_SERVER] overrides. Prototyping only — the key ships in the binary.
  */
 class AiTransport(
     @PublishedApi internal val proxyClient: HttpClient, // carries the Firebase bearer-token interceptor
@@ -112,8 +112,8 @@ class AiTransport(
 
     @PublishedApi
     internal fun resolveMode(hasAiApiKey: Boolean): AiMode {
-        Constants.USE_AI_PROXY_SERVER?.let { return if (it) AiMode.PROXY else AiMode.DIRECT }
-        return if (Constants.CLOUD_FUNCTIONS_URL.isBlank() && hasAiApiKey) AiMode.DIRECT else AiMode.PROXY
+        AppConfiguration.USE_AI_PROXY_SERVER?.let { return if (it) AiMode.PROXY else AiMode.DIRECT }
+        return if (AppConfiguration.CLOUD_FUNCTIONS_URL.isBlank() && hasAiApiKey) AiMode.DIRECT else AiMode.PROXY
     }
 
     /**

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/OpenAiApiService.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/OpenAiApiService.kt
@@ -7,7 +7,7 @@ import com.kotlinfoundation.koko.data.source.remote.request.ai.openai.OpenAiCrea
 import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseResponse
 import com.kotlinfoundation.koko.data.source.remote.response.ai.openai.OpenAiCreateChatResponse
 import com.kotlinfoundation.koko.data.source.remote.response.ai.openai.OpenAiCreateImageResponse
-import com.kotlinfoundation.koko.util.Constants
+import com.kotlinfoundation.koko.root.AppConfiguration
 import io.ktor.http.HttpMethod
 
 class OpenAiApiService(private val aiTransport: AiTransport) {
@@ -45,7 +45,7 @@ class OpenAiApiService(private val aiTransport: AiTransport) {
      */
     suspend fun createChat(requestBody: OpenAiCreateChatRequest): AiApiBaseResponse<OpenAiCreateChatResponse> = aiTransport.execute(
         method = HttpMethod.Post,
-        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/openAiCreateTextCompletion",
+        proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/openAiCreateTextCompletion",
         direct = directSpec("https://api.openai.com/v1/chat/completions"),
         body = requestBody,
     )
@@ -58,7 +58,7 @@ class OpenAiApiService(private val aiTransport: AiTransport) {
      */
     suspend fun createImage(requestBody: OpenAiCreateImageRequest): AiApiBaseResponse<OpenAiCreateImageResponse> = aiTransport.execute(
         method = HttpMethod.Post,
-        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/openAiCreateImage",
+        proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/openAiCreateImage",
         direct = directSpec("https://api.openai.com/v1/images/generations"),
         body = requestBody,
     )

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/ReplicateApiService.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/ReplicateApiService.kt
@@ -4,7 +4,7 @@ import com.kotlinfoundation.koko.common.BuildConfig
 import com.kotlinfoundation.koko.data.source.remote.request.ai.replicate.ReplicatePredictionRequest
 import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseResponse
 import com.kotlinfoundation.koko.data.source.remote.response.ai.replicate.ReplicatePredictionResponse
-import com.kotlinfoundation.koko.util.Constants
+import com.kotlinfoundation.koko.root.AppConfiguration
 import io.ktor.http.HttpMethod
 
 /**
@@ -58,7 +58,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
         requestBody: ReplicatePredictionRequest<Input>,
     ): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
         method = HttpMethod.Post,
-        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/replicateCreateModelPrediction",
+        proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCreateModelPrediction",
         direct = directSpec("https://api.replicate.com/v1/models/$modelOwner/$modelName/predictions"),
         proxyQueryParams = mapOf("model_owner" to modelOwner, "model_name" to modelName),
         body = requestBody,
@@ -85,7 +85,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
      */
     suspend inline fun <reified Input> createPrediction(requestBody: ReplicatePredictionRequest<Input>): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
         method = HttpMethod.Post,
-        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/replicateCreatePrediction",
+        proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCreatePrediction",
         direct = directSpec("https://api.replicate.com/v1/predictions"),
         body = requestBody,
     )
@@ -106,7 +106,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
      */
     suspend inline fun <reified Input> getPredictionStatus(id: String): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
         method = HttpMethod.Get,
-        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/replicateGetPredictionStatus",
+        proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateGetPredictionStatus",
         direct = directSpec("https://api.replicate.com/v1/predictions/$id"),
         proxyQueryParams = mapOf("id" to id),
     )
@@ -127,7 +127,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
      */
     suspend inline fun <reified Input> cancelPrediction(id: String): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
         method = HttpMethod.Post,
-        proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/replicateCancelPrediction",
+        proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCancelPrediction",
         direct = directSpec("https://api.replicate.com/v1/predictions/$id/cancel"),
         proxyQueryParams = mapOf("id" to id),
     )

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/account/AccountScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/account/AccountScreen.kt
@@ -48,8 +48,8 @@ import com.kotlinfoundation.koko.generated.resources.help_and_support
 import com.kotlinfoundation.koko.generated.resources.subscriptions
 import com.kotlinfoundation.koko.generated.resources.title_screen_account
 import com.kotlinfoundation.koko.generated.resources.title_sign_in
+import com.kotlinfoundation.koko.root.AppConfiguration
 import com.kotlinfoundation.koko.root.AppGlobalUiState
-import com.kotlinfoundation.koko.util.Constants
 import com.kotlinfoundation.koko.util.UiMessage
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -126,7 +126,7 @@ fun AccountScreen(
                 )
             }
 
-            if (Constants.AUTH_SOCIAL_LOGIN_ENABLED || uiState.user?.id?.isNotEmpty() == true) {
+            if (AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED || uiState.user?.id?.isNotEmpty() == true) {
                 ProfileInfoBox(user = uiState.user, onClick = {
                     if (uiState.user == null) {
                         onUiEvent(AccountUiEvent.OnClickSignIn)
@@ -149,7 +149,7 @@ private fun ProfileInfoBox(user: User?, onClick: () -> Unit) {
     AppCardContainer(
         modifier = Modifier.fillMaxWidth(),
         onClick = {
-            if (Constants.AUTH_SOCIAL_LOGIN_ENABLED) {
+            if (AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED) {
                 onClick()
             } else {
                 user?.id?.let {
@@ -164,7 +164,7 @@ private fun ProfileInfoBox(user: User?, onClick: () -> Unit) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(AppTheme.spacing.horizontalItemSpacing),
         ) {
-            if (Constants.AUTH_SOCIAL_LOGIN_ENABLED) {
+            if (AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED) {
                 AsyncImage(
                     model = ImageRequest.Builder(LocalPlatformContext.current)
                         .data(user?.photoUrl)

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/account/AccountViewModel.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/account/AccountViewModel.kt
@@ -14,7 +14,7 @@ import com.kotlinfoundation.koko.generated.resources.Res
 import com.kotlinfoundation.koko.generated.resources.help_and_support
 import com.kotlinfoundation.koko.generated.resources.logout
 import com.kotlinfoundation.koko.generated.resources.subscriptions
-import com.kotlinfoundation.koko.util.Constants
+import com.kotlinfoundation.koko.root.AppConfiguration
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.StateFlow
@@ -45,7 +45,7 @@ class AccountViewModel(
     private fun settingsItemsFor(isSignedIn: Boolean): List<SettingsItemUiState> = buildList {
         add(subscriptionsItem)
         add(supportItem)
-        if (Constants.AUTH_SOCIAL_LOGIN_ENABLED && isSignedIn) add(logoutItem)
+        if (AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED && isSignedIn) add(logoutItem)
     }
 
     private val _uiState = MutableStateFlow(AccountUiState())
@@ -57,7 +57,7 @@ class AccountViewModel(
         ) { currentUser, currentSubscription, uiState ->
             val user = currentUser.getOrNull()
             uiState.copy(
-                user = if (user?.isAnonymous == true && Constants.AUTH_SOCIAL_LOGIN_ENABLED) null else user,
+                user = if (user?.isAnonymous == true && AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED) null else user,
                 settingsItemList = settingsItemsFor(isSignedIn = user != null),
                 showUpgradePremiumBanner = currentSubscription.isFree,
             )

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/helpandsupport/HelpAndSupportScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/helpandsupport/HelpAndSupportScreen.kt
@@ -17,8 +17,8 @@ import com.kotlinfoundation.koko.designsystem.theme.AppTheme
 import com.kotlinfoundation.koko.generated.resources.Res
 import com.kotlinfoundation.koko.generated.resources.help_and_support
 import com.kotlinfoundation.koko.generated.resources.item_contact_support
+import com.kotlinfoundation.koko.root.AppConfiguration
 import com.kotlinfoundation.koko.util.AppUtil
-import com.kotlinfoundation.koko.util.Constants
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
@@ -52,11 +52,11 @@ fun HelpAndSupportScreen(
                     }
 
                     UiRes.string.privacy_policy -> {
-                        localUriHandler.openUri(Constants.URL_PRIVACY_POLICY)
+                        localUriHandler.openUri(AppConfiguration.URL_PRIVACY_POLICY)
                     }
 
                     UiRes.string.terms_conditions -> {
-                        localUriHandler.openUri(Constants.URL_TERMS_CONDITIONS)
+                        localUriHandler.openUri(AppConfiguration.URL_TERMS_CONDITIONS)
                     }
                 }
             },

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/creditpack/CreditPackPaywallScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/creditpack/CreditPackPaywallScreen.kt
@@ -48,8 +48,8 @@ import com.kotlinfoundation.koko.presentation.screens.paywall.PaywallPackageUiSt
 import com.kotlinfoundation.koko.presentation.screens.paywall.PaywallPreviewData
 import com.kotlinfoundation.koko.presentation.screens.paywall.PaywallUiEvent
 import com.kotlinfoundation.koko.presentation.screens.paywall.PaywallUiState
+import com.kotlinfoundation.koko.root.AppConfiguration
 import com.kotlinfoundation.koko.subscription.api.PurchasePackageId
-import com.kotlinfoundation.koko.util.Constants
 import com.kotlinfoundation.koko.util.StoreDevice
 import com.kotlinfoundation.koko.util.StoreScreenshot
 import org.jetbrains.compose.resources.painterResource
@@ -289,7 +289,7 @@ internal fun FooterLinksRow() {
         FooterLink(
             text = stringResource(Res.string.paywall_footer_privacy),
             onClick = {
-                if (Constants.URL_PRIVACY_POLICY.isNotEmpty()) uriHandler.openUri(Constants.URL_PRIVACY_POLICY)
+                if (AppConfiguration.URL_PRIVACY_POLICY.isNotEmpty()) uriHandler.openUri(AppConfiguration.URL_PRIVACY_POLICY)
             },
         )
         Text(
@@ -301,7 +301,7 @@ internal fun FooterLinksRow() {
         FooterLink(
             text = stringResource(Res.string.paywall_footer_terms),
             onClick = {
-                if (Constants.URL_TERMS_CONDITIONS.isNotEmpty()) uriHandler.openUri(Constants.URL_TERMS_CONDITIONS)
+                if (AppConfiguration.URL_TERMS_CONDITIONS.isNotEmpty()) uriHandler.openUri(AppConfiguration.URL_TERMS_CONDITIONS)
             },
         )
     }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/signin/SignInScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/signin/SignInScreen.kt
@@ -53,8 +53,8 @@ import com.kotlinfoundation.koko.generated.resources.title_sign_in
 import com.kotlinfoundation.koko.generated.resources.title_sign_up
 import com.kotlinfoundation.koko.generated.resources.txt_main_action_to_sign_in
 import com.kotlinfoundation.koko.presentation.components.AuthUIHelperButtons
+import com.kotlinfoundation.koko.root.AppConfiguration
 import com.kotlinfoundation.koko.root.AppGlobalUiState
-import com.kotlinfoundation.koko.util.Constants
 import com.kotlinfoundation.koko.util.UiMessage
 import com.kotlinfoundation.koko.util.logging.AppLogger
 import kotlinx.coroutines.launch
@@ -103,7 +103,7 @@ fun SignInScreen(
             )
 
             // Google/Apple buttons only when social login is enabled; otherwise anonymous-only.
-            if (Constants.AUTH_SOCIAL_LOGIN_ENABLED) {
+            if (AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED) {
                 AuthUIHelperButtons(
                     linkAccount = signInMode.not(),
                     modifier = Modifier.padding(top = AppTheme.spacing.largeSpacing).fillMaxWidth(),
@@ -161,8 +161,8 @@ fun SignInScreen(
 
             AgreePrivacyPolicyTermsConditionsText(
                 modifier = Modifier.padding(top = AppTheme.spacing.largeSpacing).fillMaxWidth(),
-                privacyPolicyUrl = Constants.URL_PRIVACY_POLICY,
-                termsConditionsUrl = Constants.URL_TERMS_CONDITIONS,
+                privacyPolicyUrl = AppConfiguration.URL_PRIVACY_POLICY,
+                termsConditionsUrl = AppConfiguration.URL_TERMS_CONDITIONS,
             )
         }
     }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/AppConfiguration.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/AppConfiguration.kt
@@ -1,0 +1,70 @@
+package com.kotlinfoundation.koko.root
+
+import com.kotlinfoundation.koko.auth.api.AuthServiceProviderFactory
+import com.kotlinfoundation.koko.auth.firebase.Firebase
+import com.kotlinfoundation.koko.subscription.config.activeSubscriptionProviderFactory
+
+/**
+ * Per-app configuration a developer sets/flips when spinning up an app on this kit — behavioral toggles,
+ * backend URLs, contact/legal info, and the auth/subscription provider selectors.
+ *
+ * Compile-time (baked into the binary). This is distinct from:
+ * - `Constants` — framework details unlikely to change per app (DB/prefs file names, paywall
+ *   entitlement/placement ids, product-id conventions).
+ * - `FeatureFlagManager` — runtime flags controllable remotely via Firebase Remote Config.
+ */
+object AppConfiguration {
+    const val URL_PRIVACY_POLICY = ""
+    const val URL_TERMS_CONDITIONS = ""
+    const val CONTACT_EMAIL = "support@example.com"
+    const val APPSTORE_APP_ID = ""
+
+    // Enables Apple and Google sign-in. If false, only anonymous login is supported.
+    // Default false — anonymous auth is the easiest path to a working app (just Firebase +
+    // Anonymous sign-in). Flip to true to add Google/Apple (see the enable-auth skill for the
+    // extra config: GOOGLE_WEB_CLIENT_ID, iOS Info.plist client IDs, Sign In with Apple capability).
+    const val AUTH_SOCIAL_LOGIN_ENABLED = false
+
+    /**
+     * CLOUD_FUNCTIONS_URL should be something like: "https://REGION-PROJECT_ID.cloudfunctions.net"
+     * Regions:
+     * US(Default): us-central1
+     * EU: europe-west1
+     *
+     * This is used AI proxy functions such as OpenAi, Replicate
+     */
+    const val CLOUD_FUNCTIONS_URL = ""
+
+    /**
+     * How AI (OpenAI/Replicate) calls are routed.
+     *
+     * - `null` (AUTO, default): use the Cloud Functions proxy, unless [CLOUD_FUNCTIONS_URL] is blank AND a
+     *   provider key is set in `local.properties` — then call the provider directly from the device.
+     * - `true`: always use the proxy.
+     * - `false`: always call the provider directly.
+     *
+     * Keep the proxy for production so API keys stay in Secret Manager, never in the app binary. Direct
+     * mode is a no-Firebase prototyping shortcut (the key ships in the app) — see `integrate-web-proxy`.
+     */
+    val USE_AI_PROXY_SERVER: Boolean? = null
+
+    /**
+     * The subscription provider is chosen in ONE place — the `SUBSCRIPTION_PROVIDER`
+     * Gradle property in `gradle.properties` (default: `ADAPTY`):
+     *
+     *   SUBSCRIPTION_PROVIDER=ADAPTY
+     *   or
+     *   SUBSCRIPTION_PROVIDER=REVENUECAT
+     *
+     *   Also in local.properties add the following:
+     *
+     *   SUBSCRIPTION_PROVIDER_ANDROID_API_KEY=YOUR_API_KEY
+     *   SUBSCRIPTION_PROVIDER_IOS_API_KEY=YOUR_API_KEY
+     *
+     * That property decides which provider module is on the classpath; this accessor
+     * resolves to whichever one is linked. Do NOT name a concrete provider here.
+     */
+    val subscriptionProviderFactory get() = activeSubscriptionProviderFactory
+
+    val authServiceProviderFactory get() = AuthServiceProviderFactory.Firebase
+}

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/Di.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/Di.kt
@@ -85,13 +85,13 @@ private val dataModule = module {
     factoryOf(::ReplicateApiService)
 
     // Auth provider
-    factory { Constants.authServiceProviderFactory } bind AuthServiceProviderFactory::class
+    factory { AppConfiguration.authServiceProviderFactory } bind AuthServiceProviderFactory::class
     single { get<AuthServiceProviderFactory>().create() } bind AuthServiceProvider::class
 
     // Subscription Provider. When no real SDK key is set (isSubscriptionMockActive), swap in the
     // MockSubscriptionProvider so the paywall/purchase/unlock flow is explorable with zero keys.
     // Auto-reverts to the real provider (Adapty/RevenueCat) the moment a key is configured.
-    factory { Constants.subscriptionProviderFactory } bind SubscriptionProviderFactory::class
+    factory { AppConfiguration.subscriptionProviderFactory } bind SubscriptionProviderFactory::class
     single {
         if (isSubscriptionMockActive()) {
             val userPreferences = get<UserPreferences>()

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
@@ -1,38 +1,6 @@
 package com.kotlinfoundation.koko.util
 
-import com.kotlinfoundation.koko.auth.api.AuthServiceProviderFactory
-import com.kotlinfoundation.koko.auth.firebase.Firebase
-import com.kotlinfoundation.koko.subscription.config.activeSubscriptionProviderFactory
-
 object Constants {
-    const val URL_PRIVACY_POLICY = ""
-    const val URL_TERMS_CONDITIONS = ""
-    const val CONTACT_EMAIL = "support@example.com"
-    const val APPSTORE_APP_ID = ""
-
-    // Enables Apple and Google sign-in. If false, only anonymous login is supported.
-    // Default false — anonymous auth is the easiest path to a working app (just Firebase +
-    // Anonymous sign-in). Flip to true to add Google/Apple (see the enable-auth skill for the
-    // extra config: GOOGLE_WEB_CLIENT_ID, iOS Info.plist client IDs, Sign In with Apple capability).
-    const val AUTH_SOCIAL_LOGIN_ENABLED = false
-
-    /**
-     * The subscription provider is chosen in ONE place — the `SUBSCRIPTION_PROVIDER`
-     * Gradle property in `gradle.properties` (default: `ADAPTY`):
-     *
-     *   SUBSCRIPTION_PROVIDER=ADAPTY
-     *   or
-     *   SUBSCRIPTION_PROVIDER=REVENUECAT
-     *
-     *   Also in local.properties add the following:
-     *
-     *   SUBSCRIPTION_PROVIDER_ANDROID_API_KEY=YOUR_API_KEY
-     *   SUBSCRIPTION_PROVIDER_IOS_API_KEY=YOUR_API_KEY
-     *
-     * That property decides which provider module is on the classpath; this accessor
-     * resolves to whichever one is linked. Do NOT name a concrete provider here.
-     */
-    val subscriptionProviderFactory get() = activeSubscriptionProviderFactory
 
     /**
      * Identifier used to unlock Premium access.
@@ -86,29 +54,6 @@ object Constants {
      */
     val PAYWALL_PLACEMENT_ONBOARDING: String? = null
 
-    /**
-     * CLOUD_FUNCTIONS_URL should be something like: "https://REGION-PROJECT_ID.cloudfunctions.net"
-     * Regions:
-     * US(Default): us-central1
-     * EU: europe-west1
-     *
-     * This is used AI proxy functions such as OpenAi, Replicate
-     */
-    const val CLOUD_FUNCTIONS_URL = ""
-
-    /**
-     * How AI (OpenAI/Replicate) calls are routed.
-     *
-     * - `null` (AUTO, default): use the Cloud Functions proxy, unless [CLOUD_FUNCTIONS_URL] is blank AND a
-     *   provider key is set in `local.properties` — then call the provider directly from the device.
-     * - `true`: always use the proxy.
-     * - `false`: always call the provider directly.
-     *
-     * Keep the proxy for production so API keys stay in Secret Manager, never in the app binary. Direct
-     * mode is a no-Firebase prototyping shortcut (the key ships in the app) — see `integrate-web-proxy`.
-     */
-    val USE_AI_PROXY_SERVER: Boolean? = null
-
     const val LOCAL_DB_STORAGE_NAME = "local_storage.db"
 
     // DataStore requires the file name to end with ".preferences_pb"
@@ -120,8 +65,6 @@ object Constants {
         } else {
             "https://apps.apple.com/account/subscriptions"
         }
-
-    val authServiceProviderFactory get() = AuthServiceProviderFactory.Firebase
 
     val MAX_FILE_UPLOAD_SIZE = 10 * 1024 * 1024L // 10mb
 }

--- a/MobileApp/shared/src/iosMain/kotlin/com/kotlinfoundation/koko/util/AppUtilImpl.ios.kt
+++ b/MobileApp/shared/src/iosMain/kotlin/com/kotlinfoundation/koko/util/AppUtilImpl.ios.kt
@@ -1,5 +1,6 @@
 package com.kotlinfoundation.koko.util
 
+import com.kotlinfoundation.koko.root.AppConfiguration
 import platform.Foundation.NSBundle
 import platform.Foundation.NSURL
 import platform.MessageUI.MFMailComposeViewController
@@ -20,11 +21,11 @@ class AppUtilImpl : AppUtil {
             val appName = getAppName()
             val mailComposeViewController = MFMailComposeViewController()
             mailComposeViewController.setSubject("$appName Feedback/Bug Report")
-            mailComposeViewController.setToRecipients(listOf(Constants.CONTACT_EMAIL))
+            mailComposeViewController.setToRecipients(listOf(AppConfiguration.CONTACT_EMAIL))
             val rootViewController = UIApplication.sharedApplication.keyWindow?.rootViewController
             rootViewController?.presentViewController(mailComposeViewController, true, {})
         } catch (e: Exception) {
-            val mailUrl = NSURL(string = "mailto:${Constants.CONTACT_EMAIL}")
+            val mailUrl = NSURL(string = "mailto:${AppConfiguration.CONTACT_EMAIL}")
             UIApplication.sharedApplication.openURL(mailUrl)
         }
     }
@@ -44,5 +45,5 @@ class AppUtilImpl : AppUtil {
         return "$versionName ($versionCode)"
     }
 
-    private fun getAppStoreLink(): String = "https://apps.apple.com/app/id${Constants.APPSTORE_APP_ID}"
+    private fun getAppStoreLink(): String = "https://apps.apple.com/app/id${AppConfiguration.APPSTORE_APP_ID}"
 }

--- a/MobileApp/shared/src/jvmMain/kotlin/com/kotlinfoundation/koko/util/AppUtilImpl.jvm.kt
+++ b/MobileApp/shared/src/jvmMain/kotlin/com/kotlinfoundation/koko/util/AppUtilImpl.jvm.kt
@@ -1,5 +1,6 @@
 package com.kotlinfoundation.koko.util
 
+import com.kotlinfoundation.koko.root.AppConfiguration
 import java.awt.Desktop
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
@@ -26,7 +27,7 @@ class AppUtilImpl : AppUtil {
     override fun openFeedbackMail() {
         val subject = "${getAppName()} Feedback/Bug Report"
         val uri = URI(
-            "mailto:${Constants.CONTACT_EMAIL}?subject=${encode(subject)}",
+            "mailto:${AppConfiguration.CONTACT_EMAIL}?subject=${encode(subject)}",
         )
 
         runCatching {

--- a/skills/configure-environment/SKILL.md
+++ b/skills/configure-environment/SKILL.md
@@ -12,7 +12,8 @@ credentials, IDs, and toggles.
 |------|-------|-----------|
 | `MobileApp/local.properties` | SDK path + all secret API keys | **No — gitignored** |
 | `MobileApp/gradle.properties` | subscription-provider toggle | Yes |
-| `shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt` | URLs, emails, feature flags, Cloud Functions URL | Yes |
+| `shared/src/commonMain/.../root/AppConfiguration.kt` | per-app config: URLs, contact email, AI routing (`CLOUD_FUNCTIONS_URL`, `USE_AI_PROXY_SERVER`), `AUTH_SOCIAL_LOGIN_ENABLED`, provider factories | Yes |
+| `shared/src/commonMain/.../util/Constants.kt` | framework constants: paywall entitlement/placement ids, DB/prefs file names | Yes |
 
 > `MobileApp/local.properties` is gitignored (`MobileApp/.gitignore`), so it never ships filled — copy
 > it from the committed **`MobileApp/local.properties.example`** and fill what your phase needs. Keys
@@ -50,7 +51,7 @@ credentials, IDs, and toggles.
 
 > **Direct AI mode (prototyping):** `OPENAI_API_KEY` / `REPLICATE_API_KEY` in `local.properties` are used
 > only for the **direct** (no-Firebase) AI path — the app calls the provider straight from the device when
-> `Constants.CLOUD_FUNCTIONS_URL` is blank and a key is set (`Constants.USE_AI_PROXY_SERVER` overrides). The key
+> `AppConfiguration.CLOUD_FUNCTIONS_URL` is blank and a key is set (`AppConfiguration.USE_AI_PROXY_SERVER` overrides). The key
 > ships in the app binary, so this is prototyping only. In **production** the app calls the web-proxy and
 > the keys live in **Google Cloud Secret Manager**, not on device — see `integrate-web-proxy`.
 
@@ -69,7 +70,7 @@ that needs it (and `check_env.sh` tells you when).
 
 ## `MobileApp/gradle.properties` — subscription provider toggle
 
-One switch selects the billing backend module and drives `Constants.subscriptionProviderFactory`.
+One switch selects the billing backend module and drives `AppConfiguration.subscriptionProviderFactory`.
 Default is `ADAPTY`; the alternative is `REVENUECAT`. Both must compile.
 
 ```properties
@@ -78,22 +79,28 @@ SUBSCRIPTION_PROVIDER=ADAPTY
 ```
 
 Switching providers = change this property **plus** the provider's API keys in `local.properties`.
-Never hardcode a concrete provider in `Constants.kt`.
+Never hardcode a concrete provider in `AppConfiguration.kt`.
 
-## `Constants.kt` — code-level config
+## `AppConfiguration.kt` — per-app code-level config
 
-`shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt`:
+`shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/AppConfiguration.kt` — the toggles/values a
+developer sets per app:
 
 | Field | Purpose |
 |-------|---------|
 | `CLOUD_FUNCTIONS_URL` | Base URL of the deployed web proxy — `https://REGION-PROJECT_ID.cloudfunctions.net` (default region `us-central1`). Set in the `integrate-web-proxy` skill. |
+| `USE_AI_PROXY_SERVER` | `null` (auto) / `true` (force proxy) / `false` (force direct on-device AI). See `integrate-web-proxy`. |
 | `AUTH_SOCIAL_LOGIN_ENABLED` | `false` (default) = anonymous auth only, the easy path; `true` = also show Apple + Google sign-in (needs `GOOGLE_WEB_CLIENT_ID` + iOS config — see `enable-auth`). |
-| `URL_PRIVACY_POLICY` | Privacy policy URL (needed before store publishing). |
-| `URL_TERMS_CONDITIONS` | Terms & conditions URL. |
+| `URL_PRIVACY_POLICY` / `URL_TERMS_CONDITIONS` | Legal URLs (needed before store publishing). |
 | `CONTACT_EMAIL` | Support/contact email shown in-app. |
 | `APPSTORE_APP_ID` | Numeric App Store app id (for rate/review deep links). |
-| `PAYWALL_PREMIUM_ACCESS` | Entitlement / access-level id for Premium. |
-| `PAYWALL_PLACEMENT_*` | Paywall placement identifiers (credits pack, default, onboarding). |
+| `subscriptionProviderFactory` / `authServiceProviderFactory` | Provider selectors (resolve the gradle-chosen backend). |
+
+## `Constants.kt` — framework constants
+
+`shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt` (unlikely to change per app):
+`PAYWALL_PREMIUM_ACCESS` (entitlement id), `PAYWALL_PLACEMENT_*` (placement ids), `CREDIT_PACK_PRODUCT_ID_PREFIX`,
+DB/prefs file names.
 
 Runtime **feature flags** live separately in
 `shared/src/commonMain/.../data/source/featureflag/FeatureFlagManager.kt`.

--- a/skills/integrate-web-proxy/SKILL.md
+++ b/skills/integrate-web-proxy/SKILL.md
@@ -13,8 +13,8 @@ uniform envelope. Requires a Blaze-plan Firebase project (`setup-firebase`) and 
 
 > **Prototyping shortcut — Direct AI mode (no Firebase).** To try AI generation *before* deploying this
 > proxy: put an `OPENAI_API_KEY` / `REPLICATE_API_KEY` in `local.properties` and leave
-> `Constants.CLOUD_FUNCTIONS_URL` blank. The app's `AiTransport` then calls the provider **directly** from
-> the device (auto-detected; `Constants.USE_AI_PROXY_SERVER` overrides — `true`=proxy, `false`=direct).
+> `AppConfiguration.CLOUD_FUNCTIONS_URL` blank. The app's `AiTransport` then calls the provider **directly** from
+> the device (auto-detected; `AppConfiguration.USE_AI_PROXY_SERVER` overrides — `true`=proxy, `false`=direct).
 > **Not for production** — the key is
 > compiled into the app binary. Deploy this proxy and clear those keys before shipping. Note: text→image
 > is fully Firebase-free; image-*editing* still uploads the reference image via `KMPStorage`/Firebase
@@ -132,12 +132,12 @@ change**.
 
 To add a **new** endpoint:
 - **AI provider call** — add a method to the AI service that calls
-  `aiTransport.execute(method, proxyUrl = "${Constants.CLOUD_FUNCTIONS_URL}/<functionName>", direct = directSpec("<providerUrl>"), proxyQueryParams = …, body = …)`.
+  `aiTransport.execute(method, proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/<functionName>", direct = directSpec("<providerUrl>"), proxyQueryParams = …, body = …)`.
   `AiTransport` picks proxy vs direct and adapts the response — the DTOs and `handleAsResult` don't change.
 - **Other backend call** — follow `add-api-service` (Ktor service + DTOs + repository `Result`).
 
 Specifics for this backend:
-- **Base URL** = `Constants.CLOUD_FUNCTIONS_URL`; the path is the function **name**
+- **Base URL** = `AppConfiguration.CLOUD_FUNCTIONS_URL`; the path is the function **name**
   (e.g. `/openAiCreateTextCompletion`). Most endpoints are `POST`; dynamic values go as **query params**
   (the functions read `req.query`, not path segments).
 - **Auth** — the proxy client attaches `Authorization: Bearer <Firebase ID token>` automatically; you

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -69,7 +69,7 @@ defaults to `false`, so the Google/Apple buttons are hidden and `GOOGLE_WEB_CLIE
 - **Agent Action** — **Ask the developer: "do you also want Google / Apple sign-in?"**
   - **No** (recommended for a first app) → nothing to do; anonymous auth works. Skip to step 4.
   - **Yes** → read the `enable-auth` skill and proceed with the User Action below.
-- **User Action** (only if they said yes) — Set `Constants.AUTH_SOCIAL_LOGIN_ENABLED = true`, then in
+- **User Action** (only if they said yes) — Set `AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED = true`, then in
   Firebase Auth → Sign-in method enable **Google** and **Apple** (re-download **both**
   `google-services.json` and `GoogleService-Info.plist`); copy the **Web client ID** into
   `GOOGLE_WEB_CLIENT_ID` in `MobileApp/local.properties`; fill the iOS `Info.plist` client IDs
@@ -97,7 +97,7 @@ the SDK **credentials** early if they want them.
 - **User Action** — Set Secret Manager secrets `OPENAI_API_KEY` / `REPLICATE_API_KEY`
   (https://console.cloud.google.com/security/secret-manager), then from `Web/` run
   `firebase deploy --only functions`. Copy the printed base URL
-  (`https://REGION-PROJECT_ID.cloudfunctions.net`) into `Constants.CLOUD_FUNCTIONS_URL`. **Stop and confirm.**
+  (`https://REGION-PROJECT_ID.cloudfunctions.net`) into `AppConfiguration.CLOUD_FUNCTIONS_URL`. **Stop and confirm.**
 - **Agent Action** — Wire a client that calls the deployed function following the `add-api-service`
   pattern (Ktor service + DTOs, Firebase ID token in the `Authorization: Bearer` header, repository
   wraps in `Result`). Optionally test the backend locally first with

--- a/skills/integrations/progress-template.md
+++ b/skills/integrations/progress-template.md
@@ -42,7 +42,7 @@
 - [ ] **[Agent]** Explain `Web/functions`, `{statusCode, errorMessage, data}` shape, `requireAuth`
 - [ ] **[User]** Set Secret Manager `OPENAI_API_KEY` / `REPLICATE_API_KEY`
 - [ ] **[User]** `firebase deploy --only functions` from `Web/`
-- [ ] **[User]** Paste base URL into `Constants.CLOUD_FUNCTIONS_URL` → existing AI flow now uses the proxy (no code change; the proxy client attaches the Firebase token). Hand-wire only for a NEW endpoint.
+- [ ] **[User]** Paste base URL into `AppConfiguration.CLOUD_FUNCTIONS_URL` → existing AI flow now uses the proxy (no code change; the proxy client attaches the Firebase token). Hand-wire only for a NEW endpoint.
 - [ ] **[Agent]** *(prototyping alt)* Skip the proxy: set `OPENAI_API_KEY`/`REPLICATE_API_KEY` in `local.properties`, leave `CLOUD_FUNCTIONS_URL` blank → direct provider calls (key on device — not for production)
 
 ## 6. Validation gate

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -26,14 +26,14 @@ Don't answer from memory — **run the checks and report what's unmet**, then po
 ./scripts/check_env.sh --phase publishing
 ```
 Every `⚠️` must be resolved before release. It covers:
-- `Constants.URL_PRIVACY_POLICY` / `URL_TERMS_CONDITIONS` set to **live, reachable** pages (stores reject placeholders).
-- `Constants.CONTACT_EMAIL` is your own (not the `support@example.com` boilerplate).
+- `AppConfiguration.URL_PRIVACY_POLICY` / `URL_TERMS_CONDITIONS` set to **live, reachable** pages (stores reject placeholders).
+- `AppConfiguration.CONTACT_EMAIL` is your own (not the `support@example.com` boilerplate).
 - **AI backend uses the proxy, not on-device keys** — flags `USE_AI_PROXY_SERVER=false`, or a blank
   `CLOUD_FUNCTIONS_URL` with a direct `OPENAI_API_KEY`/`REPLICATE_API_KEY` (key would ship in the binary).
   Production must deploy the web-proxy (`integrate-web-proxy`) and clear direct keys.
 - **Subscription keys are real, not the demo mock** — if you sell subscriptions/IAPs, set the real
   Adapty/RevenueCat SDK keys (`setup-subscriptions`); otherwise the paywall runs the client-only mock.
-- `Constants.APPSTORE_APP_ID` (set once App Store Connect assigns it).
+- `AppConfiguration.APPSTORE_APP_ID` (set once App Store Connect assigns it).
 
 **B. Human-only readiness (can't be auto-checked)** — confirm each, sending the developer to the step/skill:
 - Package / applicationId / bundle id + display name **locked** (`refactor-package`, step 1).
@@ -136,7 +136,7 @@ Verify Constants config: `./scripts/check_env.sh --phase publishing`.
   primary language), the 1.0.0 version, categories, age-rating questionnaire, App Privacy /
   data usage, App Review info, and localized metadata (subtitle / description / keywords /
   what's-new / support + marketing URLs) with the generated screenshots + 1024 icon. Copy the
-  numeric **Apple ID** back into `Constants.APPSTORE_APP_ID`. **Stop and confirm.**
+  numeric **Apple ID** back into `AppConfiguration.APPSTORE_APP_ID`. **Stop and confirm.**
 
 ### 8. Create the Google Play Console app — `setup-google-play`
 - **Agent Action** — Read the `setup-google-play` skill; walk the developer through it.

--- a/skills/publishing/progress-template.md
+++ b/skills/publishing/progress-template.md
@@ -50,7 +50,7 @@
 - [ ] **[User]** Create app (bundle id, SKU, primary language) + 1.0.0 version
 - [ ] **[User]** Categories, age rating, App Privacy / data usage, App Review info
 - [ ] **[User]** Metadata (subtitle/description/keywords/what's-new/support+marketing URLs) + screenshots + 1024 icon
-- [ ] **[User]** Copy numeric Apple ID → `Constants.APPSTORE_APP_ID`
+- [ ] **[User]** Copy numeric Apple ID → `AppConfiguration.APPSTORE_APP_ID`
 
 ## 8. Google Play Console app — `setup-google-play`
 - [ ] **[User]** Create app

--- a/skills/setup-appstore-connect/SKILL.md
+++ b/skills/setup-appstore-connect/SKILL.md
@@ -47,15 +47,15 @@ In the app → **iOS App** sidebar, a **1.0.0 Prepare for Submission** version e
 
 **App Privacy → Get Started:** declare what data the app collects and how it's used (e.g.
 Firebase Analytics/Crashlytics → identifiers/usage data; auth → account). Provide your
-**Privacy Policy URL** — this must match `Constants.URL_PRIVACY_POLICY` and be a real,
+**Privacy Policy URL** — this must match `AppConfiguration.URL_PRIVACY_POLICY` and be a real,
 reachable page (Apple rejects placeholders). A terms/EULA URL goes in
-`Constants.URL_TERMS_CONDITIONS`.
+`AppConfiguration.URL_TERMS_CONDITIONS`.
 
 ## 5. App Review Information
 
 At the bottom of the version page:
 
-- **Contact info** (first name, last name, phone, email — use `Constants.CONTACT_EMAIL`)
+- **Contact info** (first name, last name, phone, email — use `AppConfiguration.CONTACT_EMAIL`)
 - **Sign-in required?** The starter kit signs in **anonymously** by default, so usually no
   demo account is needed; if you enabled gated social login, provide a demo account.
 - **Notes** to the reviewer if any feature needs explanation.

--- a/skills/setup-google-play/SKILL.md
+++ b/skills/setup-google-play/SKILL.md
@@ -33,8 +33,8 @@ sure the app id is final (use the `refactor-package` skill first if not).
   (`distribution/store_screenshots/<locale>/<device>/`); add tablet screenshots if you ship
   tablet support.
 
-Category, contact email (use `Constants.CONTACT_EMAIL`), and **Privacy Policy URL** (must
-match `Constants.URL_PRIVACY_POLICY` and be reachable) are set under **Store settings** /
+Category, contact email (use `AppConfiguration.CONTACT_EMAIL`), and **Privacy Policy URL** (must
+match `AppConfiguration.URL_PRIVACY_POLICY` and be reachable) are set under **Store settings** /
 **App content**.
 
 ## 3. App content (Policy → App content)

--- a/skills/setup-subscriptions/SKILL.md
+++ b/skills/setup-subscriptions/SKILL.md
@@ -25,11 +25,11 @@ SUBSCRIPTION_PROVIDER=ADAPTY
 
 That property does two things: (a) `shared/build.gradle.kts` puts only the matching provider module
 on the classpath (`libs/subscription/subscription-adapty` or `subscription-revenuecat`), and (b)
-`Constants.subscriptionProviderFactory` delegates to `activeSubscriptionProviderFactory` — the single
+`AppConfiguration.subscriptionProviderFactory` delegates to `activeSubscriptionProviderFactory` — the single
 symbol each provider module exposes in package `com.kotlinfoundation.koko.subscription.config`.
 
-- **Never hardcode a provider in `Constants`.** `Constants` must stay provider-agnostic; the property
-  resolves it so build + app code can't drift.
+- **Never hardcode a provider in `AppConfiguration`.** `AppConfiguration.subscriptionProviderFactory` must
+  stay provider-agnostic; the gradle property resolves it so build + app code can't drift.
 - **Both `ADAPTY` and `REVENUECAT` builds must compile.** If you touch subscription code, flip the
   property to the other value and rebuild before declaring done.
 


### PR DESCRIPTION
Per-app config had outgrown `Constants.kt` (it mixed framework detail with per-app toggles). Extract a new **`root/AppConfiguration`** object for the values a developer sets per app; leave framework wiring in `Constants`. **Pure refactor — no behavior change.**

## Moved to `AppConfiguration`
Legal URLs (`URL_PRIVACY_POLICY`/`URL_TERMS_CONDITIONS`), `CONTACT_EMAIL`, `APPSTORE_APP_ID`, `AUTH_SOCIAL_LOGIN_ENABLED`, `CLOUD_FUNCTIONS_URL`, `USE_AI_PROXY_SERVER`, and the `subscriptionProviderFactory` / `authServiceProviderFactory` selectors.

## Kept in `Constants`
Framework detail: `PAYWALL_PREMIUM_ACCESS`, `PAYWALL_PLACEMENT_*`, `CREDIT_PACK_PRODUCT_ID_PREFIX`, DB/prefs file names, store URL, upload cap.

## Also
- All `Constants.X → AppConfiguration.X` references updated (~12 Kotlin files).
- `scripts/check_env.sh` reads `AppConfiguration.kt` for the URLs/AI/auth values it verifies.
- Docs updated: AGENTS/CLAUDE (new *App configuration* section), skills, and the Documentation submodule ([KAppMaker-Docs#16](https://github.com/KAppMaker/KAppMaker-Docs/pull/16)).

Layering: `AppConfiguration` (compile-time per-app) vs `Constants` (framework) vs `FeatureFlagManager` (runtime, Remote Config).

## Verification
`./gradlew spotlessCheck :shared:jvmTest :shared:testAndroidHostTest :androidApp:assembleDebug` — all green, zero behavior change. `check_env.sh --phase publishing` reads the moved fields from their new home (same output).

This is Phase 1 of two; Phase 2 (`PREMIUM_FEATURES_ENABLED` free-app mode) follows on its own branch.