### PR TITLE
Add previews for every screen, so agents can render any UI on demand

### DIFF
--- a/MobileApp/shared/src/androidHostTest/kotlin/com/kotlinfoundation/koko/screenshot/PreviewScreenshotTest.kt
+++ b/MobileApp/shared/src/androidHostTest/kotlin/com/kotlinfoundation/koko/screenshot/PreviewScreenshotTest.kt
@@ -12,11 +12,20 @@ import com.github.takahirom.roborazzi.RoborazziComposeOptions
 import com.github.takahirom.roborazzi.RoborazziComposePreviewTestCategory
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.github.takahirom.roborazzi.composeTestRule
+import com.kotlinfoundation.koko.data.source.featureflag.FeatureFlagManager
+import com.kotlinfoundation.koko.data.source.featureflag.NoImplFeatureFlagManager
+import com.kotlinfoundation.koko.util.AppUtil
 import com.kotlinfoundation.koko.util.StoreScreenshot
+import org.junit.AfterClass
+import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
@@ -68,6 +77,46 @@ class PreviewScreenshotTest(
     companion object {
         private const val PACKAGE_ROOT = "com.kotlinfoundation.koko"
         private const val GENERATE_STOREFRONT_FLAG = "generateStoreScreenshots"
+
+        /**
+         * A few composables reach into Koin via `koinInject<T>()` rather than taking the dependency
+         * as a parameter — e.g. the AdMob banner inside [HomeScreen] injects [FeatureFlagManager],
+         * and `HelpAndSupportScreen` injects [AppUtil]. Without a Koin context those previews fail
+         * with `KoinApplication has not been started`, and because previews share one JVM the
+         * failure depends on test order, which made it look intermittent.
+         *
+         * Start a minimal container with preview-safe stand-ins so every preview renders
+         * deterministically. Only bind what composables actually inject — this is not the app graph.
+         */
+        @BeforeClass
+        @JvmStatic
+        fun startKoinForPreviews() {
+            if (GlobalContext.getOrNull() != null) return
+            startKoin {
+                modules(
+                    module {
+                        single<FeatureFlagManager> { NoImplFeatureFlagManager }
+                        single<AppUtil> { PreviewAppUtil }
+                    },
+                )
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun stopKoinAfterPreviews() {
+            if (GlobalContext.getOrNull() != null) stopKoin()
+        }
+
+        private object PreviewAppUtil : AppUtil {
+            override fun getAppName(): String = "Koko"
+
+            override fun shareApp() = Unit
+
+            override fun openFeedbackMail() = Unit
+
+            override fun getAppVersionInfo(): String = "1.0.0"
+        }
 
         @JvmStatic
         @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")

--- a/MobileApp/shared/src/androidHostTest/kotlin/com/kotlinfoundation/koko/screenshot/PreviewScreenshotTest.kt
+++ b/MobileApp/shared/src/androidHostTest/kotlin/com/kotlinfoundation/koko/screenshot/PreviewScreenshotTest.kt
@@ -80,13 +80,17 @@ class PreviewScreenshotTest(
 
         /**
          * A few composables reach into Koin via `koinInject<T>()` rather than taking the dependency
-         * as a parameter — e.g. the AdMob banner inside [HomeScreen] injects [FeatureFlagManager],
-         * and `HelpAndSupportScreen` injects [AppUtil]. Without a Koin context those previews fail
-         * with `KoinApplication has not been started`, and because previews share one JVM the
-         * failure depends on test order, which made it look intermittent.
+         * as a parameter — the AdMob banner rendered by `HomeScreen` injects [FeatureFlagManager],
+         * and `HelpAndSupportScreen` injects [AppUtil]. Nothing else in the test suite starts Koin,
+         * so without this those previews fail with `KoinApplication has not been started`.
          *
-         * Start a minimal container with preview-safe stand-ins so every preview renders
-         * deterministically. Only bind what composables actually inject — this is not the app graph.
+         * Start one minimal container for the class with preview-safe stand-ins, and stop it after —
+         * the lifecycle Koin's testing docs ask for. Deliberately NOT `KoinTestRule`: that starts and
+         * stops per test method, which for a parameterized preview run means restarting a two-binding
+         * container ~50 times for no benefit. Reach for `koin-test` if a future test needs
+         * `declareMock` / `KoinTest.inject()`.
+         *
+         * Bind only what composables actually inject — this is not the app graph.
          */
         @BeforeClass
         @JvmStatic

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/account/AccountScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/account/AccountScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
@@ -241,5 +242,13 @@ private fun LogoutModalBottomSheet(
             color = AppTheme.colors.text.primary,
             style = AppTheme.typography.h5,
         )
+    }
+}
+
+@Preview
+@Composable
+private fun AccountScreenPreview() {
+    AppTheme {
+        AccountScreen(uiState = AccountUiState(), onUiEvent = {})
     }
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/creditbalance/CreditBalanceScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/creditbalance/CreditBalanceScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -332,4 +333,12 @@ private fun motivationalMessageRes(credits: Int): StringResource = when {
     credits == 1 -> Res.string.credit_motivational_one
     credits <= 5 -> Res.string.credit_motivational_low
     else -> Res.string.credit_motivational_plenty
+}
+
+@Preview
+@Composable
+private fun CreditBalanceScreenPreview() {
+    AppTheme {
+        CreditBalanceScreen(uiState = CreditBalanceUiState(), onUiEvent = {})
+    }
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/gallery/GalleryScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/gallery/GalleryScreen.kt
@@ -170,3 +170,11 @@ private fun GalleryStoreScreenshot_iPhone_en() {
         GalleryScreen(uiState = GalleryUiState(), onUiEvent = {})
     }
 }
+
+@Preview
+@Composable
+private fun GalleryScreenPreview() {
+    AppTheme {
+        GalleryScreen(uiState = GalleryUiState(), onUiEvent = {})
+    }
+}

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/generationresult/GenerationResultScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/generationresult/GenerationResultScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kotlinfoundation.koko.designsystem.components.AsyncImageWithShimmer
 import com.kotlinfoundation.koko.designsystem.components.CircularActionButton
@@ -152,6 +153,18 @@ private fun ActionButtons(
                 hapticFeedback.performHapticFeedback(HapticFeedbackType.Reject)
                 onUiEvent(GenerationResultUiEvent.OnClickReport)
             },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun GenerationResultScreenPreview() {
+    AppTheme {
+        GenerationResultScreen(
+            uiState = GenerationResultUiState(),
+            onUiEvent = {},
+            onNavigateToBack = {},
         )
     }
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/helpandsupport/HelpAndSupportScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/helpandsupport/HelpAndSupportScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import com.kotlinfoundation.koko.designsystem.components.ScreenWithToolbar
 import com.kotlinfoundation.koko.designsystem.components.SettingItemListContainer
 import com.kotlinfoundation.koko.designsystem.components.SettingsItemUiState
@@ -61,5 +62,13 @@ fun HelpAndSupportScreen(
                 }
             },
         )
+    }
+}
+
+@Preview
+@Composable
+private fun HelpAndSupportScreenPreview() {
+    AppTheme {
+        HelpAndSupportScreen(onNavigateBack = {})
     }
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/home/HomeScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/home/HomeScreen.kt
@@ -276,3 +276,11 @@ private fun HomeStoreScreenshot_iPhone_en() {
         HomeScreen(uiState = HomeUiState(creditBalance = 12), onUiEvent = {})
     }
 }
+
+@Preview
+@Composable
+private fun HomeScreenPreview() {
+    AppTheme {
+        HomeScreen(uiState = HomeUiState(creditBalance = 12), onUiEvent = {})
+    }
+}

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/PaywallScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/PaywallScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kotlinfoundation.koko.designsystem.components.DemoBanner
 import com.kotlinfoundation.koko.designsystem.components.LoadingProgress
@@ -115,5 +116,17 @@ fun PaywallScreen(
                 onDismiss = onDismiss,
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun PaywallScreenPreview() {
+    AppTheme {
+        PaywallScreen(
+            uiState = PaywallPreviewData.subscriptionState(),
+            onUiEvent = {},
+            onDismiss = {},
+        )
     }
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/creditpack/CreditPackPaywallScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/creditpack/CreditPackPaywallScreen.kt
@@ -331,3 +331,15 @@ private fun CreditPackPaywallStoreScreenshot_iPhone_en() {
         CreditPackPaywallScreen(uiState = PaywallPreviewData.creditPackState(), onUiEvent = {})
     }
 }
+
+@Preview
+@Composable
+private fun CreditPackPaywallScreenPreview() {
+    AppTheme {
+        CreditPackPaywallScreen(
+            uiState = PaywallPreviewData.creditPackState(),
+            onUiEvent = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/profile/ProfileScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/profile/ProfileScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
@@ -171,5 +172,16 @@ fun UserInputWithLabel(
             color = AppTheme.colors.text.primary,
         )
         userInput()
+    }
+}
+
+@Preview
+@Composable
+private fun ProfileScreenPreview() {
+    AppTheme {
+        ProfileScreen(
+            currentUser = User(id = "1", displayName = "Jane Doe", email = "jane@example.com"),
+            onUiEvent = {},
+        )
     }
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/signin/SignInScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/signin/SignInScreen.kt
@@ -71,6 +71,30 @@ fun SignInScreen(
 ) {
     val userRepository = koinInject<UserRepository>()
 
+    SignInScreen(
+        isSignIn = isSignIn,
+        modifier = modifier,
+        onSuccessfulSignIn = onSuccessfulSignIn,
+        onNavigateBack = onNavigateBack,
+        onOauthSigned = userRepository::onSuccessfulOauthSign,
+        continueAsGuest = userRepository::continueAsGuest,
+    )
+}
+
+/**
+ * Pure overload — the two account actions come in as lambdas instead of injecting
+ * [UserRepository], so this renders in `@Preview` and `runComposeUiTest` with no Koin.
+ * The ViewModel-less overload above wires the real repository.
+ */
+@Composable
+fun SignInScreen(
+    isSignIn: Boolean,
+    modifier: Modifier = Modifier,
+    onSuccessfulSignIn: () -> Unit,
+    onNavigateBack: () -> Unit,
+    onOauthSigned: () -> Unit,
+    continueAsGuest: suspend () -> Result<Unit>,
+) {
     val scrollState = rememberScrollState()
     LaunchedEffect(true) {
         scrollState.animateScrollTo(scrollState.maxValue, tween(500))
@@ -111,7 +135,7 @@ fun SignInScreen(
                 ) { result ->
                     result.onSuccess {
                         AppLogger.d("Successful sign in")
-                        userRepository.onSuccessfulOauthSign()
+                        onOauthSigned()
                         onSuccessfulSignIn()
                     }.onFailure { error ->
                         AppLogger.e("Error occurred while signing in, $error")
@@ -141,7 +165,7 @@ fun SignInScreen(
                 onClick = {
                     isGuestLoading = true
                     coroutineScope.launch {
-                        userRepository.continueAsGuest()
+                        continueAsGuest()
                             .onSuccess { onSuccessfulSignIn() }
                             .onFailure { error ->
                                 AppLogger.e("Continue as guest failed: ${error.message}")
@@ -225,8 +249,30 @@ private fun TitleText(modifier: Modifier, isSignIn: Boolean) {
     )
 }
 
-// No @Preview here yet: this screen calls `koinInject<UserRepository>()` internally, and
-// UserRepository is a concrete class with its own constructor dependencies, so a preview cannot
-// supply a stand-in the way FeatureFlagManager/AppUtil can (see PreviewScreenshotTest). To make
-// this previewable, extract a stateless overload that takes the sign-in state/callbacks as
-// parameters, the way the other screens do.
+@Preview
+@Composable
+private fun SignInScreenSignInPreview() {
+    AppTheme {
+        SignInScreen(
+            isSignIn = true,
+            onSuccessfulSignIn = {},
+            onNavigateBack = {},
+            onOauthSigned = {},
+            continueAsGuest = { Result.success(Unit) },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SignInScreenSignUpPreview() {
+    AppTheme {
+        SignInScreen(
+            isSignIn = false,
+            onSuccessfulSignIn = {},
+            onNavigateBack = {},
+            onOauthSigned = {},
+            continueAsGuest = { Result.success(Unit) },
+        )
+    }
+}

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/signin/SignInScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/signin/SignInScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kotlinfoundation.koko.data.repository.UserRepository
 import com.kotlinfoundation.koko.designsystem.components.AgreePrivacyPolicyTermsConditionsText
@@ -223,3 +224,9 @@ private fun TitleText(modifier: Modifier, isSignIn: Boolean) {
         style = AppTheme.typography.h3,
     )
 }
+
+// No @Preview here yet: this screen calls `koinInject<UserRepository>()` internally, and
+// UserRepository is a concrete class with its own constructor dependencies, so a preview cannot
+// supply a stand-in the way FeatureFlagManager/AppUtil can (see PreviewScreenshotTest). To make
+// this previewable, extract a stateless overload that takes the sign-in state/callbacks as
+// parameters, the way the other screens do.

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/subscriptions/SubscriptionsScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/subscriptions/SubscriptionsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kotlinfoundation.koko.designsystem.components.LoadingProgress
@@ -123,5 +124,13 @@ private fun SubscriptionsScreen(
                 },
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun SubscriptionsScreenPreview() {
+    AppTheme {
+        SubscriptionsScreen(uiState = SubscriptionsUiState(), onUiEvent = {})
     }
 }


### PR DESCRIPTION
Follow-up to #18. That PR unbroke Roborazzi and added the `verify-ui` skill, but only **onboarding** had a plain `@Preview` — so "show me the profile screen" still had no answer.

**13 of 14 screens now render to a PNG. 50 previews, 0 failures** (was 36 component-only).

## What's added

Previews for: account, credit balance, gallery, generation result, help & support, home, paywall, credit-pack paywall, profile, subscriptions, sign-in + sign-up.

Only `RemotePaywallScreen` is left out — it wraps the provider's remote view, so there's nothing local to render.

## Adding them surfaced a real bug in the screenshot suite

Compiling wasn't the bar; **rendering** was. Three previews failed with `KoinApplication has not been started`, because some composables reach into Koin instead of taking dependencies as parameters:

| Injected | By | Broke |
|---|---|---|
| `FeatureFlagManager` | AdMob banner | **HomeScreen** (renders a banner) |
| `AppUtil` | `HelpAndSupportScreen` | its preview |
| `UserRepository` | `SignInScreen` | its preview |

**Nothing in the suite ever started Koin** — it only passed before because no preview happened to need it.

`PreviewScreenshotTest` now starts one minimal container for the class with preview-safe stand-ins (the existing `NoImplFeatureFlagManager`, plus a small `AppUtil`) and stops it after. It binds only what composables actually inject — **not** the app graph.

### Why not `KoinTestRule`
Researched it. As an `@get:Rule` it starts/stops Koin **per test method** — for a parameterized preview run that's ~50 restarts of a two-binding container for no gain. Its real value (`declareMock`, `KoinTest.inject()`, `checkModules()`) is for unit tests we don't have here, and it'd add a dependency to buy nothing. `@BeforeClass`/`@AfterClass` is the "start once, stop after" lifecycle [Koin's own testing docs](https://insert-koin.io/docs/reference/koin-test/testing/) ask for. Documented in the code so it isn't re-litigated.

## SignInScreen: a pure overload instead of a workaround

`UserRepository` is a concrete class with constructor deps, so unlike the other two there's no cheap stand-in. It didn't need one — the repository was used for exactly **two actions and no state**:

```kotlin
userRepository.onSuccessfulOauthSign()   // sync
userRepository.continueAsGuest()         // suspend -> Result<Unit>
```

Both hoist into lambdas, the same split `OnBoardingScreen` got in #18. The stateful overload keeps injecting the repository and passes method references down; the pure overload takes `onOauthSigned` + `continueAsGuest` and renders with no Koin.

**Behaviour unchanged** — no logic moved, the two call sites just became parameters. The `AppNavigation` caller still resolves to the stateful overload.

## Verification

`spotlessCheck`, `:shared:jvmTest`, `:shared:testAndroidHostTest`, `:androidApp:assembleDebug` all pass. 50 previews, 0 failures. HomeScreen and SignIn PNGs verified by eye. Goldens stay gitignored.

