### PR TITLE
Add idea-to-app entry flow (new-app + build-features) with resumable feature tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,17 @@ Two layers:
 - **Guides** — one per phase of the developer journey. Each is an ordered checklist whose steps are tagged **Agent Action** / **User Action** / **Validation**; stop at each **User Action** and wait for the developer. Copy the guide's `progress-template.md` to track progress.
 - **Task skills** — one job each, usable standalone; the guides call them by name.
 
+**Progress tracking (read these before resuming any work):** progress files live at the repo root, are committed, and are how a new session learns what's already done.
+
+| File | Tracks | Written by |
+|---|---|---|
+| `PROGRESS_FEATURES.md` | **What's actually built** — each model/screen from the PRD, plus the branded onboarding/paywall | `build-features` |
+| `PROGRESS_P1_GETTING_STARTED.md` … `PROGRESS_P5_GROWTH.md` | The *guide's* steps for each phase | the phase guides |
+
+**Resume rule:** before building, read the relevant progress file and continue from the **first unchecked item**. Never redo checked work; never re-derive a plan while unchecked items remain. Tick items off as you finish them, not at the end.
+
+**Starting from an idea** ("build me a habit tracker"): run **`skills/new-app/`** first — it interviews the developer, writes `AiGuidelines/project/{prd,user_flow,ui_ux}.md`, picks the app name/id, and records deferred decisions as `TODO(<phase>)` markers in `root/AppConfiguration.kt`. It then hands off to Phase 1. Phase 1 needs **no Firebase, no subscription provider, no store account** (mock provider + direct-mode AI cover it).
+
 **Developer journey (walk the guides in order):**
 
 | Phase | Guide | Goal |
@@ -347,7 +358,7 @@ Two layers:
 | 5 · Growth | `skills/growth/` | Analytics/Crashlytics/RemoteConfig, push, onboarding, virality loops |
 
 **Task skills** (grouped by phase):
-- **P1** `run-the-app`, `refactor-package`, `new-screen`, `new-local-model`, `add-api-service`, `save-preferences`, `add-permission`, `new-module`
+- **P1** `new-app`, `build-features`, `run-the-app`, `refactor-package`, `new-screen`, `new-local-model`, `add-api-service`, `save-preferences`, `add-permission`, `new-module`
 - **P2** `configure-environment`, `setup-firebase`, `enable-auth`, `integrate-web-proxy`
 - **P3** `generate-app-icons`, `bump-version`, `setup-signing`, `store-screenshots`, `setup-appstore-connect`, `setup-google-play`, `publish-release`
 - **P4** `design-paywall`, `setup-subscriptions`, `enable-credits`, `enable-ads`

--- a/MobileApp/local.properties.example
+++ b/MobileApp/local.properties.example
@@ -17,7 +17,7 @@
 sdk.dir=/Users/you/Library/Android/sdk
 
 # --- [P2] Social sign-in (OPTIONAL) ------------------------------------------------------------
-# Only needed if you turn on Google/Apple sign-in (Constants.AUTH_SOCIAL_LOGIN_ENABLED = true).
+# Only needed if you turn on Google/Apple sign-in (AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED = true).
 # The recommended easy path is Firebase + Anonymous auth, which needs NONE of these.
 # Get it from: Firebase Console -> Authentication -> Google provider -> Web client ID.
 GOOGLE_WEB_CLIENT_ID=
@@ -47,11 +47,12 @@ ADMOB_REWARDED_AD_ID_IOS=
 # Image hosting token, only if you use image upload. Get it from https://api.imgbb.com/
 IMGBB_TOKEN=
 
-# --- Direct AI (no-Firebase prototyping) -------------------------------------------------------
+# --- [P1] Direct AI (no-Firebase prototyping) --------------------------------------------------
+# Only needed if your app uses AI. This is the phase-1 path: no Firebase, no backend.
 # By default the app calls OpenAI/Replicate through the Cloud Functions web-proxy, which reads these
 # keys from Google Cloud Secret Manager (production-safe — keys never on device).
-# For a QUICK no-Firebase prototype, set a key here AND leave CLOUD_FUNCTIONS_URL blank in Constants.kt:
-# the app then calls the provider directly from the device.
+# For a QUICK no-Firebase prototype, set a key here AND leave AppConfiguration.CLOUD_FUNCTIONS_URL
+# blank: the app then calls the provider directly from the device.
 # WARNING: the key is compiled into the app binary — prototyping only. For production, deploy the
 # web-proxy and clear these (see the integrate-web-proxy skill).
 # OpenAI:    https://platform.openai.com/   Replicate: https://replicate.com/account/api-tokens

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/AppConfiguration.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/root/AppConfiguration.kt
@@ -15,9 +15,17 @@ import com.kotlinfoundation.koko.subscription.config.activeSubscriptionProviderF
  */
 object AppConfiguration {
 
+    // TODO(publish): your live privacy policy URL — stores reject placeholders (`publishing` skill).
     const val URL_PRIVACY_POLICY = ""
+
+    // TODO(publish): your live terms & conditions URL (`publishing` skill).
     const val URL_TERMS_CONDITIONS = ""
+
+    // TODO(publish): your real support email — ships as boilerplate (`publishing` skill).
     const val CONTACT_EMAIL = "support@example.com"
+
+    // TODO(publish): numeric App Store id, available once the app exists in App Store Connect
+    // (`setup-appstore-connect` skill).
     const val APPSTORE_APP_ID = ""
 
     /**
@@ -41,6 +49,8 @@ object AppConfiguration {
      *
      * This is used AI proxy functions such as OpenAi, Replicate
      */
+    // TODO(integrations): deployed Cloud Functions base URL. Blank is fine to start — direct mode
+    // works without Firebase (`integrate-web-proxy` skill).
     const val CLOUD_FUNCTIONS_URL = ""
 
     // Enables Apple and Google sign-in. If false, only anonymous login is supported.

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,6 +28,11 @@ checklist whose steps are tagged **Agent Action** (an agent/dev does it: code, s
 moving on). An agent following a guide **stops at each User Action** and waits for you. Copy the
 guide's `progress-template.md` into your repo to track where you are.
 
+**Progress files** live at your repo root and get committed, so any session resumes where the last one
+stopped: **`PROGRESS_FEATURES.md`** (what's actually built — each model/screen from the PRD, written by
+[build-features](build-features/SKILL.md)) and **`PROGRESS_P1…P5`** (each phase guide's steps). The rule:
+read the file first, continue from the first unchecked item, tick items off as you go.
+
 **Task skills** do one job each and are usable standalone. The guides call them by name.
 
 ## Environment keys (don't get silently skipped)
@@ -44,9 +49,14 @@ so a forgotten key is invisible in the build. Two tools make it visible:
 
 ## The journey (5 phases)
 
+**Starting from an idea?** Run **[new-app](new-app/SKILL.md)** first — it interviews you, writes the
+PRD / user flow / UI direction, and records the decisions you can defer. It then hands straight to the
+Phase 1 guide. No accounts needed to get going: the kit ships a mock subscription provider and a
+no-Firebase AI path, so Firebase / Adapty / store accounts wait until the phase that needs them.
+
 | Phase | Guide | You end with |
 |---|---|---|
-| 1 · First Run | [getting-started](getting-started/SKILL.md) | The app **running on your own device**, rebranded, driven purely locally — no cloud. |
+| 1 · First Run | [getting-started](getting-started/SKILL.md) | The app **running on your own device**, rebranded, with **your MVP features** built — no cloud. |
 | 2 · Integrations | [integrations](integrations/SKILL.md) | Firebase + auth + the web-proxy backend wired; real remote calls work. |
 | 3 · Publication | [publishing](publishing/SKILL.md) | Icons, release signing (keys in CI, not the app), store listings, first build in review. |
 | 4 · Monetization | [monetization](monetization/SKILL.md) | Subscriptions + credit-pack IAPs + paywall + ads; a test purchase unlocks premium. |
@@ -58,6 +68,8 @@ so a forgotten key is invisible in the build. Two tools make it visible:
 
 | Skill | Use when |
 |---|---|
+| [new-app](new-app/SKILL.md) | Starting from an idea — interview, write the PRD/user-flow/UI docs, pick name + id, record deferred decisions |
+| [build-features](build-features/SKILL.md) | Building your app's real features from the PRD (also later: "add streaks to my habit tracker") |
 | [run-the-app](run-the-app/SKILL.md) | Building/running the app on Android, Desktop, Web, or iOS for the first time |
 | [refactor-package](refactor-package/SKILL.md) | Renaming the package / applicationId / bundle ID / display name (rebrand) |
 | [new-screen](new-screen/SKILL.md) | Adding a screen (scaffolds UI + route + DI wiring) |

--- a/skills/build-features/SKILL.md
+++ b/skills/build-features/SKILL.md
@@ -73,6 +73,8 @@ Reach for these only if the feature actually needs them:
 - **`add-api-service`** — a remote call (any public URL; no backend needed).
 - **`save-preferences`** — a simple setting/flag.
 - **`add-permission`** — camera/notifications/etc.
+- **`new-module`** — only if the code genuinely belongs outside `shared/` (a reusable library, or a
+  second implementation behind an API). Most features do **not** need this.
 
 ## 4. Brand the screens that already ship — **Agent Action**
 

--- a/skills/build-features/SKILL.md
+++ b/skills/build-features/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: build-features
+description: Build the app's real features from prd.md / user_flow.md — derive the screens and local models, scaffold them with new-screen / new-local-model, and implement the UI per ui_ux.md. Use to implement the MVP after the product is defined, or any time later to add a feature described in the PRD ("add streaks to my habit tracker").
+---
+
+# Build the app's features from the PRD
+
+Turns the product docs into **this app's actual screens and data** — not demo scaffolding.
+
+**Prerequisite:** [`AiGuidelines/project/prd.md`](../../AiGuidelines/project/prd.md) and
+[`user_flow.md`](../../AiGuidelines/project/user_flow.md) are filled. If they're still blank
+(just a heading), run the **`new-app`** skill first — don't invent the product here.
+
+All commands run from `MobileApp/`.
+
+## 0. Resume before you build — **Agent Action, always first**
+
+**`PROGRESS_FEATURES.md`** at the repository root is the record of what has actually been built.
+
+- **If it exists:** read it and **continue from the first unchecked item**. Do **not** re-derive the
+  plan and do **not** redo checked work.
+- **If it doesn't:** copy [`progress-template.md`](progress-template.md) (next to this file) to
+  `PROGRESS_FEATURES.md` at the repo root, then derive the plan (step 1) and fill it in.
+
+**Tick items off as you finish them, not at the end** — a session can stop at any point, and this file
+is the only thing that tells the next one what's left. Commit it with the code.
+
+## 1. Derive the build plan — **Agent Action**
+
+Read `prd.md` (core features), `user_flow.md` (screen map + navigation), and `ui_ux.md` (visual
+direction). From them produce:
+
+- **Screens** — one per screen in the user flow.
+- **Local models** — one per persisted entity in the PRD (a habit, a completion, …).
+- **Navigation** — which screen leads where; which are bottom-nav tabs.
+
+**Show the plan and get an explicit confirm before generating anything.** List it plainly:
+
+```
+Models:  Habit, HabitCompletion
+Screens: HabitList (tab), HabitDetail, AddHabit, Stats (tab)
+```
+
+Once confirmed, **write the plan into `PROGRESS_FEATURES.md`** (one line per model and per screen)
+before you generate anything — that's what makes the build resumable.
+
+## 2. Scaffold — **Agent Action, and run these SEQUENTIALLY**
+
+> [!IMPORTANT]
+> Both scripts **patch shared files** (`Routes.kt`, `AppNavigation.kt`, `root/Di.kt`,
+> `AppDatabase.kt`, `DatabaseModule.kt`) at their insertion-point markers. **Never run them in
+> parallel** — concurrent runs corrupt those files. One at a time, models first.
+
+```bash
+./scripts/make_local.sh Habit          # → domain model + @Entity + @Dao + DB + Koin
+./scripts/generate_screen.sh HabitList # → Screen + UiState + ViewModel + route + DI
+```
+
+Use the **`new-local-model`** and **`new-screen`** skills for the rules each one expects.
+
+## 3. Implement — **Agent Action, parallelize here**
+
+Once scaffolding is done, the per-feature work lives in **separate folders**, so it's safe to fan out
+**one subagent per screen/model**:
+
+- **Models** — real columns on the `@Entity`, update both mappers, DAO queries the feature needs.
+- **Screens** — build the UI in the pure composable overload per `ui_ux.md`; keep logic in the
+  ViewModel; use `designsystem` components (`AppButton`, `AppCard`, …).
+- **Navigation** — edit the generated `entry<…>` blocks in `AppNavigation.kt` to add the callbacks
+  the flow needs. *(This file is shared — do this yourself, not in a subagent.)*
+
+Reach for these only if the feature actually needs them:
+- **`add-api-service`** — a remote call (any public URL; no backend needed).
+- **`save-preferences`** — a simple setting/flag.
+- **`add-permission`** — camera/notifications/etc.
+
+## 4. Brand the screens that already ship — **Agent Action**
+
+The kit **already includes an onboarding flow and a paywall** (`presentation/screens/onboarding/`,
+`presentation/screens/paywall/`). Out of the box they show boilerplate copy about the wrong product —
+the developer will hit them the moment they run the app, so fix them now, not at publish time:
+
+- **Onboarding** — rebuild the copy/steps from
+  [`AiGuidelines/project/onboarding.md`](../../AiGuidelines/project/onboarding.md): the chosen pattern,
+  the goal-capture question, the first-taste moment, permission benefit framing. Use the
+  **`design-onboarding`** skill.
+- **Paywall** — apply the **primary model + benefit copy** from
+  [`AiGuidelines/project/paywall.md`](../../AiGuidelines/project/paywall.md) to the `paywall_*` strings
+  in `composeResources/values/strings.xml`. Use the **`design-paywall`** skill.
+  - It's fully testable right now: the **mock provider** runs paywall → purchase → unlock with **no
+    account and no keys** (a red demo banner shows while mocked).
+  - Leave **prices / trial length / pack sizes** as `TODO(monetization)` — those are Phase 4, set when
+    the real store products exist.
+
+## 5. Validate — **Agent Action → User confirms**
+
+```bash
+./gradlew spotlessApply
+```
+Then run the **`run-quality-gates`** skill, and have the developer run the app
+(`./gradlew :desktopApp:run` is fastest) to confirm the features behave.
+
+---
+
+## Adding features later
+
+Same skill, smaller scope: describe the feature (or point at the PRD section), confirm the plan, scaffold
+sequentially, implement, validate. If the feature isn't in `prd.md` yet, add it there first so the docs
+stay the source of truth — then append it under **Later additions** in `PROGRESS_FEATURES.md` and work
+it the same way.

--- a/skills/build-features/SKILL.md
+++ b/skills/build-features/SKILL.md
@@ -73,6 +73,10 @@ Reach for these only if the feature actually needs them:
 - **`add-api-service`** — a remote call (any public URL; no backend needed).
 - **`save-preferences`** — a simple setting/flag.
 - **`add-permission`** — camera/notifications/etc.
+- **AI (OpenAI / Replicate)** — works in this phase with **no Firebase**: put `OPENAI_API_KEY` and/or
+  `REPLICATE_API_KEY` in `MobileApp/local.properties` and leave `AppConfiguration.CLOUD_FUNCTIONS_URL`
+  blank — `AiTransport` then calls the provider straight from the device. The key ships in the binary,
+  so it's **prototyping only**: `integrate-web-proxy` moves it off-device before you publish.
 - **`new-module`** — only if the code genuinely belongs outside `shared/` (a reusable library, or a
   second implementation behind an API). Most features do **not** need this.
 

--- a/skills/build-features/progress-template.md
+++ b/skills/build-features/progress-template.md
@@ -1,0 +1,50 @@
+# Features — <App name>
+
+> [!NOTE]
+> **Setup:** the `build-features` skill copies this template to the repository root as
+> **`PROGRESS_FEATURES.md`** and keeps it up to date. It is the record of **what has actually been
+> built** from the PRD — the phase files (`PROGRESS_P1…`) track the *guide's* steps; this one tracks
+> *your app's features*.
+>
+> **Resume rule:** before building anything, read this file and continue from the first unchecked
+> item. Never redo a checked item, and never re-derive the plan while unchecked items remain.
+>
+> **Commit it.** It travels with the repo so any session/machine can pick up where the last one stopped.
+
+**Source of truth:** `AiGuidelines/project/prd.md` · `user_flow.md` · `ui_ux.md`
+**Status key:** `[ ]` not started · `[~]` in progress · `[x]` done
+
+---
+
+## Models
+<!-- one line per persisted entity from the PRD; scaffold with make_local.sh (run sequentially) -->
+
+- [ ] `<Model>` — scaffolded ☐ · real columns + mappers ☐ · DAO queries ☐
+
+## Screens
+<!-- one line per screen in user_flow.md; scaffold with generate_screen.sh (run sequentially) -->
+
+- [ ] `<Screen>` — scaffolded ☐ · UI per `ui_ux.md` ☐ · nav callbacks wired ☐
+
+## Screens that ship with the kit (brand them to this product)
+
+- [ ] **onboarding** — copy/steps rebuilt from `AiGuidelines/project/onboarding.md` (`design-onboarding`)
+- [ ] **paywall** — primary model + benefit copy from `AiGuidelines/project/paywall.md`
+      (`design-paywall`). Runs on the mock provider — no account needed.
+      Prices / trial / pack sizes stay `TODO(monetization)` until Phase 4.
+
+## Optional building blocks (only if a feature needs one)
+
+- [ ] Remote call — `add-api-service`
+- [ ] Stored setting — `save-preferences`
+- [ ] Device permission — `add-permission`
+
+## Validation
+
+- [ ] `run-quality-gates` passes (spotless, tests, Android debug build)
+- [ ] Developer ran the app and confirmed the features behave
+
+---
+
+## Later additions
+<!-- append new features here as they're requested; add them to prd.md first -->

--- a/skills/configure-environment/SKILL.md
+++ b/skills/configure-environment/SKILL.md
@@ -42,8 +42,8 @@ credentials, IDs, and toggles.
 | `ADMOB_INTERSTITIAL_AD_ID_IOS` | Interstitial ad unit (iOS) | AdMob console | monetization |
 | `ADMOB_REWARDED_AD_ID_IOS` | Rewarded ad unit (iOS) | AdMob console | monetization |
 | `IMGBB_TOKEN` | Image hosting/upload token | https://api.imgbb.com/ account | when using image upload |
-| `OPENAI_API_KEY` | Direct OpenAI calls (no proxy) | https://platform.openai.com/ | integrations (direct/dev — see note) |
-| `REPLICATE_API_KEY` | Direct Replicate calls (no proxy) | https://replicate.com/account/api-tokens | integrations (direct/dev — see note) |
+| `OPENAI_API_KEY` | Direct OpenAI calls (no proxy, no Firebase) | https://platform.openai.com/ | **phase 1** if the app uses AI (direct) · proxied in integrations — see note |
+| `REPLICATE_API_KEY` | Direct Replicate calls (no proxy, no Firebase) | https://replicate.com/account/api-tokens | **phase 1** if the app uses AI (direct) · proxied in integrations — see note |
 
 > **Subscription mock:** while the two subscription keys are unset, the app runs a built-in mock
 > provider so the paywall/purchase/unlock/cancel flow works with zero keys (a red "Demo paywall" banner

--- a/skills/design-onboarding/SKILL.md
+++ b/skills/design-onboarding/SKILL.md
@@ -42,5 +42,9 @@ UiState + ViewModel, wired into navigation + DI).
   measurable.
 
 ## Done
-Onboarding runs end to end, captures the goal, delivers a first taste, and primes permissions. This is
-the `design-onboarding` step of the `growth` phase.
+Onboarding runs end to end, captures the goal, delivers a first taste, and primes permissions.
+
+**When to run this:** the kit ships an onboarding flow already, so it shows boilerplate until you brand
+it — do that in **Phase 1** (`build-features`), since it's the first thing every user sees. The
+**`growth`** phase revisits it later to *optimize* activation (funnel events, priming, A/B copy) — not
+to design it from scratch.

--- a/skills/design-paywall/SKILL.md
+++ b/skills/design-paywall/SKILL.md
@@ -71,6 +71,16 @@ Once `paywall.md` has **no** remaining `TAILOR PER APP` markers, the offer is de
 **`setup-subscriptions`** (subscriptions) and **`enable-credits`** (credit packs) to create the matching
 products.
 
+## When to run this — split across two phases
+
+The kit ships a working paywall, so it shows boilerplate until you brand it:
+
+- **Phase 1 (`build-features`)** — the **primary model + benefit copy** (`paywall_*` strings). Fully
+  testable now: the **mock provider** runs paywall → purchase → unlock with **no account, no keys**.
+- **Phase 4 (`monetization`)** — the **numbers**: prices & packages, trial length, credit-pack sizes.
+  Set them when you create the real store products (they're marked `TODO(monetization)` in
+  `AiGuidelines/project/paywall.md` until then).
+
 ## Related skills
 
 `setup-subscriptions` · `enable-credits` · `store-screenshots` (paywall PNGs) ·

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -1,13 +1,19 @@
 ---
 name: getting-started
-description: Phase-1 blueprint for the KMP starter kit — get the app running locally on your own device, rebrand it, and drive it with a screen, a Room model, a preference, a network call, and a permission (all LOCAL-only). Use when getting started with the KMP contest starter kit / on first run / initial setup, before touching Firebase, backend, or publishing.
+description: Phase-1 blueprint for the KMP starter kit — get the app running locally on your own device, rebrand it, and build your MVP features from the PRD (all LOCAL-only, no accounts). Use when getting started with the KMP contest starter kit / on first run / initial setup, before touching Firebase, backend, or publishing.
 ---
 
 # Getting Started — Phase 1 (First Run, LOCAL-ONLY)
 
-**Goal:** get the app **running on your own device/emulator**, rebranded to your app, and driven
-**purely locally** — one screen, one Room model, one preference, one plain network request, one device
-permission. Prove the loop end-to-end before adding any cloud services.
+**Goal:** get the app **running on your own device/emulator**, rebranded to your app, with **your MVP
+features built** — all **purely locally**. Prove the loop end-to-end before adding any cloud services.
+
+**Start here?** If the developer arrived with an *idea* and no product docs yet ("build me a habit
+tracker"), run the **`new-app`** skill first — it interviews them and writes `prd.md` / `user_flow.md` /
+`ui_ux.md` plus the app name/id this guide needs. `new-app` hands straight back here.
+
+**No accounts needed in this phase.** No Firebase, no Adapty/RevenueCat, no Play/App Store account —
+the kit's mock subscription provider and direct-mode AI cover it.
 
 **Explicitly deferred to later phases** (do NOT do these now):
 - Firebase (Analytics, Messaging, Crashlytics, RemoteConfig), authentication, backend / web-proxy → the **`integrations`** guide.
@@ -54,7 +60,7 @@ Verify: `./scripts/check_env.sh --phase getting-started`.
 
 ### B. Rebrand to your app
 
-5. **Agent Action** — Rename the package / applicationId / iOS bundle ID + display name with the **`refactor-package`** skill:
+5. **Agent Action** — Rename the package / applicationId / iOS bundle ID + display name with the **`refactor-package`** skill, using the **app id + name decided in `new-app`** (if the developer hasn't picked one yet, ask — offer 3 suggestions with one recommended):
    ```bash
    ./scripts/refactor_package.sh --app-id com.example.newapp --app-name NewApp
    ```
@@ -62,21 +68,20 @@ Verify: `./scripts/check_env.sh --phase getting-started`.
 
 ### C. Define the product (grounds everything downstream)
 
-7. **Agent Action** — Fill `AiGuidelines/project/prd.md` (what the app is, who it's for, scope, core value). Search for `TAILOR PER APP` markers.
-8. **Agent Action** — Fill `AiGuidelines/project/user_flow.md` (primary flows + screen sequence).
+7. **Agent Action** — The product should already be defined by the **`new-app`** skill: `AiGuidelines/project/prd.md`, `user_flow.md`, and `ui_ux.md` filled, name/id decided, deferred decisions marked `TODO(<phase>)` in `root/AppConfiguration.kt`.
+   - If those files are still blank (just a heading), **stop and run `new-app` first** — it interviews the developer and writes them. Never invent the product yourself.
 
-### D. Build the local loop
+### D. Build your features
 
-9. **Agent Action** — Add a screen with the **`new-screen`** skill (`./scripts/generate_screen.sh YourScreenName` — scaffolds Screen + UiState + ViewModel and wires route + DI). Implement the UI.
-10. **Agent Action** — Persist data locally with the **`new-local-model`** skill (`./scripts/make_local.sh ModelName` — Room entity + DAO + DB registration + Koin). Add real columns and use it from a repository/ViewModel.
-11. **Agent Action** — Add a network request with the **`add-api-service`** skill (DTOs → API service → repository via `backgroundExecutor.execute { }` → ViewModel). Any public URL works — no project backend needed.
-12. **Agent Action** — Store a setting with the **`save-preferences`** skill (add a key to `UserPreferences.Keys`, read/write via the injected `UserPreferences`).
-13. **Agent Action** — Ask for a device permission with the **`add-permission`** skill (`rememberCameraPermissionState()` etc. or `rememberAppPermissionState(...)`; add iOS `NS*UsageDescription` if needed).
+8. **Agent Action** — Build the MVP with the **`build-features`** skill: it derives the screens + local models from `prd.md`/`user_flow.md`, scaffolds them (`make_local.sh` / `generate_screen.sh`, **run sequentially** — they patch shared files), implements the UI per `ui_ux.md`, and brands the onboarding + paywall screens that already ship.
+   - It records every model/screen in **`PROGRESS_FEATURES.md`** at the repo root and ticks them off as it goes — so if a session stops, the next one resumes from the first unchecked item instead of guessing.
+   - Underlying skills it uses: **`new-local-model`**, **`new-screen`**, and — only if a feature needs them — **`add-api-service`** (any public URL, no backend), **`save-preferences`**, **`add-permission`**.
+   - Everything stays local: **no Firebase, no provider account, no store account** in this phase. The paywall runs on the mock provider if you touch it.
 
 ### E. Validate
 
-14. **Agent Action** — Run the **`run-quality-gates`** skill (`spotlessApply`/`spotlessCheck`, `:shared:jvmTest :shared:testAndroidHostTest`, `:androidApp:assembleDebug`).
-15. **User Action** — Re-run the app and confirm the new screen + data/preference/permission behave as expected on a device.
+9. **Agent Action** — Run the **`run-quality-gates`** skill (`spotlessApply`/`spotlessCheck`, `:shared:jvmTest :shared:testAndroidHostTest`, `:androidApp:assembleDebug`).
+10. **User Action** — Re-run the app and confirm your features behave as expected on a device.
 
 ---
 

--- a/skills/getting-started/progress-template.md
+++ b/skills/getting-started/progress-template.md
@@ -22,19 +22,18 @@
 - [ ] **Validation** — App still builds after the rename.
 
 ## C. Define the product
-- [ ] **Agent** — Fill `AiGuidelines/project/prd.md`.
-- [ ] **Agent** — Fill `AiGuidelines/project/user_flow.md`.
+- [ ] **Agent** — Product defined by the `new-app` skill: `prd.md`, `user_flow.md`, `ui_ux.md` filled + confirmed.
+- [ ] **Agent** — App name/id decided; deferred decisions marked `TODO(<phase>)` in `root/AppConfiguration.kt`.
 
-## D. Local loop
-- [ ] **Agent** — Add a screen (`new-screen` skill) and implement its UI.
-- [ ] **Agent** — Persist a model locally (`new-local-model` skill).
-- [ ] **Agent** — Add a network request (`add-api-service` skill).
-- [ ] **Agent** — Store a setting (`save-preferences` skill).
-- [ ] **Agent** — Request a device permission (`add-permission` skill).
+## D. Build your features — `build-features`
+> Per-feature status lives in **`PROGRESS_FEATURES.md`** (repo root), not here. This is just the gate.
+- [ ] **Agent** — Plan derived from `prd.md`/`user_flow.md`, confirmed, and written to `PROGRESS_FEATURES.md`.
+- [ ] **Agent** — Every model + screen in `PROGRESS_FEATURES.md` is checked off.
+- [ ] **Agent** — Shipped onboarding + paywall screens branded to this product.
 
 ## E. Validate
 - [ ] **Agent** — Run quality gates (`run-quality-gates` skill).
-- [ ] **User** — Re-run the app; confirm new screen/data/preference/permission work on a device.
+- [ ] **User** — Re-run the app; confirm your features work on a device.
 
 ## Gate
 - [ ] App launches on at least one platform and shows the Home screen; quality gates pass.

--- a/skills/growth/SKILL.md
+++ b/skills/growth/SKILL.md
@@ -63,11 +63,14 @@ Verify: `./scripts/check_env.sh --phase growth`.
   token (logged as `Firebase onNewToken`). **Stop and confirm.**
 - **Validation** — The test push is received on a real device.
 
-### 3. Polish onboarding — `design-onboarding`
-- **Agent Action** — Read the `design-onboarding` skill. Fill the `TAILOR PER APP` markers in
-  `AiGuidelines/project/onboarding.md` (goal-capture question, first-taste moment, permission
-  priming), then build/refine the onboarding screens via the `new-screen` skill. Tie the
-  notification-permission priming step to step 2.
+### 3. Optimize onboarding — `design-onboarding`
+
+Onboarding was designed and built in Phase 1 (`new-app` wrote `onboarding.md`, `build-features` branded
+the screens). This step **optimizes activation**, it doesn't design from scratch.
+
+- **Agent Action** — Read the `design-onboarding` skill. Instrument each step with screen-view/funnel
+  events, tie the **notification-permission priming** to step 2, and refine the copy against real
+  drop-off. If `AiGuidelines/project/onboarding.md` still has `TAILOR PER APP` markers, fill them now.
 - **Validation** — Onboarding runs end to end; screen-view events for each step land in DebugView.
 
 ### 4. Add virality + review loops — `add-virality-loop`

--- a/skills/monetization/SKILL.md
+++ b/skills/monetization/SKILL.md
@@ -57,15 +57,18 @@ Verify: `./scripts/check_env.sh --phase monetization`.
 
 ## Ordered checklist
 
-### 1. Design the offer
+### 1. Complete the offer — the numbers
 
-- [ ] **Agent Action** — Run the **`design-paywall`** skill. This hands the developer the paywall
-      designer role prompt and the `paywall.md` fill-in template so they author the offer
-      architecture (primary model, prices, trial framing, credit packs) *before* any product is
-      created. Products are shaped by the offer, so this comes first.
-- [ ] **User Action** — Fill in the `TAILOR PER APP` blanks in `AiGuidelines/project/paywall.md`
-      (primary model, monthly/annual/lifetime prices, trial length, credit-pack sizes).
-- [ ] **Validation** — `AiGuidelines/project/paywall.md` has no remaining `TAILOR PER APP` markers.
+The **primary model + benefit copy** were already decided in Phase 1 (`new-app` / `build-features`), and
+the paywall has been running on the **mock provider** since then. What's missing are the numbers, which
+shape the store products — so settle them before creating any product.
+
+- [ ] **Agent Action** — Run the **`design-paywall`** skill and open `AiGuidelines/project/paywall.md`.
+      The primary model should already be filled; the remaining blanks are marked `TODO(monetization)`.
+- [ ] **User Action** — Fill the remaining `TAILOR PER APP` blanks: **prices & packages**
+      (monthly/annual/lifetime), **trial length**, **credit-pack sizes**.
+- [ ] **Validation** — `AiGuidelines/project/paywall.md` has no remaining `TAILOR PER APP` /
+      `TODO(monetization)` markers.
 
 ### 2. Set up subscriptions
 

--- a/skills/new-app/SKILL.md
+++ b/skills/new-app/SKILL.md
@@ -83,7 +83,7 @@ right phase picks it up. Everything here is **safe to defer** — the app runs w
 | Does the app have **premium (paid) features**? | `root/AppConfiguration.kt` → `PREMIUM_FEATURES_ENABLED` | `true` ✅ (paywall + credits available; app still free to download) |
 | **Subscription provider** | `MobileApp/gradle.properties` → `SUBSCRIPTION_PROVIDER` | `ADAPTY` ✅ — **mock provider runs until a real key is set, so no account is needed now** |
 | **Google/Apple sign-in**? | `AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED` | `false` ✅ (anonymous auth is enough; revisit in `integrations`) |
-| **Backend / AI proxy** | `AppConfiguration.CLOUD_FUNCTIONS_URL` | `""` ✅ (direct mode works without Firebase; set in `integrations`) |
+| **Backend / AI proxy** | `AppConfiguration.CLOUD_FUNCTIONS_URL` | `""` ✅ — **if the app uses AI**, direct mode works right now with **no Firebase**: put `OPENAI_API_KEY` / `REPLICATE_API_KEY` in `MobileApp/local.properties` and leave this blank. The proxy (keys off-device) comes in `integrations` before you publish. |
 | **Legal URLs, support email, App Store id** | `AppConfiguration.{URL_PRIVACY_POLICY, URL_TERMS_CONDITIONS, CONTACT_EMAIL, APPSTORE_APP_ID}` | leave as-is ✅ — **required only to publish** |
 
 For every **deferred** item, leave a marker on the field in `root/AppConfiguration.kt` so the owning

--- a/skills/new-app/SKILL.md
+++ b/skills/new-app/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: new-app
+description: Turn a raw app idea into a defined product — interview the developer, write prd.md / user_flow.md / ui_ux.md, decide the app name + id, and record deferred config decisions — then hand off to getting-started to build it. Use when the developer says "build me a <X> app", "I want to build …", "start a new app", or arrives with an app idea before any product docs exist.
+---
+
+# New app — from idea to a defined product
+
+**Goal:** turn a raw idea ("build me a habit tracker") into a **defined product** the rest of the
+journey can build from. This skill writes **documents and decisions only — no app code**.
+
+**Zero setup required.** Phase 1 needs **no Firebase, no Adapty/RevenueCat account, no Play/App Store
+account**. The kit ships a **mock subscription provider** (the paywall + purchase + unlock flow all work
+with no keys) and a direct-mode AI path. Every account-creating decision is **deferred** to the phase
+that actually needs it. Say so up front — it's the reason the developer can start in minutes.
+
+## How to ask (follow this exactly)
+
+- **Never ask an open-ended question.** Every question offers **concrete options** with one marked
+  **✅ recommended**, plus an escape hatch: *"decide for me"* or *"later"*.
+- Ask in **small batches** (2–3 at a time), not a wall of questions.
+- **STOP after each batch** and wait for the answer. Never invent the developer's product for them.
+- If the developer says *"you decide"* — take the ✅ recommended option and tell them what you picked.
+
+## Steps
+
+### 1. Interview the idea — **Agent asks / User answers**
+
+Adopt the role in [`AiGuidelines/agents/product_designer.md`](../../AiGuidelines/agents/product_designer.md)
+(raw idea → development-ready PRD). Ask about:
+
+1. **Core loop** — what does the user do on a typical day? (offer 2–3 interpretations of their idea, ✅ one)
+2. **Target audience** — who is it for? (offer options)
+3. **Pain points** — the top 3 problems this app resolves (propose 3, ✅, let them edit)
+4. **MVP scope** — which 3–5 features ship first? (propose a list, ✅ recommended, let them cut/add)
+5. **First-taste moment** — the one moment onboarding should deliver value in (propose 2, ✅)
+6. **Monetization intent** — free · subscription (✅ recommended) · credits/consumables · ads · decide later
+7. **UI direction** — visual style/vibe (offer 2–3 directions; see
+   [`AiGuidelines/agents/uiux_strategy.md`](../../AiGuidelines/agents/uiux_strategy.md) and
+   [`AiGuidelines/creative/`](../../AiGuidelines/creative/))
+
+Derive everything else (onboarding pattern, permission framing) yourself from these answers and state
+what you chose — don't ask more questions than the list above.
+
+### 2. Name + app id — **Agent suggests / User picks**
+
+- If the developer has no name, **suggest 3** with one ✅ recommended.
+- Derive the app id from it: `com.<org>.<appname>` (lowercase, dot-separated).
+- **Do not run the rebrand here** — `getting-started` does that with the
+  **`refactor-package`** skill. Just record the decided name + id and pass them along.
+
+### 3. Write the product docs — **Agent Action**, then User confirms
+
+These ship blank (just a heading) — author them fully from the interview:
+
+| File | Role prompt to use |
+|---|---|
+| [`AiGuidelines/project/prd.md`](../../AiGuidelines/project/prd.md) | `agents/product_designer.md` — goal, audience, core features, monetization, competitors |
+| [`AiGuidelines/project/user_flow.md`](../../AiGuidelines/project/user_flow.md) | `agents/user_flow_architect.md` — screen map + navigation paths |
+| [`AiGuidelines/project/ui_ux.md`](../../AiGuidelines/project/ui_ux.md) | `agents/uiux_strategy.md` — colors, typography, motion, design direction |
+
+**Also fill these two now** — the kit already ships an onboarding flow and a paywall, so they'd
+otherwise show boilerplate copy about the wrong product on first run. Fill the `TAILOR PER APP` blanks:
+
+| File | Fill now | Leave for later |
+|---|---|---|
+| [`AiGuidelines/project/onboarding.md`](../../AiGuidelines/project/onboarding.md) (`agents/onboarding_designer.md`) | **all of it** — pattern + why, goal-capture question(s), first-taste moment, permission benefit framing, top-3 pain points. It's the first thing every user sees = MVP UX. | — |
+| [`AiGuidelines/project/paywall.md`](../../AiGuidelines/project/paywall.md) (`agents/paywall_designer.md`) | **primary model + why** (from the monetization answer) | **prices & packages**, **trial length**, **pack sizes** → mark `TODO(monetization)` — you set these in Phase 4 when the store products are created |
+
+You can design **and test** the whole paywall now — the mock provider runs the paywall → purchase →
+unlock flow with no account and no keys. Only the real provider/products wait for Phase 4.
+
+Then **summarize the product back in a few lines and get an explicit confirm** before continuing.
+
+> `virality_loops.md` keeps its `TAILOR PER APP` markers — that's genuinely Phase 5 (`add-virality-loop`).
+
+### 4. Decisions checkpoint — **Agent asks / User picks or defers**
+
+Ask each with options + ✅ recommended + *"later"*. Record the answer immediately as described, so the
+right phase picks it up. Everything here is **safe to defer** — the app runs without any of it.
+
+| Decision | Where it goes | Default if deferred |
+|---|---|---|
+| Does the app have **premium (paid) features**? | `root/AppConfiguration.kt` → `PREMIUM_FEATURES_ENABLED` | `true` ✅ (paywall + credits available; app still free to download) |
+| **Subscription provider** | `MobileApp/gradle.properties` → `SUBSCRIPTION_PROVIDER` | `ADAPTY` ✅ — **mock provider runs until a real key is set, so no account is needed now** |
+| **Google/Apple sign-in**? | `AppConfiguration.AUTH_SOCIAL_LOGIN_ENABLED` | `false` ✅ (anonymous auth is enough; revisit in `integrations`) |
+| **Backend / AI proxy** | `AppConfiguration.CLOUD_FUNCTIONS_URL` | `""` ✅ (direct mode works without Firebase; set in `integrations`) |
+| **Legal URLs, support email, App Store id** | `AppConfiguration.{URL_PRIVACY_POLICY, URL_TERMS_CONDITIONS, CONTACT_EMAIL, APPSTORE_APP_ID}` | leave as-is ✅ — **required only to publish** |
+
+For every **deferred** item, leave a marker on the field in `root/AppConfiguration.kt` so the owning
+phase can find it:
+
+```kotlin
+// TODO(publish): your live privacy policy URL — stores reject placeholders (see `publishing` skill)
+const val URL_PRIVACY_POLICY = ""
+```
+
+Use `TODO(integrations)` / `TODO(publish)` / `TODO(monetization)` to name the phase that resolves it.
+
+### 5. Hand off — **Agent Action**
+
+Product is defined. **Continue straight into the [`getting-started`](../getting-started/SKILL.md)
+guide** (don't make the developer ask) — it installs prereqs, runs the app, rebrands it with the name
+and id decided in step 2, and builds the MVP features via **`build-features`**.
+
+---
+
+## Validation gate (new-app done)
+
+> **`prd.md`, `user_flow.md`, and `ui_ux.md` are filled and confirmed; app name + id decided;
+> deferred decisions recorded as `TODO(<phase>)` markers.**
+
+Then run **`getting-started`**. Nothing here required a single account or API key.

--- a/skills/run-the-app/SKILL.md
+++ b/skills/run-the-app/SKILL.md
@@ -53,3 +53,9 @@ Do NOT run iOS builds for routine validation — they are slow. Only when the ch
 - Slowest builds are the first one (dependency + JDK download) and iOS — this is expected.
 
 Desktop (`:desktopApp:run`) is the quickest sanity check that the app builds and shows the Home screen.
+
+## Next
+
+Once it runs, you're at step A of the **`getting-started`** guide — continue there: rebrand with
+**`refactor-package`**, then build your features with **`build-features`**. If you don't have a product
+defined yet (`AiGuidelines/project/prd.md` is still blank), start with the **`new-app`** skill.

--- a/skills/run-the-app/SKILL.md
+++ b/skills/run-the-app/SKILL.md
@@ -11,11 +11,17 @@ All gradle commands run from `MobileApp/`.
 
 - **JDK 17+** (first run also downloads the JetBrains JDK + Compose — expect a slow initial build).
 - **Android SDK** installed (Android Studio bundles it).
-- **`sdk.dir`** set in `MobileApp/local.properties`:
+- **`sdk.dir`** set in `MobileApp/local.properties`. That file is gitignored, so a fresh clone has none —
+  copy the committed template and set the one value everyone needs:
+  ```bash
+  cp MobileApp/local.properties.example MobileApp/local.properties   # then edit sdk.dir
+  ```
   ```properties
   sdk.dir=/Users/you/Library/Android/sdk
   ```
-  Without this, any Android task fails immediately with "SDK location not found".
+  Without this, any Android task fails immediately with "SDK location not found". Every other key in the
+  template is optional and phase-tagged (`[P1]`…`[P5]`) — leave them blank for now; see
+  `configure-environment`.
 - **JetBrains Kotlin Multiplatform plugin** in Android Studio (`Settings → Plugins → Marketplace →` search "Kotlin Multiplatform", install, restart). This is what surfaces the non-Android run targets — without it Android Studio shows only the **Android** target.
 - iOS also needs Xcode (macOS only).
 


### PR DESCRIPTION
## Why

Today, if a developer says *"build me a habit tracker"*, nothing routes them into the journey. If `getting-started` does fire, it runs the app, rebrands, then **invents a PRD itself** (no interview), and Phase 1's "local loop" is **generic demo scaffolding** — add *a* screen, *a* model. You end up with a rebranded template, not your app. The `product_designer.md` role prompt existed but **no skill referenced it**.

This makes the flow deterministic and low-friction: the agent interviews, defines the product, then builds it — with **no external accounts** until the phase that needs them.

## New skills

**`new-app`** — the entry point. Triggers on "build me a &lt;X&gt; app".
- Interviews with **options + a ✅ recommendation** (never open-ended), batched, stopping for answers
- Decides app name/id (suggests 3), writes `prd.md` / `user_flow.md` / `ui_ux.md` / `onboarding.md` + the paywall model
- **Decisions checkpoint** — every account-creating choice deferrable with a default
- Hands straight off to `getting-started` (agent auto-chains; user types nothing)
- Wires the previously **orphaned** `product_designer`, `user_flow_architect`, `uiux_strategy`, `onboarding_designer`, `paywall_designer` prompts

**`build-features`** — builds your *real* screens/models from the PRD, and brands the onboarding + paywall screens the kit already ships. Reusable later ("add streaks"). Flags that the generator scripts patch shared files (`Routes.kt`, `AppNavigation.kt`, `Di.kt`, `AppDatabase.kt`) so **scaffolding must run sequentially**; only per-screen work fans out.

## Resumability

**`PROGRESS_FEATURES.md`** (repo root, committed) records what's *actually built* — per model, per screen, plus branded onboarding/paywall. **Resume rule:** read it first, continue from the first unchecked item, tick as you go. Previously a whole MVP collapsed into 4 generic checkboxes, so a stopped session had to guess.

Phase files keep tracking guide steps; `getting-started` section D is now a **gate** over `PROGRESS_FEATURES.md` rather than duplicating it.

## Phase corrections

The kit **ships** `screens/onboarding` and `screens/paywall`, but design was deferred to Phase 4/5 — i.e. *after publishing*. So Phase 1 showed boilerplate about the wrong product.

| | Phase 1 (now) | Phase 4/5 (still) |
|---|---|---|
| `onboarding.md` | all markers — pattern, goal-capture, first-taste, priming, pain points | growth = *optimize* activation |
| `paywall.md` | primary model + benefit copy (**mock provider = testable, zero accounts**) | monetization = **the numbers** (prices, trial, packs) |

`AppConfiguration.kt` gains `TODO(publish)` / `TODO(integrations)` markers as the visible deferred-config checklist. (`SUBSCRIPTION_PROVIDER` stays in `gradle.properties` — that file forbids naming a provider.)

## Result

`new-app` (PRD + decisions) → `getting-started` (run → rebrand → `build-features` → validate) → `integrations` → `publishing` → `monetization` → `growth` — resumable at any point, zero accounts through Phase 1.

`AGENTS.md` documents the progress files + resume rule so agents pick it up as ambient context.