### PR TITLE
Enable web direct-mode AI via dev-server CORS proxy

### DIFF
--- a/MobileApp/shared/src/androidMain/kotlin/com/kotlinfoundation/koko/util/Platform.android.kt
+++ b/MobileApp/shared/src/androidMain/kotlin/com/kotlinfoundation/koko/util/Platform.android.kt
@@ -62,6 +62,8 @@ internal actual fun onApplicationStartPlatformSpecific() {
     )
 }
 
+actual fun getPlatform(): Platform = Platform.Android
+
 internal actual val isAndroid = true
 internal actual val isDebug = BuildConfig.DEBUG
 actual val defaultAsyncDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/OpenAiApiService.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/OpenAiApiService.kt
@@ -8,9 +8,16 @@ import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseRespons
 import com.kotlinfoundation.koko.data.source.remote.response.ai.openai.OpenAiCreateChatResponse
 import com.kotlinfoundation.koko.data.source.remote.response.ai.openai.OpenAiCreateImageResponse
 import com.kotlinfoundation.koko.root.AppConfiguration
+import com.kotlinfoundation.koko.util.Platform
+import com.kotlinfoundation.koko.util.getPlatform
 import io.ktor.http.HttpMethod
 
 class OpenAiApiService(private val aiTransport: AiTransport) {
+
+    // Web can't call api.openai.com directly (no CORS); it goes through the same-origin dev-server proxy
+    // (see webApp/build.gradle.kts). Everyone else hits the provider directly.
+    private val baseUrl: String
+        get() = if (getPlatform() == Platform.Web) "http://localhost:8080/openai" else "https://api.openai.com"
 
     private fun directSpec(url: String) = AiDirectSpec(url = url, apiKey = BuildConfig.OPENAI_API_KEY)
 
@@ -46,7 +53,7 @@ class OpenAiApiService(private val aiTransport: AiTransport) {
     suspend fun createChat(requestBody: OpenAiCreateChatRequest): AiApiBaseResponse<OpenAiCreateChatResponse> = aiTransport.execute(
         method = HttpMethod.Post,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/openAiCreateTextCompletion",
-        direct = directSpec("https://api.openai.com/v1/chat/completions"),
+        direct = directSpec("$baseUrl/v1/chat/completions"),
         body = requestBody,
     )
 
@@ -59,7 +66,7 @@ class OpenAiApiService(private val aiTransport: AiTransport) {
     suspend fun createImage(requestBody: OpenAiCreateImageRequest): AiApiBaseResponse<OpenAiCreateImageResponse> = aiTransport.execute(
         method = HttpMethod.Post,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/openAiCreateImage",
-        direct = directSpec("https://api.openai.com/v1/images/generations"),
+        direct = directSpec("$baseUrl/v1/images/generations"),
         body = requestBody,
     )
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/ReplicateApiService.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/remote/apiservices/ai/ReplicateApiService.kt
@@ -5,6 +5,8 @@ import com.kotlinfoundation.koko.data.source.remote.request.ai.replicate.Replica
 import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseResponse
 import com.kotlinfoundation.koko.data.source.remote.response.ai.replicate.ReplicatePredictionResponse
 import com.kotlinfoundation.koko.root.AppConfiguration
+import com.kotlinfoundation.koko.util.Platform
+import com.kotlinfoundation.koko.util.getPlatform
 import io.ktor.http.HttpMethod
 
 /**
@@ -13,6 +15,12 @@ import io.ktor.http.HttpMethod
  *
  */
 class ReplicateApiService(val aiTransport: AiTransport) {
+
+    // Web can't call api.replicate.com directly (no CORS); it goes through the same-origin dev-server
+    // proxy (see webApp/build.gradle.kts). Everyone else hits the provider directly.
+    @PublishedApi
+    internal val baseUrl: String
+        get() = if (getPlatform() == Platform.Web) "http://localhost:8080/replicate" else "https://api.replicate.com"
 
     @PublishedApi
     internal fun directSpec(url: String) = AiDirectSpec(
@@ -59,7 +67,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
     ): AiApiBaseResponse<ReplicatePredictionResponse> = aiTransport.execute(
         method = HttpMethod.Post,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCreateModelPrediction",
-        direct = directSpec("https://api.replicate.com/v1/models/$modelOwner/$modelName/predictions"),
+        direct = directSpec("$baseUrl/v1/models/$modelOwner/$modelName/predictions"),
         proxyQueryParams = mapOf("model_owner" to modelOwner, "model_name" to modelName),
         body = requestBody,
     )
@@ -86,7 +94,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
     suspend fun createPrediction(requestBody: ReplicatePredictionRequest): AiApiBaseResponse<ReplicatePredictionResponse> = aiTransport.execute(
         method = HttpMethod.Post,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCreatePrediction",
-        direct = directSpec("https://api.replicate.com/v1/predictions"),
+        direct = directSpec("$baseUrl/v1/predictions"),
         body = requestBody,
     )
 
@@ -107,7 +115,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
     suspend fun getPredictionStatus(id: String): AiApiBaseResponse<ReplicatePredictionResponse> = aiTransport.execute(
         method = HttpMethod.Get,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateGetPredictionStatus",
-        direct = directSpec("https://api.replicate.com/v1/predictions/$id"),
+        direct = directSpec("$baseUrl/v1/predictions/$id"),
         proxyQueryParams = mapOf("id" to id),
     )
 
@@ -128,7 +136,7 @@ class ReplicateApiService(val aiTransport: AiTransport) {
     suspend fun cancelPrediction(id: String): AiApiBaseResponse<ReplicatePredictionResponse> = aiTransport.execute(
         method = HttpMethod.Post,
         proxyUrl = "${AppConfiguration.CLOUD_FUNCTIONS_URL}/replicateCancelPrediction",
-        direct = directSpec("https://api.replicate.com/v1/predictions/$id/cancel"),
+        direct = directSpec("$baseUrl/v1/predictions/$id/cancel"),
         proxyQueryParams = mapOf("id" to id),
     )
 }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Platform.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Platform.kt
@@ -3,6 +3,16 @@ package com.kotlinfoundation.koko.util
 import kotlinx.coroutines.CoroutineDispatcher
 import org.koin.core.module.Module
 
+/** The platform the app is currently running on. */
+sealed interface Platform {
+    data object Android : Platform
+    data object Ios : Platform
+    data object Desktop : Platform
+    data object Web : Platform
+}
+
+expect fun getPlatform(): Platform
+
 // Per-platform hooks resolved via expect/actual: the platform's Koin module, app-start side
 // effects, environment flags, and the default background dispatcher.
 internal expect val platformModule: Module

--- a/MobileApp/shared/src/iosMain/kotlin/com/kotlinfoundation/koko/util/Platform.ios.kt
+++ b/MobileApp/shared/src/iosMain/kotlin/com/kotlinfoundation/koko/util/Platform.ios.kt
@@ -52,9 +52,11 @@ object IosPushNotificationHandler {
     }
 }
 
+actual fun getPlatform(): Platform = Platform.Ios
+
 internal actual val isAndroid = false
 
 @OptIn(ExperimentalNativeApi::class)
-internal actual val isDebug = Platform.isDebugBinary
+internal actual val isDebug = kotlin.native.Platform.isDebugBinary
 
 actual val defaultAsyncDispatcher: CoroutineDispatcher = Dispatchers.IO

--- a/MobileApp/shared/src/jvmMain/kotlin/com/kotlinfoundation/koko/util/Platform.jvm.kt
+++ b/MobileApp/shared/src/jvmMain/kotlin/com/kotlinfoundation/koko/util/Platform.jvm.kt
@@ -41,6 +41,8 @@ internal actual fun onApplicationStartPlatformSpecific() {
     FileKit.init("com.kotlinfoundation.koko")
 }
 
+actual fun getPlatform(): Platform = Platform.Desktop
+
 internal actual val isAndroid: Boolean
     get() = false
 internal actual val isDebug: Boolean

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/Platform.web.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/Platform.web.kt
@@ -41,6 +41,8 @@ internal actual fun onApplicationStartPlatformSpecific() {
     )
 }
 
+actual fun getPlatform(): Platform = Platform.Web
+
 internal actual val isAndroid: Boolean get() = false
 internal actual val isDebug: Boolean get() = false
 

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
@@ -77,7 +77,7 @@ class FileManagerImpl(
         val extension = fileExtension
             ?: url.fileExtension().ifEmpty { null }
             ?: return@execute Result.failure(Exception("Failed to download. Please specify file extension"))
-        val bytes = httpClient.get(url).readRawBytes()
+        val bytes = httpClient.get(url.throughDevProxy()).readRawBytes()
         val name = createNewUniqueFileNameWithExtension(fileExtension = extension)
         store[name] = bytes
         Result.success(name)
@@ -105,6 +105,23 @@ class FileManagerImpl(
     private fun String.decodeBase64OrNull(): ByteArray? = runCatching { Base64.decode(this) }.getOrNull()
 
     private fun String.fileExtension(): String = substringAfterLast('.', "").substringBefore(';').lowercase()
+
+    /**
+     * Rewrite a provider CDN URL to the same-origin dev-server proxy so the browser can fetch the
+     * generated image (the CDNs, e.g. `replicate.delivery`, send no `Access-Control-Allow-Origin`, so a
+     * direct cross-origin fetch is CORS-blocked). Matches the `devServer.proxy` block in
+     * `webApp/build.gradle.kts`. Local-dev only; a deployed web build fetches via the Cloud Functions proxy.
+     */
+    private fun String.throughDevProxy(): String = CDN_PROXY_REWRITES.entries
+        .firstOrNull { (origin, _) -> startsWith(origin) }
+        ?.let { (origin, proxyPath) -> proxyPath + removePrefix(origin) }
+        ?: this
+
+    private companion object {
+        val CDN_PROXY_REWRITES = mapOf(
+            "https://replicate.delivery" to "http://localhost:8080/rdelivery",
+        )
+    }
 }
 
 @OptIn(ExperimentalEncodingApi::class)

--- a/MobileApp/webApp/build.gradle.kts
+++ b/MobileApp/webApp/build.gradle.kts
@@ -24,6 +24,45 @@ kotlin {
                 devServer =
                     (devServer ?: KotlinWebpackConfig.DevServer()).apply {
                         static(project.projectDir.path)
+                        // Local-dev CORS bypass for DIRECT-mode AI: the browser can't call
+                        // api.replicate.com / api.openai.com (no Access-Control-Allow-Origin), so the app
+                        // (on web) calls same-origin /replicate & /openai and the dev server proxies them
+                        // to the provider with the key forwarded server-side. See baseUrl in
+                        // ReplicateApiService / OpenAiApiService.
+                        // Deployed web still needs the Cloud Functions proxy (CLOUD_FUNCTIONS_URL).
+                        proxy =
+                            (proxy ?: mutableListOf()).apply {
+                                add(
+                                    KotlinWebpackConfig.DevServer.Proxy(
+                                        context = mutableListOf("/replicate"),
+                                        target = "https://api.replicate.com",
+                                        pathRewrite = mutableMapOf("^/replicate" to ""),
+                                        changeOrigin = true,
+                                        secure = false,
+                                    ),
+                                )
+                                add(
+                                    KotlinWebpackConfig.DevServer.Proxy(
+                                        context = mutableListOf("/openai"),
+                                        target = "https://api.openai.com",
+                                        pathRewrite = mutableMapOf("^/openai" to ""),
+                                        changeOrigin = true,
+                                        secure = false,
+                                    ),
+                                )
+                                // Replicate's output-image CDN also sends no CORS headers, so the
+                                // generated image is fetched through the proxy too (see FileManager.web.kt).
+                                add(
+                                    KotlinWebpackConfig.DevServer.Proxy(
+                                        // Non-nested prefix: "/replicate" would greedily match this path too.
+                                        context = mutableListOf("/rdelivery"),
+                                        target = "https://replicate.delivery",
+                                        pathRewrite = mutableMapOf("^/rdelivery" to ""),
+                                        changeOrigin = true,
+                                        secure = false,
+                                    ),
+                                )
+                            }
                     }
             }
         }


### PR DESCRIPTION
## Problem

DIRECT-mode AI (no Cloud Functions proxy) works on native/desktop but **not on web**. The browser blocks the calls: `api.replicate.com`, `api.openai.com`, and `replicate.delivery` (the output-image CDN) send no `Access-Control-Allow-Origin`, so cross-origin `fetch` is CORS-blocked. Previously the only fix was deploying the full Firebase proxy.

## Approach

Route web calls through the **wasm dev server** so they're same-origin:

- `webApp/build.gradle.kts` — `devServer.proxy` forwards `/replicate` → api.replicate.com, `/openai` → api.openai.com, `/rdelivery` → replicate.delivery, with the key forwarded server-side.
- New `getPlatform()` (sealed `Platform`: Android / Ios / Desktop / Web) in `Platform.kt` + actuals. The AI services pick their base URL by platform: web → the localhost proxy paths, everyone else → the provider hosts directly.
- `FileManager.web.kt` rewrites the `replicate.delivery` output URL through `/rdelivery` so the generated-image download isn't CORS-blocked either.

## Verified

Web text→image end-to-end with `CLOUD_FUNCTIONS_URL` blank:
- `POST localhost:8080/replicate/... → 201` (prediction succeeded)
- `GET localhost:8080/rdelivery/... → 200` (output image)
- image renders on the Result screen.

wasm + shared JVM compile clean; spotless applied.

## Caveats

- **Local-dev only** — works while the wasm dev server runs. A *deployed* web build still needs the Cloud Functions proxy (`CLOUD_FUNCTIONS_URL`).
- Web base URL is hardcoded to the dev-server default port `8080`.
- Direct mode still ships the key in the web binary — prototyping only.