### PR TITLE
Web file storage (in-memory) + hide the dead camera button on desktop/web

### DIFF
--- a/MobileApp/designsystem/src/commonMain/kotlin/com/kotlinfoundation/koko/designsystem/components/addorchosefilecontainer/AddOrChooseFileContainer.kt
+++ b/MobileApp/designsystem/src/commonMain/kotlin/com/kotlinfoundation/koko/designsystem/components/addorchosefilecontainer/AddOrChooseFileContainer.kt
@@ -84,6 +84,7 @@ fun AddOrChooseFileContainer(
     onClickCaptureOrRecord: () -> Unit = {},
     onClickSelectFromGallery: () -> Unit = {},
     onFileRemoved: (FileItemUiState) -> Unit = {},
+    isCaptureSupported: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     val fileSelectionMode = uiState.mode
@@ -164,6 +165,7 @@ fun AddOrChooseFileContainer(
             onDismiss = { isChooseFileSourceModalVisible = false },
             type = fileSelectionMode.type,
             isTipsTextVisible = uiState.isHintTextVisible,
+            isCaptureSupported = isCaptureSupported,
             hintUiText = uiState.hintUiText,
             onClickCaptureOrRecord = {
                 isChooseFileSourceModalVisible = false

--- a/MobileApp/designsystem/src/commonMain/kotlin/com/kotlinfoundation/koko/designsystem/components/addorchosefilecontainer/FileSourceModal.kt
+++ b/MobileApp/designsystem/src/commonMain/kotlin/com/kotlinfoundation/koko/designsystem/components/addorchosefilecontainer/FileSourceModal.kt
@@ -31,6 +31,7 @@ fun FileSourceModal(
     onClickCaptureOrRecord: () -> Unit,
     onClickSelectFromGallery: () -> Unit,
     isTipsTextVisible: Boolean = true,
+    isCaptureSupported: Boolean = true,
     hintUiText: UiText? = null,
 ) {
     val modalTitle =
@@ -67,13 +68,16 @@ fun FileSourceModal(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(AppTheme.spacing.groupedVerticalElementSpacing),
         ) {
-            AppButton(
-                size = ButtonSize.SMALL,
-                modifier = Modifier.fillMaxWidth(),
-                text = btnRecordOrCaptureNowText,
-                startIcon = btnRecordOrCaptureNowIcon,
-                onClick = onClickCaptureOrRecord,
-            )
+            // Hidden on platforms without in-app capture (desktop/web) — the picker is the only path there.
+            if (isCaptureSupported) {
+                AppButton(
+                    size = ButtonSize.SMALL,
+                    modifier = Modifier.fillMaxWidth(),
+                    text = btnRecordOrCaptureNowText,
+                    startIcon = btnRecordOrCaptureNowIcon,
+                    onClick = onClickCaptureOrRecord,
+                )
+            }
 
             AppButton(
                 size = ButtonSize.SMALL,

--- a/MobileApp/designsystem/src/commonMain/kotlin/com/kotlinfoundation/koko/designsystem/components/addorchosefilecontainer/FileSourceModal.kt
+++ b/MobileApp/designsystem/src/commonMain/kotlin/com/kotlinfoundation/koko/designsystem/components/addorchosefilecontainer/FileSourceModal.kt
@@ -68,7 +68,6 @@ fun FileSourceModal(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(AppTheme.spacing.groupedVerticalElementSpacing),
         ) {
-            // Hidden on platforms without in-app capture (desktop/web) — the picker is the only path there.
             if (isCaptureSupported) {
                 AppButton(
                     size = ButtonSize.SMALL,

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/repository/GenerationRepository.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/repository/GenerationRepository.kt
@@ -14,13 +14,11 @@ import com.kotlinfoundation.koko.domain.usecase.AiGenerationProvider
 import com.kotlinfoundation.koko.root.AppConfiguration
 import com.kotlinfoundation.koko.util.analytics.Analytics
 import com.kotlinfoundation.koko.util.file.FileManager
+import com.kotlinfoundation.koko.util.file.mimeTypeForFileName
 import com.kotlinfoundation.koko.util.logging.AppLogger
 import com.mmk.kmpstorage.core.FileUploadProgress
 import com.mmk.kmpstorage.core.KMPStorage
 import com.mmk.kmpstorage.core.extensions.putFile
-import io.github.vinceglb.filekit.mimeType
-import io.github.vinceglb.filekit.nameWithoutExtension
-import io.github.vinceglb.filekit.readBytes
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
@@ -104,18 +102,16 @@ class GenerationRepository(
     private suspend fun GenerationInput.uploadFilesIntoCloud(): GenerationInput = copy(
         params = params.mapValues { (_, param) ->
             param.mapFileUploadUrls { fileNameWithExtension ->
-                val fileAbsolutePath =
-                    fileManager.getAbsoluteFilePathRelativeToInternal(fileNameWithExtension)
-                val file = fileManager.getPlatformFile(fileAbsolutePath)
-                val fileBytes = file.readBytes()
+                // Read bytes (not a PlatformFile) — web has no file handles, and KMPStorage takes bytes.
+                val fileBytes = fileManager.readInternalFileBytes(fileNameWithExtension)
 
                 val fileUploadProgress = KMPStorage.putFile {
                     source { bytes(fileBytes) }
                     destination {
                         folder = "temporary_files"
-                        fileName = file.nameWithoutExtension
+                        fileName = fileNameWithExtension.substringBeforeLast('.')
                     }
-                    contentType = file.mimeType().toString()
+                    contentType = mimeTypeForFileName(fileNameWithExtension)
                 }
                 val uploadedUrl =
                     (fileUploadProgress as? FileUploadProgress.Completed)?.result?.url

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/repository/GenerationRepository.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/repository/GenerationRepository.kt
@@ -102,7 +102,6 @@ class GenerationRepository(
     private suspend fun GenerationInput.uploadFilesIntoCloud(): GenerationInput = copy(
         params = params.mapValues { (_, param) ->
             param.mapFileUploadUrls { fileNameWithExtension ->
-                // Read bytes (not a PlatformFile) — web has no file handles, and KMPStorage takes bytes.
                 val fileBytes = fileManager.readInternalFileBytes(fileNameWithExtension)
 
                 val fileUploadProgress = KMPStorage.putFile {

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/home/HomeScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/home/HomeScreen.kt
@@ -56,6 +56,7 @@ import com.kotlinfoundation.koko.generated.resources.title_screen_home
 import com.kotlinfoundation.koko.root.AppConfiguration
 import com.kotlinfoundation.koko.util.StoreDevice
 import com.kotlinfoundation.koko.util.StoreScreenshot
+import com.kotlinfoundation.koko.util.file.isCameraCaptureSupported
 import com.kotlinfoundation.koko.util.file.openCameraPicker
 import com.kotlinfoundation.koko.util.inappreview.rememberInAppReviewTrigger
 import com.kotlinfoundation.koko.util.logging.AppLogger
@@ -238,6 +239,7 @@ private fun HomeMainContent(
                 },
                 onClickSelectFromGallery = { galleryLauncher.launch() },
                 onFileRemoved = { onUiEvent(HomeUiEvent.OnReferenceImageRemoved(it)) },
+                isCaptureSupported = isCameraCaptureSupported(),
             )
             Text(
                 text = stringResource(Res.string.home_reference_image_label),

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.kt
@@ -44,6 +44,13 @@ interface FileManager {
         fileExtension: String,
     ): Result<String>
 
+    /**
+     * Reads the raw bytes of a file stored under [fileNameWithExtension] in the internal directory.
+     * Prefer this over [getPlatformFile] for cross-platform byte access — the web target has no file
+     * handles, only bytes.
+     */
+    suspend fun readInternalFileBytes(fileNameWithExtension: String): ByteArray
+
     suspend fun shareFile(absoluteFilePath: String): Result<Unit> {
         FileKit.shareFileCommon(file = getPlatformFile(absoluteFilePath))
         return Result.success(Unit)
@@ -82,6 +89,20 @@ suspend fun FileManager.saveImageToGalleryFromNetwork(
     return downloadedFileResult.map { downloadedFileName ->
         saveImageToGallery(getAbsoluteFilePathRelativeToInternal(downloadedFileName))
     }
+}
+
+/** Best-effort MIME type derived from a file name's extension, for uploads/downloads. */
+fun mimeTypeForFileName(fileName: String): String = when (fileName.substringAfterLast('.', "").lowercase()) {
+    "png" -> "image/png"
+    "jpg", "jpeg" -> "image/jpeg"
+    "webp" -> "image/webp"
+    "gif" -> "image/gif"
+    "bmp" -> "image/bmp"
+    "svg" -> "image/svg+xml"
+    "mp4" -> "video/mp4"
+    "mov" -> "video/quicktime"
+    "webm" -> "video/webm"
+    else -> "application/octet-stream"
 }
 
 expect suspend fun FileKit.shareFileCommon(file: PlatformFile)

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.kt
@@ -89,3 +89,9 @@ expect suspend fun PlatformFile.absolutePathCommon(): String
 
 /** Opens the device camera to capture a photo. Returns null if cancelled or unsupported (desktop/web). */
 expect suspend fun FileKit.openCameraPicker(): PlatformFile?
+
+/**
+ * Whether in-app camera capture is available on this platform. False on desktop/web, where
+ * [openCameraPicker] is a no-op — callers should hide the capture action and use the file picker.
+ */
+expect fun isCameraCaptureSupported(): Boolean

--- a/MobileApp/shared/src/mobileMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.mobile.kt
+++ b/MobileApp/shared/src/mobileMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.mobile.kt
@@ -11,3 +11,5 @@ actual suspend fun FileKit.shareFileCommon(file: PlatformFile) {
 }
 
 actual suspend fun FileKit.openCameraPicker(): PlatformFile? = FileKit.openCameraPicker(cameraFacing = FileKitCameraFacing.Back)
+
+actual fun isCameraCaptureSupported(): Boolean = true

--- a/MobileApp/shared/src/nonMobileMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.nonMobile.kt
+++ b/MobileApp/shared/src/nonMobileMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.nonMobile.kt
@@ -9,3 +9,5 @@ actual suspend fun FileKit.shareFileCommon(file: PlatformFile) {
 
 // Camera capture is not available on desktop/web — use the gallery / file picker instead.
 actual suspend fun FileKit.openCameraPicker(): PlatformFile? = null
+
+actual fun isCameraCaptureSupported(): Boolean = false

--- a/MobileApp/shared/src/nonWebMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.nonWeb.kt
+++ b/MobileApp/shared/src/nonWebMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.nonWeb.kt
@@ -10,6 +10,7 @@ import io.github.vinceglb.filekit.dialogs.openFileSaver
 import io.github.vinceglb.filekit.extension
 import io.github.vinceglb.filekit.filesDir
 import io.github.vinceglb.filekit.nameWithoutExtension
+import io.github.vinceglb.filekit.readBytes
 import io.github.vinceglb.filekit.saveImageToGallery
 import io.github.vinceglb.filekit.sink
 import io.github.vinceglb.filekit.size
@@ -164,6 +165,8 @@ class FileManagerImpl(
     private fun extractFileExtensionFromUrl(url: String): String? = url.substringAfterLast('.', "").takeIf { it.isNotEmpty() && it.length <= 5 }
 
     override fun getPlatformFile(absoluteFilePath: String): PlatformFile = PlatformFile(absoluteFilePath)
+
+    override suspend fun readInternalFileBytes(fileNameWithExtension: String): ByteArray = PlatformFile(getAbsoluteFilePathRelativeToInternal(fileNameWithExtension)).readBytes()
 }
 
 actual suspend fun PlatformFile.absolutePathCommon(): String = absolutePath()

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/Platform.web.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/Platform.web.kt
@@ -26,7 +26,9 @@ internal actual val platformModule: Module = module {
     includes(webDatabaseModule)
     singleOf(::PreferencesDataStoreProviderImpl) bind PreferencesDataStoreProvider::class
     factoryOf(::AppUtilImpl) bind AppUtil::class
-    factoryOf(::FileManagerImpl) bind FileManager::class
+    // Singleton, not factory: the web FileManager holds an in-memory byte store, so every
+    // consumer must share the same instance (a fresh factory instance would be empty).
+    singleOf(::FileManagerImpl) bind FileManager::class
     single { NoImplFeatureFlagManager } bind FeatureFlagManager::class
     single { NoImplAnalytics } bind Analytics::class
     single { NoImplAdsManager } bind AdsManager::class

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
@@ -30,7 +30,6 @@ class FileManagerImpl(
     private val httpClient: HttpClient = HttpClient(),
 ) : FileManager {
 
-    // name -> raw bytes, for the current session only.
     private val store = mutableMapOf<String, ByteArray>()
 
     override fun getAbsoluteFilePathRelativeToInternal(relativePathToInternal: String): String {
@@ -90,13 +89,10 @@ class FileManagerImpl(
     ): Result<String> = downloadFileFromNetworkToInternalDirectory(url, fileExtension)
         .onSuccess { name -> saveImageToGallery(name) }
 
-    // Sharing on web is a download.
     override suspend fun shareFile(absoluteFilePath: String): Result<Unit> = saveImageToGallery(absoluteFilePath)
 
     override suspend fun readInternalFileBytes(fileNameWithExtension: String): ByteArray = resolveBytes(fileNameWithExtension) ?: error("No file bytes for: $fileNameWithExtension")
 
-    // Web has no file handles. The upload path reads bytes via readInternalFileBytes and sharing is a
-    // download, so nothing in the app calls this on web.
     override fun getPlatformFile(absoluteFilePath: String): PlatformFile = throw UnsupportedOperationException("getPlatformFile is not supported on web")
 
     private fun resolveBytes(pathOrDataUrl: String): ByteArray? = when {
@@ -111,8 +107,6 @@ class FileManagerImpl(
     private fun String.fileExtension(): String = substringAfterLast('.', "").substringBefore(';').lowercase()
 }
 
-// The picked PlatformFile's bytes become a self-contained data: URL — usable both as an immediate
-// Coil preview and as the input to copyFileToInternalDirectory (which decodes it back).
 @OptIn(ExperimentalEncodingApi::class)
 actual suspend fun PlatformFile.absolutePathCommon(): String {
     val bytes = readBytes()

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
@@ -35,7 +35,7 @@ class FileManagerImpl(
 
     override fun getAbsoluteFilePathRelativeToInternal(relativePathToInternal: String): String {
         val bytes = store[relativePathToInternal] ?: return ""
-        return bytes.toDataUrl(mimeTypeForExtension(relativePathToInternal.fileExtension()))
+        return bytes.toDataUrl(mimeTypeForFileName(relativePathToInternal))
     }
 
     override suspend fun copyFileToInternalDirectory(
@@ -93,8 +93,10 @@ class FileManagerImpl(
     // Sharing on web is a download.
     override suspend fun shareFile(absoluteFilePath: String): Result<Unit> = saveImageToGallery(absoluteFilePath)
 
-    // Uploading a picked file to cloud storage (Firebase) is an integrations-phase concern and is not
-    // wired for web. The in-session pick -> display and generate -> display flows never call this.
+    override suspend fun readInternalFileBytes(fileNameWithExtension: String): ByteArray = resolveBytes(fileNameWithExtension) ?: error("No file bytes for: $fileNameWithExtension")
+
+    // Web has no file handles. The upload path reads bytes via readInternalFileBytes and sharing is a
+    // download, so nothing in the app calls this on web.
     override fun getPlatformFile(absoluteFilePath: String): PlatformFile = throw UnsupportedOperationException("getPlatformFile is not supported on web")
 
     private fun resolveBytes(pathOrDataUrl: String): ByteArray? = when {
@@ -107,18 +109,6 @@ class FileManagerImpl(
     private fun String.decodeBase64OrNull(): ByteArray? = runCatching { Base64.decode(this) }.getOrNull()
 
     private fun String.fileExtension(): String = substringAfterLast('.', "").substringBefore(';').lowercase()
-
-    private fun mimeTypeForExtension(extension: String): String = when (extension) {
-        "png" -> "image/png"
-        "jpg", "jpeg" -> "image/jpeg"
-        "webp" -> "image/webp"
-        "gif" -> "image/gif"
-        "bmp" -> "image/bmp"
-        "svg" -> "image/svg+xml"
-        "mp4" -> "video/mp4"
-        "webm" -> "video/webm"
-        else -> "application/octet-stream"
-    }
 }
 
 // The picked PlatformFile's bytes become a self-contained data: URL — usable both as an immediate
@@ -126,12 +116,5 @@ class FileManagerImpl(
 @OptIn(ExperimentalEncodingApi::class)
 actual suspend fun PlatformFile.absolutePathCommon(): String {
     val bytes = readBytes()
-    val mime = when (name.substringAfterLast('.', "").lowercase()) {
-        "png" -> "image/png"
-        "jpg", "jpeg" -> "image/jpeg"
-        "webp" -> "image/webp"
-        "gif" -> "image/gif"
-        else -> "application/octet-stream"
-    }
-    return "data:$mime;base64,${Base64.encode(bytes)}"
+    return "data:${mimeTypeForFileName(name)};base64,${Base64.encode(bytes)}"
 }

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
@@ -4,34 +4,69 @@ import com.kotlinfoundation.koko.data.BackgroundExecutor
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.download
+import io.github.vinceglb.filekit.name
+import io.github.vinceglb.filekit.readBytes
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
+/**
+ * Web (js/wasmJs) file manager. The browser has no filesystem paths, so this keeps file bytes in an
+ * in-memory map keyed by the same unique names the other platforms use, and resolves a name to a
+ * `data:` URL for display (Coil on web loads it through the Ktor/fetch engine). Byte storage is
+ * **session-scoped** — images do not survive a page reload (Room rows do, but their bytes are gone).
+ *
+ * Any string that leaves this class as an "absolute path" is a `data:` URL, and any web-internal
+ * resolution accepts either such a URL or a bare store name.
+ */
+@OptIn(ExperimentalEncodingApi::class)
 class FileManagerImpl(
     private val backgroundExecutor: BackgroundExecutor = BackgroundExecutor.IO,
     private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    private val httpClient: HttpClient = HttpClient(),
 ) : FileManager {
+
+    // name -> raw bytes, for the current session only.
+    private val store = mutableMapOf<String, ByteArray>()
+
     override fun getAbsoluteFilePathRelativeToInternal(relativePathToInternal: String): String {
-        TODO("Not yet implemented")
+        val bytes = store[relativePathToInternal] ?: return ""
+        return bytes.toDataUrl(mimeTypeForExtension(relativePathToInternal.fileExtension()))
     }
 
     override suspend fun copyFileToInternalDirectory(
         originalFileAbsolutePath: String,
         newFileName: String?,
-    ): Result<String> {
-        TODO("Not yet implemented")
+    ): Result<String> = backgroundExecutor.execute {
+        val bytes = resolveBytes(originalFileAbsolutePath)
+            ?: return@execute Result.failure(Exception("No file to copy for: $originalFileAbsolutePath"))
+        val extension = originalFileAbsolutePath.fileExtension().ifEmpty { "png" }
+        val name = newFileName ?: createNewUniqueFileNameWithExtension(extension)
+        store[name] = bytes
+        Result.success(name)
     }
 
     override suspend fun saveBase64ImageToInternalDirectory(
         base64Image: String,
         imageExtension: String,
-    ): String? {
-        TODO("Not yet implemented")
-    }
+    ): String? = backgroundExecutor.execute {
+        val bytes = base64Image.decodeBase64OrNull()
+            ?: return@execute Result.failure(Exception("Invalid base64 image"))
+        val name = createNewUniqueFileNameWithExtension(fileExtension = imageExtension)
+        store[name] = bytes
+        Result.success(name)
+    }.getOrNull()
 
-    override suspend fun saveImageToGallery(absoluteFilePath: String): Result<Unit> {
-        FileKit.download(getPlatformFile(absoluteFilePath))
-        return Result.success(Unit)
+    override suspend fun saveImageToGallery(absoluteFilePath: String): Result<Unit> = backgroundExecutor.execute {
+        val bytes = resolveBytes(absoluteFilePath)
+            ?: return@execute Result.failure(Exception("Nothing to save for: $absoluteFilePath"))
+        val extension = absoluteFilePath.fileExtension().ifEmpty { "png" }
+        FileKit.download(bytes = bytes, fileName = createNewUniqueFileNameWithExtension(extension))
+        Result.success(Unit)
     }
 
     override suspend fun saveFileByPickingUpLocation(absoluteFilePath: String): Result<Unit> = saveImageToGallery(absoluteFilePath)
@@ -39,22 +74,64 @@ class FileManagerImpl(
     override suspend fun downloadFileFromNetworkToInternalDirectory(
         url: String,
         fileExtension: String?,
-    ): Result<String> {
-        TODO("Not yet implemented")
+    ): Result<String> = backgroundExecutor.execute {
+        val extension = fileExtension
+            ?: url.fileExtension().ifEmpty { null }
+            ?: return@execute Result.failure(Exception("Failed to download. Please specify file extension"))
+        val bytes = httpClient.get(url).readRawBytes()
+        val name = createNewUniqueFileNameWithExtension(fileExtension = extension)
+        store[name] = bytes
+        Result.success(name)
     }
 
     override suspend fun saveFileFromNetworkToGalleryByPickingUpLocation(
         url: String,
         fileExtension: String,
-    ): Result<String> {
-        TODO("Not yet implemented")
+    ): Result<String> = downloadFileFromNetworkToInternalDirectory(url, fileExtension)
+        .onSuccess { name -> saveImageToGallery(name) }
+
+    // Sharing on web is a download.
+    override suspend fun shareFile(absoluteFilePath: String): Result<Unit> = saveImageToGallery(absoluteFilePath)
+
+    // Uploading a picked file to cloud storage (Firebase) is an integrations-phase concern and is not
+    // wired for web. The in-session pick -> display and generate -> display flows never call this.
+    override fun getPlatformFile(absoluteFilePath: String): PlatformFile = throw UnsupportedOperationException("getPlatformFile is not supported on web")
+
+    private fun resolveBytes(pathOrDataUrl: String): ByteArray? = when {
+        pathOrDataUrl.startsWith("data:") -> pathOrDataUrl.substringAfter(',', "").decodeBase64OrNull()
+        else -> store[pathOrDataUrl]
     }
 
-    override fun getPlatformFile(absoluteFilePath: String): PlatformFile {
-        TODO("Not yet implemented")
+    private fun ByteArray.toDataUrl(mimeType: String): String = "data:$mimeType;base64,${Base64.encode(this)}"
+
+    private fun String.decodeBase64OrNull(): ByteArray? = runCatching { Base64.decode(this) }.getOrNull()
+
+    private fun String.fileExtension(): String = substringAfterLast('.', "").substringBefore(';').lowercase()
+
+    private fun mimeTypeForExtension(extension: String): String = when (extension) {
+        "png" -> "image/png"
+        "jpg", "jpeg" -> "image/jpeg"
+        "webp" -> "image/webp"
+        "gif" -> "image/gif"
+        "bmp" -> "image/bmp"
+        "svg" -> "image/svg+xml"
+        "mp4" -> "video/mp4"
+        "webm" -> "video/webm"
+        else -> "application/octet-stream"
     }
 }
 
+// The picked PlatformFile's bytes become a self-contained data: URL — usable both as an immediate
+// Coil preview and as the input to copyFileToInternalDirectory (which decodes it back).
+@OptIn(ExperimentalEncodingApi::class)
 actual suspend fun PlatformFile.absolutePathCommon(): String {
-    TODO("Not yet implemented")
+    val bytes = readBytes()
+    val mime = when (name.substringAfterLast('.', "").lowercase()) {
+        "png" -> "image/png"
+        "jpg", "jpeg" -> "image/jpeg"
+        "webp" -> "image/webp"
+        "gif" -> "image/gif"
+        else -> "application/octet-stream"
+    }
+    return "data:$mime;base64,${Base64.encode(bytes)}"
 }


### PR DESCRIPTION
`FileManager` was only fully implemented on Android/iOS/Desktop. Two gaps, both fixed here — no new dependencies, no JS files, no source-set surgery.

## 1. Web file ops were stubbed → the web AI flow threw

`shared/src/webMain/.../util/file/FileManager.web.kt` was almost entirely `TODO("Not yet implemented")`. Picking an image works (FileKit's picker is multiplatform), but everything after — persist the bytes, then display them — threw on web.

Rewrote it as a **session, in-memory** store:
- `name → bytes` map. Save ops (base64 / copy / network download) store bytes under the **same unique names** the other platforms use and return the name, so Room and `GenerationRepository` are unchanged.
- Display resolves a name to a **`data:` URL**. Coil 3 renders it via its built-in `DataUriFetcher` (a default component in commonMain, so present on web) — **no custom Coil setup, no JS interop, no OPFS**. `absolutePathCommon` also returns a `data:` URL, so a picked reference image previews immediately and round-trips through `copyFileToInternalDirectory` (which decodes it back).
- `saveImageToGallery` / `shareFile` → a browser download via `FileKit.download(bytes, fileName)`.
- `getPlatformFile` stays **unsupported** on web — it's only used to upload a picked file to Firebase Storage, an integrations-phase concern the in-session flow never hits.

**Known limitation (accepted):** web image bytes are session-scoped and do **not** survive a page reload. Room rows persist (OPFS), but their bytes are gone. Full OPFS persistence was scoped out as too complex for the value.

## 2. Dead "Take photo" button on desktop/web

`openCameraPicker()` returns `null` off mobile, but `FileSourceModal` always showed the capture button — a silent no-op on desktop and web.

- Added `expect fun isCameraCaptureSupported()` (`true` on `mobile`, `false` on `nonMobile`) — reuses the existing source-set split; `openCameraPicker` is untouched.
- Threaded `isCaptureSupported` through `AddOrChooseFileContainer` → `FileSourceModal` to hide the capture button where it does nothing. `HomeScreen` passes `isCameraCaptureSupported()`. Mobile capture is unchanged.

## Why `data:` URLs are enough

Generated/reference images flow through the app as an absolute-path `String` fed to Coil (`AsyncImageWithShimmer(model: String)`); Room stores only the file **name**, resolved to a display string at read time. So the web impl only needs to hold bytes by name and hand back a string Coil can render — and Coil's default `DataUriFetcher` decodes `data:…;base64,…` directly. (Verified against the resolved Coil3 3.5.0 sources: `RealImageLoader` registers `DataUriFetcher.Factory()` in commonMain.)

## Verification

`compileKotlinWasmJs`, `compileKotlinJs`, `compileKotlinJvm`, `compileAppleMainKotlinMetadata`, `:shared:jvmTest`, `:androidApp:assembleDebug`, and `spotlessCheck` — all green. The live browser flow (`:webApp:wasmJsBrowserDevelopmentRun` → pick → preview, generate → display) is the one thing static checks can't cover; the display path is proven by Coil's default `DataUriFetcher`.