### PR TITLE
Make UI verification fast and accurate for agents 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ MobileApp/
 │   ├── src/jsMain/          # js createSQLiteWorker() actual (js("…") worker factory)
 │   ├── src/nonWebMain/      # Code shared across non-web platforms (FileManager.nonWeb, etc.)
 │   ├── src/jvmMain/         # Desktop DatabaseProvider + Platform.jvm.kt etc.
-│   ├── src/commonTest/      # Shared tests (screentest/ for UI tests)
+│   ├── src/commonTest/      # Shared tests (JVM + Android host)
 │   ├── src/jvmTest/         # JVM-only tests (e.g. Compose UI tests via runComposeUiTest)
 │   ├── src/androidHostTest/ # Robolectric host tests + optional Roborazzi screenshot tooling
 │   └── src/commonMain/.../util/StoreScreenshot.kt # @StoreScreenshot annotation + StoreDevice enum
@@ -126,8 +126,9 @@ All Gradle commands run from `MobileApp/`.
 
 ### Test layout
 - Unit / Flow / ViewModel tests: `shared/src/commonTest/kotlin/`. Use `kotlinx-coroutines-test` for `runTest` + `StandardTestDispatcher`/`UnconfinedTestDispatcher`. No Turbine — collect `Flow` emissions via `launch { flow.toList(emissions) }` if needed.
-- Compose UI tests: `shared/src/commonTest/screentest/` (multiplatform via `runComposeUiTest`) for tests runnable on both JVM and Android host, or `shared/src/jvmTest/` for JVM-only Compose UI tests.
-- Screenshot tests (optional, local only — NOT a PR gate, goldens are not committed): Roborazzi auto-generates a parameterized Robolectric test from the `roborazzi { generateComposePreviewRobolectricTests { … } }` block in `shared/build.gradle.kts`. Record baselines with `./gradlew :shared:recordRoborazziAndroidHostTest`, compare with `./gradlew :shared:verifyRoborazziAndroidHostTest`.
+- Compose UI tests: `shared/src/commonTest/kotlin/` (multiplatform via `runComposeUiTest`, runs on both JVM and Android host) or `shared/src/jvmTest/kotlin/` for JVM-only ones. Screens expose a **pure `(uiState, onUiEvent)` overload** so they render with no ViewModel/Koin — see `SampleComposeUiTest` for the template, and the **`verify-ui`** skill.
+- Screenshot tests (optional, local only — NOT a PR gate, goldens are not committed): **every `@Preview`** under `com.kotlinfoundation.koko` is snapshotted by the parameterized `PreviewScreenshotTest` (`shared/src/androidHostTest/`), which discovers previews via ComposablePreviewScanner. Record with `./gradlew :shared:recordRoborazziAndroidHostTest` → PNGs in `shared/src/androidHostTest/snapshots/`; compare with `./gradlew :shared:verifyRoborazziAndroidHostTest`.
+- Tests run on a **JDK 21** JVM (`tasks.withType<Test>` in `shared/build.gradle.kts`) while code compiles against 17. Robolectric loads real dependency bytecode and `filekit` ≥ 0.14 ships Java 21 class files, so a 17 test JVM fails the preview scan with `UnsupportedClassVersionError`. The foojay resolver provisions the JDK automatically.
 
 ### `@Preview` annotation
 Always use `androidx.compose.ui.tooling.preview.Preview`, NOT `org.jetbrains.compose.ui.tooling.preview.Preview` (the latter is deprecated as of CMP 1.10 and not discovered by ComposablePreviewScanner). The multiplatform-aware AndroidX import comes from `org.jetbrains.compose.ui:ui-tooling-preview` (already wired in `shared` and `designsystem`).
@@ -363,7 +364,7 @@ Two layers:
 - **P3** `generate-app-icons`, `bump-version`, `setup-signing`, `store-screenshots`, `setup-appstore-connect`, `setup-google-play`, `publish-release`
 - **P4** `design-paywall`, `setup-subscriptions`, `enable-credits`, `enable-ads`
 - **P5** `setup-analytics`, `enable-notifications`, `design-onboarding`, `add-virality-loop`
-- **Cross-phase** `run-quality-gates`
+- **Cross-phase** `verify-ui` (behaviour via headless Compose tests + appearance via a rendered PNG), `run-quality-gates`
 
 ### Screen Generation
 **Whenever the user asks for a new screen, run this from `MobileApp/`** instead of hand-creating files:

--- a/MobileApp/shared/build.gradle.kts
+++ b/MobileApp/shared/build.gradle.kts
@@ -216,6 +216,18 @@ tasks.withType<Test>().configureEach {
         "generateStoreScreenshots",
         providers.gradleProperty("generateStoreScreenshots").orElse("false").get(),
     )
+
+    // Run tests on JDK 21 while everything still COMPILES against 17 (jvmToolchain(17)).
+    // Robolectric loads real dependency bytecode, and filekit >= 0.14 ships Java 21 class
+    // files (major 65). On a 17 test JVM the preview scanner dies with
+    // `UnsupportedClassVersionError: io/github/vinceglb/filekit/PlatformFile`, which takes
+    // out the whole Roborazzi run. The foojay resolver in settings.gradle.kts provisions
+    // the JDK automatically, so no manual install is needed.
+    javaLauncher.set(
+        javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(21))
+        },
+    )
 }
 
 tasks.register("generateStoreScreenshots") {

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/onboarding/OnBoardingScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/onboarding/OnBoardingScreen.kt
@@ -48,6 +48,26 @@ fun OnBoardingScreen(
         }
     }
 
+    OnBoardingScreen(
+        modifier = modifier,
+        style = style,
+        uiState = uiState,
+        onUiEvent = viewModel::onUiEvent,
+    )
+}
+
+/**
+ * Pure overload — no ViewModel, so it renders from plain state in
+ * `runComposeUiTest` and `@Preview`. Navigation side effects stay in the
+ * ViewModel overload above.
+ */
+@Composable
+fun OnBoardingScreen(
+    modifier: Modifier = Modifier,
+    style: OnBoardingScreenStyle,
+    uiState: OnBoardingUiState,
+    onUiEvent: (OnBoardingUiEvent) -> Unit,
+) {
     Crossfade(
         targetState = uiState.isLoading,
         animationSpec = tween(durationMillis = 500),
@@ -62,7 +82,7 @@ fun OnBoardingScreen(
                     OnBoardingScreenVariation1(
                         modifier = Modifier.fillMaxSize(),
                         uiState = uiState,
-                        onUiEvent = viewModel::onUiEvent,
+                        onUiEvent = onUiEvent,
                     )
                 }
 
@@ -70,7 +90,7 @@ fun OnBoardingScreen(
                     OnBoardingScreenVariation2(
                         modifier = Modifier.fillMaxSize(),
                         uiState = uiState,
-                        onUiEvent = viewModel::onUiEvent,
+                        onUiEvent = onUiEvent,
                     )
                 }
             }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/onboarding/OnBoardingScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/onboarding/OnBoardingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kotlinfoundation.koko.designsystem.components.LogoImage
 import com.kotlinfoundation.koko.designsystem.theme.AppTheme
@@ -115,5 +116,33 @@ private fun SplashLogo(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center,
     ) {
         LogoImage(modifier = Modifier.scale(scale))
+    }
+}
+
+// Snapshotted by PreviewScreenshotTest — `./gradlew :shared:recordRoborazziAndroidHostTest`
+// renders these to shared/src/androidHostTest/snapshots/. See the `verify-ui` skill.
+// `isLoading = false` skips the splash so the actual onboarding content renders.
+
+@Preview
+@Composable
+private fun OnBoardingScreenStyle1Preview() {
+    AppTheme {
+        OnBoardingScreen(
+            style = OnBoardingScreenStyle.STYLE1,
+            uiState = OnBoardingUiState(isLoading = false),
+            onUiEvent = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun OnBoardingScreenStyle2Preview() {
+    AppTheme {
+        OnBoardingScreen(
+            style = OnBoardingScreenStyle.STYLE2,
+            uiState = OnBoardingUiState(isLoading = false),
+            onUiEvent = {},
+        )
     }
 }

--- a/MobileApp/shared/src/jvmTest/kotlin/com/kotlinfoundation/koko/example/SampleComposeUiTest.kt
+++ b/MobileApp/shared/src/jvmTest/kotlin/com/kotlinfoundation/koko/example/SampleComposeUiTest.kt
@@ -1,60 +1,61 @@
 package com.kotlinfoundation.koko.example
 
-import androidx.compose.foundation.clickable
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import com.kotlinfoundation.koko.designsystem.theme.AppTheme
+import com.kotlinfoundation.koko.presentation.screens.home.HomeScreen
+import com.kotlinfoundation.koko.presentation.screens.home.HomeUiEvent
+import com.kotlinfoundation.koko.presentation.screens.home.HomeUiState
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
 /**
- * Demonstrates a multiplatform Compose UI test using the new `runComposeUiTest` API
- * from `org.jetbrains.compose.ui:ui-test`. Runs headlessly on JVM as part of
- * `:shared:jvmTest`.
+ * Template for verifying a REAL app screen headlessly — copy this shape for new screens.
+ *
+ * How it works: every screen has a **pure overload** taking `uiState` + `onUiEvent` instead of a
+ * ViewModel, so a test can render it with no Koin, no ViewModel, no device and no browser. Queries
+ * go through Compose's semantics tree (the same data a screen reader uses), so
+ * `onNodeWithText("42")` matches real rendered text rather than a pixel guess.
+ *
+ * Run: `./gradlew :shared:jvmTest` — ~2s warm, and part of the PR gate.
+ *
+ * This covers behaviour. For *visual* checks (layout, spacing, theming) add a `@Preview` — it is
+ * snapshotted automatically by `PreviewScreenshotTest`; see the `verify-ui` skill.
  */
 @OptIn(ExperimentalTestApi::class)
 class SampleComposeUiTest {
     @Test
-    fun `clicking a labeled clickable invokes the callback exactly once`() = runComposeUiTest {
-        var clickCount = 0
-
+    fun `home screen renders the credit balance from uiState`() = runComposeUiTest {
         setContent {
-            ClickableLabel(
-                text = "Tap me",
-                onClick = { clickCount++ },
-            )
+            AppTheme {
+                HomeScreen(uiState = HomeUiState(creditBalance = 42), onUiEvent = {})
+            }
         }
 
-        onNodeWithText("Tap me")
+        // The toolbar credit chip reflects state directly.
+        onNodeWithText("42").assertExists()
+    }
+
+    @Test
+    fun `clicking the credit chip emits OnClickToolbarCredits`() = runComposeUiTest {
+        val events = mutableListOf<HomeUiEvent>()
+
+        setContent {
+            AppTheme {
+                HomeScreen(uiState = HomeUiState(creditBalance = 7), onUiEvent = { events += it })
+            }
+        }
+
+        onNodeWithText("7")
             .assertIsEnabled()
             .performClick()
 
-        assertTrue(clickCount == 1, "expected exactly one click, got $clickCount")
-    }
-
-    @Composable
-    private fun ClickableLabel(
-        text: String,
-        onClick: () -> Unit,
-    ) {
-        Text(
-            text = text,
-            modifier =
-            Modifier
-                .semantics {
-                    role = Role.Button
-                    contentDescription = text
-                }
-                .clickable(onClick = onClick),
+        assertTrue(
+            events.any { it is HomeUiEvent.OnClickToolbarCredits },
+            "expected OnClickToolbarCredits, got $events",
         )
     }
 }

--- a/skills/README.md
+++ b/skills/README.md
@@ -122,4 +122,5 @@ no-Firebase AI path, so Firebase / Adapty / store accounts wait until the phase 
 
 | Skill | Use when |
 |---|---|
+| [verify-ui](verify-ui/SKILL.md) | Confirming a screen behaves (headless Compose test, ~2s) and looks right (render a PNG and look at it) |
 | [run-quality-gates](run-quality-gates/SKILL.md) | Validating changes before commit/PR (lint, tests, build) |

--- a/skills/build-features/SKILL.md
+++ b/skills/build-features/SKILL.md
@@ -100,6 +100,12 @@ the developer will hit them the moment they run the app, so fix them now, not at
 
 ## 5. Validate — **Agent Action → User confirms**
 
+Verify each screen you built with the **`verify-ui`** skill *before* handing back:
+- **Behaviour** — a headless `runComposeUiTest` against the screen's pure `(uiState, onUiEvent)`
+  overload (~2s): state renders, clicks emit the right events.
+- **Appearance** — add a `@Preview`, run `./gradlew :shared:recordRoborazziAndroidHostTest`, and
+  **look at the PNG**. This is what catches layout/spacing/theming mistakes that tests pass right over.
+
 ```bash
 ./gradlew spotlessApply
 ```

--- a/skills/design-onboarding/SKILL.md
+++ b/skills/design-onboarding/SKILL.md
@@ -48,3 +48,7 @@ Onboarding runs end to end, captures the goal, delivers a first taste, and prime
 it — do that in **Phase 1** (`build-features`), since it's the first thing every user sees. The
 **`growth`** phase revisits it later to *optimize* activation (funnel events, priming, A/B copy) — not
 to design it from scratch.
+
+**See what it looks like:** use the **`verify-ui`** skill to render each onboarding page to a PNG
+(`./gradlew :shared:recordRoborazziAndroidHostTest` → `snapshots/*OnBoarding*.png`) and look at it.
+That's also how to answer "show me the onboarding screens" — no emulator needed.

--- a/skills/design-paywall/SKILL.md
+++ b/skills/design-paywall/SKILL.md
@@ -83,5 +83,6 @@ The kit ships a working paywall, so it shows boilerplate until you brand it:
 
 ## Related skills
 
-`setup-subscriptions` · `enable-credits` · `store-screenshots` (paywall PNGs) ·
+`verify-ui` (render the paywall to a PNG and look at it — also how to answer "show me the paywall") ·
+`setup-subscriptions` · `enable-credits` · `store-screenshots` (paywall PNGs for the storefront) ·
 `monetization` (phase guide).

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -80,7 +80,7 @@ Verify: `./scripts/check_env.sh --phase getting-started`.
 
 ### E. Validate
 
-9. **Agent Action** — Run the **`run-quality-gates`** skill (`spotlessApply`/`spotlessCheck`, `:shared:jvmTest :shared:testAndroidHostTest`, `:androidApp:assembleDebug`).
+9. **Agent Action** — Verify the UI with the **`verify-ui`** skill (headless Compose test for behaviour ~2s + render a `@Preview` to a PNG and look at it), then run the **`run-quality-gates`** skill (`spotlessApply`/`spotlessCheck`, `:shared:jvmTest :shared:testAndroidHostTest`, `:androidApp:assembleDebug`).
 10. **User Action** — Re-run the app and confirm your features behave as expected on a device.
 
 ---

--- a/skills/new-screen/SKILL.md
+++ b/skills/new-screen/SKILL.md
@@ -32,7 +32,8 @@ Insertion points in those three files are marked with
 1. Edit the generated `entry<>` block in `AppNavigation.kt` to add the navigation callbacks the screen needs (`navigator.navigate(...)`, `navigator.goBack()`, ...).
 2. Implement the UI in the pure-composable overload; keep logic in the ViewModel.
 3. Feature folders contain **only** `*Screen.kt`, `*UiState.kt`, `*ViewModel.kt` — never a `*ScreenRoute.kt` (routes live in `Routes.kt`).
-4. Validate with the `run-quality-gates` skill.
+4. Verify it with the **`verify-ui`** skill — a headless Compose test for behaviour (the generated dual-overload makes this possible), plus a `@Preview` rendered to a PNG you can actually look at.
+5. Validate with the `run-quality-gates` skill.
 
 ---
 

--- a/skills/run-quality-gates/SKILL.md
+++ b/skills/run-quality-gates/SKILL.md
@@ -35,6 +35,7 @@ gates below will pass regardless.
 
 Rules:
 
+- **Changed UI?** These gates prove it compiles and behaves — they do **not** prove it *looks* right (screenshot tests aren't a PR gate). Use the **`verify-ui`** skill to render the screen to a PNG and check it.
 - Do NOT run iOS builds/tests for routine validation — they are slow. Only when the change is iOS-specific or the user asks.
 - Web check when web code changed: `./gradlew :shared:compileKotlinWasmJs :shared:compileKotlinJs`.
 - Quick iOS-code compile check without a full build: `./gradlew :shared:compileAppleMainKotlinMetadata`.

--- a/skills/store-screenshots/SKILL.md
+++ b/skills/store-screenshots/SKILL.md
@@ -34,6 +34,10 @@ Rules:
 - `@StoreScreenshot` previews are excluded from regression screenshot tests and only render when the script sets `-PgenerateStoreScreenshots=true` — don't try to run them via the normal test tasks.
 - The annotation + `StoreDevice` enum live at `shared/src/commonMain/.../util/StoreScreenshot.kt`.
 
+> **Just want to *see* a screen** (not produce storefront assets)? That's the **`verify-ui`** skill —
+> it renders any `@Preview` to a PNG at normal size. This skill is only for the huge, marketing-ready
+> storefront images.
+
 ---
 
 *Phase 3 · Publication — part of the [publishing](../publishing/SKILL.md) guide.*

--- a/skills/verify-ui/SKILL.md
+++ b/skills/verify-ui/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: verify-ui
+description: Verify a screen or component actually works — behaviour via headless Compose UI tests, and appearance by rendering it to a PNG and looking at it. Use after building or changing any UI, or when asked to check/verify/confirm a screen renders and behaves correctly.
+---
+
+# Verify UI — fast and accurate
+
+Two tools, two questions. Use both when you changed how something **looks**; the first alone is
+enough when you only changed **behaviour**.
+
+| Question | Tool | Cost |
+|---|---|---|
+| Does it *behave*? (state renders, clicks emit events) | `runComposeUiTest` | **~2s warm** |
+| Does it *look* right? (layout, spacing, theme) | Roborazzi → PNG you **read** | ~25s |
+
+Do **not** try to verify through the Web/wasm build. Compose renders to a `<canvas>`, so browser
+automation sees no DOM text and the app takes ~25s to paint before anything is queryable. It is
+strictly slower and less accurate than both tools above. All commands run from `MobileApp/`.
+
+## 1. Behaviour — `runComposeUiTest`
+
+Every screen has a **pure overload** taking `uiState` + `onUiEvent` instead of a ViewModel, so tests
+render it with no Koin, no ViewModel, no device. Queries run against Compose's semantics tree — the
+same data a screen reader uses — so you match real text, not pixels.
+
+Copy the shape in
+[`SampleComposeUiTest`](../../MobileApp/shared/src/jvmTest/kotlin/com/kotlinfoundation/koko/example/SampleComposeUiTest.kt):
+
+```kotlin
+@OptIn(ExperimentalTestApi::class)
+class MyScreenTest {
+    @Test
+    fun `renders state and emits the event`() = runComposeUiTest {
+        val events = mutableListOf<MyUiEvent>()
+        setContent {
+            AppTheme { MyScreen(uiState = MyUiState(count = 42), onUiEvent = { events += it }) }
+        }
+
+        onNodeWithText("42").assertExists()      // real rendered text
+        onNodeWithText("42").performClick()
+        assertTrue(events.any { it is MyUiEvent.OnClick })
+    }
+}
+```
+
+- Tests live in `shared/src/commonTest/kotlin/…` (runs on JVM **and** Android host) or
+  `shared/src/jvmTest/kotlin/…` (JVM only).
+- Run: `./gradlew :shared:jvmTest` — or one class:
+  `./gradlew :shared:jvmTest --tests '*MyScreenTest*'`.
+- Assert on **text/semantics**, never coordinates.
+
+> If a screen has no pure overload, add one (ViewModel overload collects state and delegates to it) —
+> that is the pattern the whole codebase uses, and it is what makes the screen testable at all.
+
+## 2. Appearance — Roborazzi, then **look at the PNG**
+
+**Any `@Preview` is automatically a screenshot test** — no test code to write. Add the preview, record,
+then *read the image*:
+
+```bash
+./gradlew :shared:recordRoborazziAndroidHostTest        # renders every @Preview
+```
+
+PNGs land in `shared/src/androidHostTest/snapshots/<Class>_<method>.png` (gitignored — goldens are
+local). **Open the PNG with your image-reading tool and confirm it looks right.** This is the step
+that catches what semantics cannot: overlap, clipping, wrong spacing, unreadable contrast.
+
+```kotlin
+@Preview
+@Composable
+private fun MyScreenPreview() {
+    AppTheme { MyScreen(uiState = MyUiState(count = 42), onUiEvent = {}) }
+}
+```
+
+To catch regressions against previously recorded goldens:
+
+```bash
+./gradlew :shared:verifyRoborazziAndroidHostTest        # fails on visual diff
+```
+
+Rules:
+- Import **`androidx.compose.ui.tooling.preview.Preview`**. The JetBrains one is not discovered.
+- `@StoreScreenshot`-tagged previews are storefront assets and are excluded here — see
+  `store-screenshots`.
+- Previews are scanned under package `com.kotlinfoundation.koko`.
+
+## 3. Finish
+
+Run the **`run-quality-gates`** skill (`spotlessApply`/`spotlessCheck`, tests, Android debug build)
+before declaring the change done.
+
+## Notes
+
+- Tests run on a **JDK 21** JVM while the code compiles against 17 (`shared/build.gradle.kts`).
+  Robolectric loads real dependency bytecode and `filekit` ≥ 0.14 ships Java 21 class files; on a 17
+  test JVM the preview scanner dies with `UnsupportedClassVersionError` and records nothing. Gradle
+  provisions the JDK automatically via the foojay resolver — don't "fix" this by lowering it back.
+- Screenshot tests are **not** a PR gate (goldens aren't committed), so run them locally when
+  appearance matters.

--- a/skills/verify-ui/SKILL.md
+++ b/skills/verify-ui/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: verify-ui
-description: Verify a screen or component actually works — behaviour via headless Compose UI tests, and appearance by rendering it to a PNG and looking at it. Use after building or changing any UI, or when asked to check/verify/confirm a screen renders and behaves correctly.
+description: Render any screen or component to a PNG you can look at or send, and verify its behaviour with headless Compose UI tests. Use after building/changing UI, when asked to check/verify/confirm a screen works — and whenever someone asks to SEE the UI ("show me the onboarding screens", "send me a picture/screenshot of the paywall", "what does the home screen look like?").
 ---
 
 # Verify UI — fast and accurate
+
+**Someone asked to *see* a screen** ("show me the onboarding screens", "send me a screenshot of the
+paywall")? You can produce that yourself — jump to [§2](#2-appearance--roborazzi-then-look-at-the-png):
+add a `@Preview` if none exists, run the record task, and read/attach the PNG. No emulator, no device,
+no manual screenshotting.
 
 Two tools, two questions. Use both when you changed how something **looks**; the first alone is
 enough when you only changed **behaviour**.
@@ -72,6 +77,20 @@ private fun MyScreenPreview() {
     AppTheme { MyScreen(uiState = MyUiState(count = 42), onUiEvent = {}) }
 }
 ```
+
+### Showing a screen to the developer
+
+When asked to **see** a screen (rather than verify it), same mechanism:
+
+1. Find the previews for it — they're named `<Class>_<method>.png`:
+   ```bash
+   ./gradlew :shared:recordRoborazziAndroidHostTest
+   ls shared/src/androidHostTest/snapshots/ | grep -i onboarding
+   ```
+2. If the screen has **no** `@Preview` yet, add one next to it (pure overload + `AppTheme`, as above),
+   re-record, and it appears.
+3. **Read the PNG** and describe/attach it. Multiple previews (e.g. each onboarding page, or
+   light/dark) each produce their own file.
 
 To catch regressions against previously recorded goldens:
 


### PR DESCRIPTION
Goal: give agents a verification loop that is **seconds, not minutes**, and grounded in semantics rather than pixels.

## The headline bug: Roborazzi recorded nothing

`recordRoborazziAndroidHostTest` failed outright — **0 PNGs**. The preview scanner died with `UnsupportedClassVersionError: io/github/vinceglb/filekit/PlatformFile`.

It's a **dependency regression**, not a toolchain mistake. Verified from the cached artifacts:

| filekit-core-android | `PlatformFile` bytecode | JDK 17? |
|---|---|---|
| **0.12.0** | major **55** (Java 11) | ✅ |
| **0.14.1** | major **65** (Java 21) | ❌ |

Robolectric loads real dependency bytecode, so on a Java 17 test JVM (major 61) any class touching filekit fails to load. `HomeScreen` has both `@Preview` and filekit types, so the whole scan aborted with `initializationError` and every preview was lost.

**Why nobody noticed:** `previews()` returns an empty list unless `roborazzi.test.record` is set — so `testAndroidHostTest` passed in 3s having rendered *nothing*.

**Fix:** run only the **test JVM on 21**, keep compiling against 17. Downgrading filekit isn't viable (`openCameraPicker`, `shareFileCommon`, `openFileSaver`, `saveImageToGallery` all in use). The foojay resolver already in `settings.gradle.kts` provisions the JDK — no manual install.

**Result: 36 preview PNGs recorded (was 0).**

## Fast + accurate verification

- **`OnBoardingScreen`** — added the pure `(uiState, onUiEvent)` overload. It was the only screen a test couldn't render without a ViewModel + Koin. (`RemotePaywallScreen` left alone — it wraps the provider's remote view.)
- **`SampleComposeUiTest`** — replaced the placeholder (which declared its own composable and tested *that*) with two tests against the **real `HomeScreen`**: state renders, click emits the event. **~2s warm.** It's the template to copy.
- **`verify-ui` skill** — behaviour via `runComposeUiTest`; appearance by recording a `@Preview` to a PNG and **reading it**. Every `@Preview` is snapshotted automatically, so visual checks cost no test code.

### Why not wasm/Playwright
Investigated and rejected, with evidence. Compose paints to a `<canvas>` inside a shadow root, so the DOM exposes **no text** (`role="button"` with `aria-label: null`), and the app needs **~25s to render** before anything is queryable. ~2min build + coordinate math vs **2.5s** headless. The skill documents this so it isn't re-litigated.

## "Show me the onboarding screens"

That's a *rendering* request. `verify-ui` now triggers on it and documents the flow.

The promise didn't hold when tested: **no screen had a plain `@Preview`** — the few that exist are `@StoreScreenshot`-tagged, which `PreviewScreenshotTest` excludes, so all 36 PNGs were design-system components. Added previews for **both onboarding styles** (possible now that the screen has a pure overload), `isLoading = false` so content renders instead of the splash. Both verified by eye.

## Wiring + doc fixes

`verify-ui` was reachable only from the index — **no UI-producing skill pointed at it**. Now referenced from `run-quality-gates`, `new-screen`, `build-features`, `design-onboarding`, `design-paywall`, `store-screenshots`, `getting-started`.

Corrected two stale `AGENTS.md` claims: `commonTest/screentest/` doesn't exist (tests are in `commonTest/kotlin/`), and there's no `generateComposePreviewRobolectricTests` block (`PreviewScreenshotTest` is hand-written). Documented the JDK 21 test JVM so it doesn't get "fixed" back to 17.

## Verification

`spotlessCheck`, `:shared:jvmTest`, `:shared:testAndroidHostTest`, `:androidApp:assembleDebug` all pass. Goldens stay gitignored.