### PR TITLE
Make Replicate request/response DTOs non-generic to fix Wasm serialization

### DIFF
--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/ai/ReplicateGenerationProvider.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/ai/ReplicateGenerationProvider.kt
@@ -11,6 +11,7 @@ import com.kotlinfoundation.koko.domain.usecase.AiGenerationProvider
 import com.kotlinfoundation.koko.util.file.FileManager
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
 /**
@@ -87,7 +88,7 @@ class ReplicateGenerationProvider(
         }
     }
 
-    fun GenerationInput.toReplicateRequestBody(): Map<String, JsonElement> {
+    fun GenerationInput.toReplicateRequestBody(): JsonObject {
         val requestBody = mutableMapOf<String, JsonElement>()
 
         requestBody[PROMPT_KEY_PARAM] = JsonPrimitive(fullPrompt())
@@ -121,7 +122,7 @@ class ReplicateGenerationProvider(
             }
         }
 
-        return requestBody
+        return JsonObject(requestBody)
     }
 
     /**
@@ -130,10 +131,10 @@ class ReplicateGenerationProvider(
      * @param modelName The name of the model (e.g., `"nano-banana""`).
      *
      */
-    private suspend inline fun <reified Input> createOfficialModelsPrediction(
+    private suspend fun createOfficialModelsPrediction(
         modelOwner: String,
         modelName: String,
-        input: Input,
+        input: JsonObject,
     ) = replicateApiService.createModelPrediction(
         modelOwner = modelOwner,
         modelName = modelName,
@@ -147,9 +148,9 @@ class ReplicateGenerationProvider(
      * Creates a prediction request for a specific community models using the Replicate API.
      * @param version The version of the model to use.
      */
-    private suspend inline fun <reified Input> createCommunityModelsPrediction(
+    private suspend fun createCommunityModelsPrediction(
         version: String?,
-        input: Input,
+        input: JsonObject,
     ) = replicateApiService.createPrediction(
         requestBody = ReplicatePredictionRequest(
             version = version,

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/ReplicateApiService.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/ReplicateApiService.kt
@@ -52,11 +52,11 @@ class ReplicateApiService(val aiTransport: AiTransport) {
      * @param requestBody The body of the request,
      * @return The response from the Replicate API as an [AiApiBaseResponse] containing [ReplicatePredictionResponse].
      */
-    suspend inline fun <reified Input> createModelPrediction(
+    suspend fun createModelPrediction(
         modelOwner: String,
         modelName: String,
-        requestBody: ReplicatePredictionRequest<Input>,
-    ): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
+        requestBody: ReplicatePredictionRequest,
+    ): AiApiBaseResponse<ReplicatePredictionResponse> = aiTransport.execute(
         method = HttpMethod.Post,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCreateModelPrediction",
         direct = directSpec("https://api.replicate.com/v1/models/$modelOwner/$modelName/predictions"),
@@ -83,7 +83,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
      * @param requestBody The body of the request, containing the model version and input parameters.
      * @return The response from the Replicate API as an [AiApiBaseResponse] containing [ReplicatePredictionResponse].
      */
-    suspend inline fun <reified Input> createPrediction(requestBody: ReplicatePredictionRequest<Input>): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
+    suspend fun createPrediction(requestBody: ReplicatePredictionRequest): AiApiBaseResponse<ReplicatePredictionResponse> = aiTransport.execute(
         method = HttpMethod.Post,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCreatePrediction",
         direct = directSpec("https://api.replicate.com/v1/predictions"),
@@ -104,7 +104,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
      * )
      * ```
      */
-    suspend inline fun <reified Input> getPredictionStatus(id: String): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
+    suspend fun getPredictionStatus(id: String): AiApiBaseResponse<ReplicatePredictionResponse> = aiTransport.execute(
         method = HttpMethod.Get,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateGetPredictionStatus",
         direct = directSpec("https://api.replicate.com/v1/predictions/$id"),
@@ -125,7 +125,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
      * )
      * ```
      */
-    suspend inline fun <reified Input> cancelPrediction(id: String): AiApiBaseResponse<ReplicatePredictionResponse<Input>> = aiTransport.execute(
+    suspend fun cancelPrediction(id: String): AiApiBaseResponse<ReplicatePredictionResponse> = aiTransport.execute(
         method = HttpMethod.Post,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCancelPrediction",
         direct = directSpec("https://api.replicate.com/v1/predictions/$id/cancel"),

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/request/ai/replicate/ReplicatePredictionRequest.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/request/ai/replicate/ReplicatePredictionRequest.kt
@@ -2,15 +2,18 @@ package com.kotlinfoundation.koko.data.source.remote.request.ai.replicate
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Represents a request to create a prediction on a Replicate model.
  * Some models require version of the model to be specified, while others don't.
  * If you used create model prediction, then you need to pass null for version.
+ *
+ * [input] is a [JsonObject] (not a type parameter) so the serializer stays concrete — a generic
+ * `@Serializable` class crashes kotlinx.serialization's reflective lookup on Kotlin/Wasm.
  */
-
 @Serializable
-data class ReplicatePredictionRequest<Input>(
+data class ReplicatePredictionRequest(
     @SerialName("version") val version: String? = null,
-    @SerialName("input") val input: Input,
+    @SerialName("input") val input: JsonObject,
 )

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/response/ai/replicate/ReplicatePredictionResponse.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/response/ai/replicate/ReplicatePredictionResponse.kt
@@ -2,13 +2,16 @@ package com.kotlinfoundation.koko.data.source.remote.response.ai.replicate
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
 
+// [input] is a concrete JsonObject rather than a type parameter — a generic @Serializable class
+// crashes kotlinx.serialization's reflective serializer lookup on Kotlin/Wasm.
 @Serializable
-data class ReplicatePredictionResponse<Input>(
+data class ReplicatePredictionResponse(
     @SerialName("id") val id: String? = null,
     @SerialName("model") val model: String? = null,
     @SerialName("version") val version: String? = null,
-    @SerialName("input") val input: Input? = null,
+    @SerialName("input") val input: JsonObject? = null,
     @SerialName("logs") val logs: String? = null,
     @SerialName("status") val status: String? = null,
     @SerialName("output") val output: String? = null,


### PR DESCRIPTION
Generating on **web** crashed with `index out of bounds` in `Array.get`, inside kotlinx.serialization's reflective serializer lookup.

## Root cause

`ReplicatePredictionRequest<Input>` is a **generic** `@Serializable` class, and `AiTransport.rawExecute` sends the body as `setBody(body: Any?)`. Ktor's ContentNegotiation then serializes it reflectively from the runtime class; constructing a generic serializer via `constructSerializerForGivenTypeArgs` with an empty type-arg array does `typeArgs[0]` and blows up on **Kotlin/Wasm**. JVM/iOS/desktop tolerate the same path, so this was **web-only** and blocked all direct-mode Replicate generation there.

Stack (abridged):
```
Array.get  ← index out of bounds
ReplicatePredictionRequest.Companion.serializer
constructSerializerForGivenTypeArgs
guessSerializer  (ktor ContentNegotiation)
AiTransport.rawExecute → ReplicateGenerationProvider.generate
```

## Fix

The `Input` is always a JSON object (`toReplicateRequestBody()` builds a `Map<String, JsonElement>`), so the type parameter buys nothing. Type `input` as a concrete **`JsonObject`** on both the request and response DTOs — `JsonObject` has a non-generic serializer Wasm handles.

- `ReplicatePredictionRequest<Input>` → `ReplicatePredictionRequest` (`input: JsonObject`)
- `ReplicatePredictionResponse<Input>` → `ReplicatePredictionResponse` (`input: JsonObject?`)
- the four `ReplicateApiService` methods and the two `ReplicateGenerationProvider` helpers drop their `<reified Input>` generics
- `toReplicateRequestBody()` now returns `JsonObject`

No behavior change on any platform. No external consumers of the generic types.

## Verification

`compileKotlinWasmJs`, `compileKotlinJs`, `compileKotlinJvm`, `compileAppleMainKotlinMetadata`, `:shared:jvmTest`, `spotlessCheck` — all green.