### PR TITLE
Fall back to direct AI mode when no proxy URL is configured

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,8 @@ directly. It picks between two backends and adapts the response so the DTOs + `A
   client with **no** Firebase interceptor, sending `Authorization: Bearer <OPENAI_API_KEY|REPLICATE_API_KEY>`
   (from `BuildConfig`/`local.properties`) + Replicate's `Prefer: wait`. The raw provider JSON is re-wrapped
   into a synthetic `AiApiBaseResponse`.
-- **Selection:** auto — direct when `AppConfiguration.CLOUD_FUNCTIONS_URL` is blank AND the provider key is set;
+- **Selection:** auto — proxy only when `AppConfiguration.CLOUD_FUNCTIONS_URL` is set, otherwise direct
+  (the proxy is useless without a URL, so a blank URL always falls back to a direct provider call).
   `AppConfiguration.USE_AI_PROXY_SERVER` (`Boolean?`; `true`=proxy, `false`=direct, `null`=auto) overrides.
   Prototyping only — direct-mode keys ship in the app
   binary; production keeps the proxy (keys in Secret Manager). `AiTransport` is **provider-agnostic**: each

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/AiTransport.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/AiTransport.kt
@@ -70,7 +70,7 @@ class AiTransport(
         proxyQueryParams: Map<String, String> = emptyMap(),
         body: Any? = null,
     ): AiApiBaseResponse<T> {
-        val mode = resolveMode(hasAiApiKey = direct.apiKey.isNotBlank())
+        val mode = resolveMode()
         val response = rawExecute(mode, method, proxyUrl, direct, proxyQueryParams, body)
         return when (mode) {
             AiMode.PROXY -> response.body()
@@ -111,9 +111,11 @@ class AiTransport(
     }
 
     @PublishedApi
-    internal fun resolveMode(hasAiApiKey: Boolean): AiMode {
+    internal fun resolveMode(): AiMode {
         AppConfiguration.USE_AI_PROXY_SERVER?.let { return if (it) AiMode.PROXY else AiMode.DIRECT }
-        return if (AppConfiguration.CLOUD_FUNCTIONS_URL.isBlank() && hasAiApiKey) AiMode.DIRECT else AiMode.PROXY
+        // Auto: the proxy only works with a proxy URL, so use it only when one is set; otherwise call
+        // the provider directly (a blank direct key then surfaces a clear auth error, not a dead proxy).
+        return if (AppConfiguration.CLOUD_FUNCTIONS_URL.isBlank()) AiMode.DIRECT else AiMode.PROXY
     }
 
     /**

--- a/skills/configure-environment/SKILL.md
+++ b/skills/configure-environment/SKILL.md
@@ -50,8 +50,8 @@ credentials, IDs, and toggles.
 > marks it). Setting a real key auto-switches to the real provider — see `setup-subscriptions`.
 
 > **Direct AI mode (prototyping):** `OPENAI_API_KEY` / `REPLICATE_API_KEY` in `local.properties` are used
-> only for the **direct** (no-Firebase) AI path — the app calls the provider straight from the device when
-> `AppConfiguration.CLOUD_FUNCTIONS_URL` is blank and a key is set (`AppConfiguration.USE_AI_PROXY_SERVER` overrides). The key
+> only for the **direct** (no-Firebase) AI path — the app calls the provider straight from the device
+> whenever `AppConfiguration.CLOUD_FUNCTIONS_URL` is blank (`AppConfiguration.USE_AI_PROXY_SERVER` overrides). The key
 > ships in the app binary, so this is prototyping only. In **production** the app calls the web-proxy and
 > the keys live in **Google Cloud Secret Manager**, not on device — see `integrate-web-proxy`.
 

--- a/skills/integrate-web-proxy/SKILL.md
+++ b/skills/integrate-web-proxy/SKILL.md
@@ -126,9 +126,9 @@ Point `CLOUD_FUNCTIONS_URL` at the emulator host while iterating, then switch ba
 
 The OpenAI/Replicate calls are **already wired** — `OpenAiApiService` / `ReplicateApiService` route
 through `AiTransport`, and the proxy `HttpClient` (`HttpClientFactory.default`) attaches the Firebase ID
-token to every request automatically. So once `CLOUD_FUNCTIONS_URL` is set (and no direct key is set /
-`USE_AI_PROXY_SERVER` isn't forcing direct), the existing generation flow uses the proxy with **no code
-change**.
+token to every request automatically. So once `CLOUD_FUNCTIONS_URL` is set (unless `USE_AI_PROXY_SERVER`
+forces direct), the existing generation flow uses the proxy with **no code change** — a set proxy URL
+takes precedence over any direct key.
 
 To add a **new** endpoint:
 - **AI provider call** — add a method to the AI service that calls


### PR DESCRIPTION
`AiTransport.resolveMode` chose the **proxy** whenever `CLOUD_FUNCTIONS_URL` was blank and no direct key was set:

```kotlin
return if (CLOUD_FUNCTIONS_URL.isBlank() && hasAiApiKey) DIRECT else PROXY
```

But the proxy can't work without a URL, so a freshly-cloned app (nothing configured yet) routed AI calls to a **dead proxy**. It should call the provider directly instead.

## Fix

Auto mode now keys purely off whether a proxy URL exists:

```kotlin
return if (CLOUD_FUNCTIONS_URL.isBlank()) DIRECT else PROXY
```

- No proxy URL → **direct** (a blank direct key then surfaces a clear auth error, not a dead proxy).
- Proxy URL set → **proxy**.
- `USE_AI_PROXY_SERVER` (`true`/`false`) override unchanged.
- Drops the now-unused `hasAiApiKey` param.

## Docs

Updated to match — a **set proxy URL takes precedence over any direct key**:
- `AGENTS.md` AI-transport selection line
- `skills/configure-environment/SKILL.md`
- `skills/integrate-web-proxy/SKILL.md`

## Verification

`compileKotlinJvm`, `compileKotlinWasmJs`, `spotlessCheck` green.