### PR TITLE
docs(skills): fix stale Constants.kt refs for moved AppConfiguration fields

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -71,7 +71,7 @@ so a forgotten key is invisible in the build. Two tools make it visible:
 
 | Skill | Use when |
 |---|---|
-| [configure-environment](configure-environment/SKILL.md) | Figuring out where a config value / API key lives (local.properties, gradle.properties, Constants.kt) |
+| [configure-environment](configure-environment/SKILL.md) | Figuring out where a config value / API key lives (local.properties, gradle.properties, AppConfiguration.kt, Constants.kt) |
 | [setup-firebase](setup-firebase/SKILL.md) | Connecting the app to Firebase (project, apps, anonymous auth) |
 | [enable-auth](enable-auth/SKILL.md) | Adding Google / Apple social sign-in |
 | [integrate-web-proxy](integrate-web-proxy/SKILL.md) | Deploying the Cloud Functions AI proxy and calling it securely |

--- a/skills/enable-auth/SKILL.md
+++ b/skills/enable-auth/SKILL.md
@@ -17,7 +17,7 @@ the UI — you're supplying credentials, not writing auth code.
 
 ## 1. Turn on the feature flag — Agent Action
 
-In `shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt`:
+In `shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/AppConfiguration.kt`:
 
 ```kotlin
 const val AUTH_SOCIAL_LOGIN_ENABLED = true

--- a/skills/integrate-web-proxy/SKILL.md
+++ b/skills/integrate-web-proxy/SKILL.md
@@ -106,7 +106,7 @@ The deploy prints the base URL, shaped
 ## 3. Point the app at the URL — User Action / Agent Action
 
 Set the base URL in
-`shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt`:
+`shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/AppConfiguration.kt`:
 
 ```kotlin
 const val CLOUD_FUNCTIONS_URL = "https://us-central1-your-project-id.cloudfunctions.net"

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -41,7 +41,7 @@ The recommended anonymous-only path needs just the Firebase config. Verify:
 ### 1. Lay out the key catalog — `configure-environment`
 - **Agent Action** — Read the `configure-environment` skill. Walk the developer through the full
   catalog of `MobileApp/local.properties` keys, the `MobileApp/gradle.properties`
-  `SUBSCRIPTION_PROVIDER` toggle, and the `Constants.kt` fields. Establish which values this phase
+  `SUBSCRIPTION_PROVIDER` toggle, and the `AppConfiguration.kt` fields. Establish which values this phase
   needs (`GOOGLE_WEB_CLIENT_ID`, `CLOUD_FUNCTIONS_URL`) vs. later phases.
 - **User Action** — Ensure `MobileApp/local.properties` exists with at least `sdk.dir` (copy it from
   the committed `MobileApp/local.properties.example` if needed). It is gitignored, so it never came

--- a/skills/integrations/progress-template.md
+++ b/skills/integrations/progress-template.md
@@ -12,7 +12,7 @@
 > *STOP RULE:* Stop at any unchecked **[User]** item and wait for confirmation before proceeding.
 
 ## 1. Key catalog — `configure-environment`
-- [ ] **[Agent]** Walk through `local.properties` keys, `gradle.properties` `SUBSCRIPTION_PROVIDER`, `Constants.kt` fields
+- [ ] **[Agent]** Walk through `local.properties` keys, `gradle.properties` `SUBSCRIPTION_PROVIDER`, `AppConfiguration.kt` fields
 - [ ] **[User]** `MobileApp/local.properties` exists with `sdk.dir` (copy from `local.properties.example`; gitignored — confirm)
 - [ ] **[Agent]** Run `./scripts/check_env.sh --phase integrations` to see which keys this phase needs
 

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -70,7 +70,7 @@ review. Guide precisely, stage local files, then wait.
 
 ## Keys / secrets you'll need
 
-- **`Constants.kt` fields** (required) — set these before you ship:
+- **`AppConfiguration.kt` fields** (required) — set these before you ship:
   - `URL_PRIVACY_POLICY` + `URL_TERMS_CONDITIONS` — your published legal URLs.
   - `CONTACT_EMAIL` — your own support email (ships as boilerplate `support@example.com`).
   - `APPSTORE_APP_ID` — numeric App Store id for rate/review + manage-subscription deep links; set it
@@ -79,7 +79,7 @@ review. Guide precisely, stage local files, then wait.
   Store Connect API key, provisioning profiles, Play service account. All move into **GitHub Actions
   secrets**, never committed — see `setup-signing`.
 
-Verify Constants config: `./scripts/check_env.sh --phase publishing`.
+Verify AppConfiguration config: `./scripts/check_env.sh --phase publishing`.
 
 ## Checklist
 
@@ -124,8 +124,8 @@ Verify Constants config: `./scripts/check_env.sh --phase publishing`.
   exist for the key screens, then run `./scripts/generate_store_screenshots.sh`. Output lands
   at `distribution/store_screenshots/<locale>/<device>/`.
 
-### 6. Set store URLs + contact in `Constants.kt`
-- **Agent Action** — In `shared/src/commonMain/.../util/Constants.kt` set
+### 6. Set store URLs + contact in `AppConfiguration.kt`
+- **Agent Action** — In `shared/src/commonMain/.../root/AppConfiguration.kt` set
   `URL_PRIVACY_POLICY`, `URL_TERMS_CONDITIONS`, and `CONTACT_EMAIL`. These must be **real,
   reachable** pages — both stores reject placeholders. (`APPSTORE_APP_ID` is filled in step 7
   once the ASC app exists.)
@@ -160,7 +160,7 @@ Verify Constants config: `./scripts/check_env.sh --phase publishing`.
 
 ### 10. Validation gate
 - **Validation** — Run `./scripts/check_env.sh --phase publishing` from `MobileApp/` — the
-  `Constants.kt` legal URLs + `CONTACT_EMAIL` must be set (no `⚠️`), `APPSTORE_APP_ID` once ASC
+  `AppConfiguration.kt` legal URLs + `CONTACT_EMAIL` must be set (no `⚠️`), `APPSTORE_APP_ID` once ASC
   assigned it.
 - **Validation** — The signed release build **uploads to the Play internal track /
   TestFlight and appears in the console**. Run the `run-quality-gates` skill before tagging a

--- a/skills/publishing/progress-template.md
+++ b/skills/publishing/progress-template.md
@@ -42,7 +42,7 @@
 - [ ] **[Agent]** `@StoreScreenshot` previews exist for key screens
 - [ ] **[Agent]** `./scripts/generate_store_screenshots.sh` → `distribution/store_screenshots/<locale>/<device>/`
 
-## 6. Store URLs + contact in `Constants.kt`
+## 6. Store URLs + contact in `AppConfiguration.kt`
 - [ ] **[Agent]** Set `URL_PRIVACY_POLICY`, `URL_TERMS_CONDITIONS`, `CONTACT_EMAIL`
 - [ ] **[User]** Privacy + terms pages are published and reachable (no placeholders)
 
@@ -66,7 +66,7 @@
 - [ ] **[User]** Submit for review on both stores
 
 ## 10. Validation gate
-- [ ] **[Validate]** `./scripts/check_env.sh --phase publishing` — Constants legal URLs + `CONTACT_EMAIL` set
+- [ ] **[Validate]** `./scripts/check_env.sh --phase publishing` — AppConfiguration legal URLs + `CONTACT_EMAIL` set
 - [ ] **[Validate]** Signed build uploads to Play internal track / TestFlight and appears in the console
 - [ ] **[Validate]** Run the `run-quality-gates` skill
 

--- a/skills/setup-appstore-connect/SKILL.md
+++ b/skills/setup-appstore-connect/SKILL.md
@@ -60,13 +60,13 @@ At the bottom of the version page:
   demo account is needed; if you enabled gated social login, provide a demo account.
 - **Notes** to the reviewer if any feature needs explanation.
 
-## 6. Grab the numeric App ID → `Constants.kt`
+## 6. Grab the numeric App ID → `AppConfiguration.kt`
 
 Once the app exists, its **Apple ID** (a numeric id, shown under *App Information → General
 Information → Apple ID*) goes into:
 
 ```
-shared/src/commonMain/.../util/Constants.kt → APPSTORE_APP_ID = "1234567890"
+shared/src/commonMain/.../root/AppConfiguration.kt → APPSTORE_APP_ID = "1234567890"
 ```
 
 Used by in-app "Rate us" / store deep-links.


### PR DESCRIPTION
Follow-up to the AppConfiguration extraction. Several skills still cited `Constants.kt` for fields that moved to `root/AppConfiguration.kt` (`APPSTORE_APP_ID`, `CLOUD_FUNCTIONS_URL`, `AUTH_SOCIAL_LOGIN_ENABLED`, legal URLs, `CONTACT_EMAIL`).

## Fixed
- `setup-appstore-connect` — `APPSTORE_APP_ID`
- `publishing` SKILL + progress-template — legal URLs / `CONTACT_EMAIL` / appstore id
- `integrate-web-proxy` — `CLOUD_FUNCTIONS_URL`
- `enable-auth` — `AUTH_SOCIAL_LOGIN_ENABLED`
- `integrations` SKILL + progress, `README` — config-file references
- Documentation submodule bumped (KAppMaker-Docs#18)

## Left as-is (correct)
`PAYWALL_PREMIUM_ACCESS`, `PAYWALL_PLACEMENT_*`, `CREDIT_PACK_PRODUCT_ID_PREFIX` — framework ids that stay in `Constants`.

Prose-only; no code/logic change. Final sweep: zero `Constants.<movedField>` across skills, AiGuidelines, AGENTS, README, docs, kotlin src.