### PR TITLE
Fix generate_screen.sh emitting an uncompilable nav entry and unsorted imports

### DIFF
--- a/MobileApp/scripts/generate_screen.sh
+++ b/MobileApp/scripts/generate_screen.sh
@@ -25,6 +25,42 @@ if [ -z "$SCREEN_NAME" ]; then
   exit 1
 fi
 
+# Add `import <fqn>` to a file, in the alphabetical slot ktlint expects. No-op if already there.
+insert_import() {
+  file=$1
+  fqn=$2
+
+  if grep -q "^import $fqn$" "$file"; then
+    return 0
+  fi
+
+  # First existing import that sorts after the new one — insert above it.
+  target_line=$(grep -n '^import ' "$file" |
+    awk -F: -v new="import $fqn" '{ text = substr($0, index($0, ":") + 1); if (text > new) { print $1; exit } }')
+
+  if [ -n "$target_line" ]; then
+    sed -i '' "${target_line}i\\
+import $fqn
+" "$file"
+    return 0
+  fi
+
+  # Sorts last: append after the final import.
+  last_import=$(grep -n '^import ' "$file" | tail -1 | cut -d: -f1)
+  if [ -n "$last_import" ]; then
+    sed -i '' "${last_import}a\\
+import $fqn
+" "$file"
+    return 0
+  fi
+
+  # No imports at all: open a block below `package`, keeping the blank line between them.
+  sed -i '' "/^package /a\\
+\\
+import $fqn
+" "$file"
+}
+
 # Capitalize the first letter, leave the rest alone.
 SCREEN_BASE="$(printf '%s' "${SCREEN_NAME:0:1}" | tr '[:lower:]' '[:upper:]')${SCREEN_NAME:1}"
 
@@ -61,7 +97,7 @@ else
   cat > "$UI_STATE_FILE" <<EOF
 package $SCREENS_PACKAGE
 
-class $UI_STATE_CLASS()
+class $UI_STATE_CLASS
 
 sealed class $UI_EVENT_CLASS {
     data object OnClick : $UI_EVENT_CLASS()
@@ -84,7 +120,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class $VIEWMODEL_CLASS() : ViewModel() {
+class $VIEWMODEL_CLASS : ViewModel() {
     private val _uiState = MutableStateFlow($UI_STATE_CLASS())
     val uiState: StateFlow<$UI_STATE_CLASS> = _uiState.asStateFlow()
 
@@ -128,7 +164,7 @@ fun $SCREEN_CLASS(
     $SCREEN_CLASS(
         modifier = modifier.fillMaxSize(),
         uiState = uiState,
-        onUiEvent = viewModel::onUiEvent
+        onUiEvent = viewModel::onUiEvent,
     )
 }
 
@@ -136,13 +172,13 @@ fun $SCREEN_CLASS(
 fun $SCREEN_CLASS(
     modifier: Modifier = Modifier,
     uiState: $UI_STATE_CLASS,
-    onUiEvent: ($UI_EVENT_CLASS) -> Unit
+    onUiEvent: ($UI_EVENT_CLASS) -> Unit,
 ) {
     ScreenWithToolbar(
         modifier = modifier,
         isScrollableContent = true, // Set to false if content itself has scrollable content such as LazyColumn
         title = "$SCREEN_CLASS",
-        includeBottomInsets = true // Set to false if bottom nav is visible
+        includeBottomInsets = true, // Set to false if bottom nav is visible
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(AppTheme.spacing.sectionSpacing)) {
             Text("$SCREEN_CLASS")
@@ -185,16 +221,8 @@ fi
 ################################
 if [ -f "$APPNAV_FILE" ]; then
   # Imports (idempotent)
-  if ! grep -q "^import $SCREENS_PACKAGE.$SCREEN_CLASS$" "$APPNAV_FILE"; then
-    sed -i '' "/^package /a\\
-import $SCREENS_PACKAGE.$SCREEN_CLASS
-" "$APPNAV_FILE"
-  fi
-  if ! grep -q "^import $SCREENS_PACKAGE.$VIEWMODEL_CLASS$" "$APPNAV_FILE"; then
-    sed -i '' "/^package /a\\
-import $SCREENS_PACKAGE.$VIEWMODEL_CLASS
-" "$APPNAV_FILE"
-  fi
+  insert_import "$APPNAV_FILE" "$SCREENS_PACKAGE.$SCREEN_CLASS"
+  insert_import "$APPNAV_FILE" "$SCREENS_PACKAGE.$VIEWMODEL_CLASS"
 
   # Entry block (idempotent)
   if grep -q "entry<$ROUTE_CLASS>" "$APPNAV_FILE"; then
@@ -202,19 +230,14 @@ import $SCREENS_PACKAGE.$VIEWMODEL_CLASS
   elif ! grep -q "// Add new screen entries below" "$APPNAV_FILE"; then
     echo "⚠️ Marker '// Add new screen entries below' missing in AppNavigation.kt — add it before re-running."
   else
-    # Insert lines bottom-up (each /i\\ goes right before the previous insert).
+    # One insert for the whole block: every `i\` anchors on the marker, so splitting this into
+    # several seds would stack the lines up in reverse order.
     sed -i '' "/\/\/ Add new screen entries below/i\\
+    entry<$ROUTE_CLASS> {\\
+        val viewModel = koinViewModel<$VIEWMODEL_CLASS>()\\
+        $SCREEN_CLASS(viewModel = viewModel)\\
     }\\
 
-" "$APPNAV_FILE"
-    sed -i '' "/\/\/ Add new screen entries below/i\\
-        $SCREEN_CLASS(viewModel = viewModel)
-" "$APPNAV_FILE"
-    sed -i '' "/\/\/ Add new screen entries below/i\\
-        val viewModel = koinViewModel<$VIEWMODEL_CLASS>()
-" "$APPNAV_FILE"
-    sed -i '' "/\/\/ Add new screen entries below/i\\
-    entry<$ROUTE_CLASS> {
 " "$APPNAV_FILE"
     echo "Updated: $APPNAV_FILE"
   fi
@@ -226,11 +249,7 @@ fi
 # 6. Di.kt — import + viewModelOf
 ################################
 if [ -f "$DI_FILE" ]; then
-  if ! grep -q "^import $SCREENS_PACKAGE.$VIEWMODEL_CLASS$" "$DI_FILE"; then
-    sed -i '' "/^package /a\\
-import $SCREENS_PACKAGE.$VIEWMODEL_CLASS
-" "$DI_FILE"
-  fi
+  insert_import "$DI_FILE" "$SCREENS_PACKAGE.$VIEWMODEL_CLASS"
 
   if grep -q "viewModelOf(::$VIEWMODEL_CLASS)" "$DI_FILE"; then
     echo "Skipping DI registration (already present): $VIEWMODEL_CLASS"


### PR DESCRIPTION
`./scripts/generate_screen.sh` wired new screens into `AppNavigation.kt` in a way that did not compile, and every generated screen failed `spotlessCheck` until it was hand-fixed. Three bugs, all in the script — no production code changes.

## 1. The nav entry block came out inverted, outside the function

The block was built from four separate `sed .../i` calls, with a comment claiming each insert lands before the previous one. It doesn't — every `i\` anchors on the **marker**, so each new line landed *below* the last and the block came out reversed, with a stray `}` closing `screens()` early:

```kotlin
    }

        ProbeThingScreen(viewModel = viewModel)
        val viewModel = koinViewModel<ProbeThingViewModel>()
    entry<ProbeThingScreenRoute> {
    // Add new screen entries below — generate_screen.sh inserts here.
}
```

Now emitted in one insert, with a comment recording why it must stay that way:

```kotlin
    entry<ProbeThingScreenRoute> {
        val viewModel = koinViewModel<ProbeThingViewModel>()
        ProbeThingScreen(viewModel = viewModel)
    }
```

`Routes.kt` was never affected — its three seds anchor on a different line each time, so the chaining genuinely works there.

## 2. Imports jammed against `package`, unsorted

`sed /^package /a` put them above the real import block with no blank line and in reverse order — a ktlint violation in both `AppNavigation.kt` and `Di.kt`. Replaced with an `insert_import` helper that finds the first import sorting after the new one and inserts above it (falling back to append-after-last, then to opening a fresh block).

## 3. Templates failed spotless

Surfaced once 1 and 2 stopped masking it: missing trailing commas in the generated `*Screen.kt`, and redundant `()` on `class XUiState()` / `class XViewModel() : ViewModel()`. So every generated screen needed a manual `spotlessApply` before it would pass CI.

## Verification

Generated screens from scratch and ran `spotlessCheck` + `:shared:compileKotlinJvm` — both pass; before, the entry block didn't compile at all.

- `ProbeThing` — PascalCase
- `zebraTail` — lowercase first letter + camelCase → class `ZebraTail*`, dir `zebratail/`
- Two accumulated (`ZebraTail`, then `AlphaFirst`) — imports each slotted into their own alphabetical position, both entry blocks well-formed and inside `screens()`
- Idempotency holds: a second run skips all six targets

## Notes

- Both probes hit only the first of `insert_import`'s three branches. The two fallbacks can't trigger in this codebase — a generated import is always `com.kotlinfoundation.koko.presentation.screens.*`, which always sorts before the `org.koin.*` imports at the bottom of both files. They're defensive only.
- Entry blocks accumulate newest-directly-above-the-marker, so they read reverse-chronologically. Compiles fine, cosmetic, and matches how `Routes.kt` already behaves.