### PR TITLE
Persist web file bytes to OPFS so images survive reload

### DIFF
--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
@@ -59,9 +59,6 @@ object Constants {
     // DataStore requires the file name to end with ".preferences_pb"
     const val PREFERENCES_STORAGE_NAME = "user_preferences.preferences_pb"
 
-    // OPFS subdirectory holding the web FileManager's persisted image bytes. App-agnostic like the DB /
-    // prefs names above — OPFS is origin-scoped so no cross-app collision, and the refactor script leaves
-    // it alone (no app id/name baked in).
     const val WEB_INTERNAL_FILES_DIR_NAME = "internal_files"
 
     val subscriptionUrl =

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/Constants.kt
@@ -59,6 +59,11 @@ object Constants {
     // DataStore requires the file name to end with ".preferences_pb"
     const val PREFERENCES_STORAGE_NAME = "user_preferences.preferences_pb"
 
+    // OPFS subdirectory holding the web FileManager's persisted image bytes. App-agnostic like the DB /
+    // prefs names above — OPFS is origin-scoped so no cross-app collision, and the refactor script leaves
+    // it alone (no app id/name baked in).
+    const val WEB_INTERNAL_FILES_DIR_NAME = "internal_files"
+
     val subscriptionUrl =
         if (isAndroid) {
             "https://play.google.com/store/account/subscriptions"

--- a/MobileApp/shared/src/jsMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.js.kt
+++ b/MobileApp/shared/src/jsMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.js.kt
@@ -6,10 +6,10 @@ import kotlin.js.Promise
 // Kotlin/JS `js(...)` does not support async/await, so these use plain Promise chains (the wasmJs actual
 // can use async/await via @JsFun).
 
-private fun opfsWriteFileJs(name: String, b64: String): Promise<Unit> = js(
+private fun opfsWriteFileJs(dirName: String, name: String, b64: String): Promise<Unit> = js(
     """
     navigator.storage.getDirectory()
-      .then(function (root) { return root.getDirectoryHandle('koko_files', { create: true }); })
+      .then(function (root) { return root.getDirectoryHandle(dirName, { create: true }); })
       .then(function (dir) { return dir.getFileHandle(name, { create: true }); })
       .then(function (fh) { return fh.createWritable(); })
       .then(function (w) {
@@ -21,14 +21,14 @@ private fun opfsWriteFileJs(name: String, b64: String): Promise<Unit> = js(
     """,
 )
 
-internal actual suspend fun opfsWriteFile(name: String, base64: String) {
-    opfsWriteFileJs(name, base64).await()
+internal actual suspend fun opfsWriteFile(dirName: String, name: String, base64: String) {
+    opfsWriteFileJs(dirName, name, base64).await()
 }
 
-private fun opfsReadAllFilesJs(): Promise<String> = js(
+private fun opfsReadAllFilesJs(dirName: String): Promise<String> = js(
     """
     navigator.storage.getDirectory()
-      .then(function (root) { return root.getDirectoryHandle('koko_files', { create: true }); })
+      .then(function (root) { return root.getDirectoryHandle(dirName, { create: true }); })
       .then(function (dir) {
         var it = dir.entries();
         var out = [];
@@ -53,4 +53,4 @@ private fun opfsReadAllFilesJs(): Promise<String> = js(
     """,
 )
 
-internal actual suspend fun opfsReadAllFiles(): String = opfsReadAllFilesJs().await()
+internal actual suspend fun opfsReadAllFiles(dirName: String): String = opfsReadAllFilesJs(dirName).await()

--- a/MobileApp/shared/src/jsMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.js.kt
+++ b/MobileApp/shared/src/jsMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.js.kt
@@ -1,0 +1,56 @@
+package com.kotlinfoundation.koko.util.file
+
+import kotlinx.coroutines.await
+import kotlin.js.Promise
+
+// Kotlin/JS `js(...)` does not support async/await, so these use plain Promise chains (the wasmJs actual
+// can use async/await via @JsFun).
+
+private fun opfsWriteFileJs(name: String, b64: String): Promise<Unit> = js(
+    """
+    navigator.storage.getDirectory()
+      .then(function (root) { return root.getDirectoryHandle('koko_files', { create: true }); })
+      .then(function (dir) { return dir.getFileHandle(name, { create: true }); })
+      .then(function (fh) { return fh.createWritable(); })
+      .then(function (w) {
+        var bin = atob(b64);
+        var arr = new Uint8Array(bin.length);
+        for (var i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+        return w.write(arr).then(function () { return w.close(); });
+      })
+    """,
+)
+
+internal actual suspend fun opfsWriteFile(name: String, base64: String) {
+    opfsWriteFileJs(name, base64).await()
+}
+
+private fun opfsReadAllFilesJs(): Promise<String> = js(
+    """
+    navigator.storage.getDirectory()
+      .then(function (root) { return root.getDirectoryHandle('koko_files', { create: true }); })
+      .then(function (dir) {
+        var it = dir.entries();
+        var out = [];
+        var step = function () {
+          return it.next().then(function (res) {
+            if (res.done) return JSON.stringify(out);
+            var n = res.value[0], h = res.value[1];
+            if (h.kind !== 'file') return step();
+            return h.getFile()
+              .then(function (f) { return f.arrayBuffer(); })
+              .then(function (ab) {
+                var buf = new Uint8Array(ab);
+                var s = '';
+                for (var i = 0; i < buf.length; i++) s += String.fromCharCode(buf[i]);
+                out.push({ n: n, d: btoa(s) });
+                return step();
+              });
+          });
+        };
+        return step();
+      })
+    """,
+)
+
+internal actual suspend fun opfsReadAllFiles(): String = opfsReadAllFilesJs().await()

--- a/MobileApp/shared/src/wasmJsMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.wasmJs.kt
+++ b/MobileApp/shared/src/wasmJsMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.wasmJs.kt
@@ -6,9 +6,9 @@ import kotlin.js.Promise
 @OptIn(ExperimentalWasmJsInterop::class)
 @JsFun(
     """
-    (name, b64) => (async () => {
+    (dirName, name, b64) => (async () => {
       const root = await navigator.storage.getDirectory();
-      const dir = await root.getDirectoryHandle('koko_files', { create: true });
+      const dir = await root.getDirectoryHandle(dirName, { create: true });
       const fh = await dir.getFileHandle(name, { create: true });
       const w = await fh.createWritable();
       const bin = atob(b64);
@@ -19,18 +19,18 @@ import kotlin.js.Promise
     })()
     """,
 )
-private external fun opfsWriteFileJs(name: String, b64: String): Promise<JsAny?>
+private external fun opfsWriteFileJs(dirName: String, name: String, b64: String): Promise<JsAny?>
 
-internal actual suspend fun opfsWriteFile(name: String, base64: String) {
-    opfsWriteFileJs(name, base64).await()
+internal actual suspend fun opfsWriteFile(dirName: String, name: String, base64: String) {
+    opfsWriteFileJs(dirName, name, base64).await()
 }
 
 @OptIn(ExperimentalWasmJsInterop::class)
 @JsFun(
     """
-    () => (async () => {
+    (dirName) => (async () => {
       const root = await navigator.storage.getDirectory();
-      const dir = await root.getDirectoryHandle('koko_files', { create: true });
+      const dir = await root.getDirectoryHandle(dirName, { create: true });
       const out = [];
       for await (const [n, h] of dir.entries()) {
         if (h.kind !== 'file') continue;
@@ -44,6 +44,6 @@ internal actual suspend fun opfsWriteFile(name: String, base64: String) {
     })()
     """,
 )
-private external fun opfsReadAllFilesJs(): Promise<JsString>
+private external fun opfsReadAllFilesJs(dirName: String): Promise<JsString>
 
-internal actual suspend fun opfsReadAllFiles(): String = opfsReadAllFilesJs().await().toString()
+internal actual suspend fun opfsReadAllFiles(dirName: String): String = opfsReadAllFilesJs(dirName).await().toString()

--- a/MobileApp/shared/src/wasmJsMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.wasmJs.kt
+++ b/MobileApp/shared/src/wasmJsMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.wasmJs.kt
@@ -1,0 +1,49 @@
+package com.kotlinfoundation.koko.util.file
+
+import kotlinx.coroutines.await
+import kotlin.js.Promise
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun(
+    """
+    (name, b64) => (async () => {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle('koko_files', { create: true });
+      const fh = await dir.getFileHandle(name, { create: true });
+      const w = await fh.createWritable();
+      const bin = atob(b64);
+      const arr = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+      await w.write(arr);
+      await w.close();
+    })()
+    """,
+)
+private external fun opfsWriteFileJs(name: String, b64: String): Promise<JsAny?>
+
+internal actual suspend fun opfsWriteFile(name: String, base64: String) {
+    opfsWriteFileJs(name, base64).await()
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
+@JsFun(
+    """
+    () => (async () => {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle('koko_files', { create: true });
+      const out = [];
+      for await (const [n, h] of dir.entries()) {
+        if (h.kind !== 'file') continue;
+        const f = await h.getFile();
+        const buf = new Uint8Array(await f.arrayBuffer());
+        let s = '';
+        for (let i = 0; i < buf.length; i++) s += String.fromCharCode(buf[i]);
+        out.push({ n: n, d: btoa(s) });
+      }
+      return JSON.stringify(out);
+    })()
+    """,
+)
+private external fun opfsReadAllFilesJs(): Promise<JsString>
+
+internal actual suspend fun opfsReadAllFiles(): String = opfsReadAllFilesJs().await().toString()

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
@@ -1,6 +1,7 @@
 package com.kotlinfoundation.koko.util.file
 
 import com.kotlinfoundation.koko.data.BackgroundExecutor
+import com.kotlinfoundation.koko.util.Constants
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.download
@@ -118,12 +119,12 @@ class FileManagerImpl(
     /** Cache the bytes in memory and persist them to OPFS (fire-and-forget) so they survive a reload. */
     private fun put(name: String, bytes: ByteArray) {
         store[name] = bytes
-        scope.launch { opfsWriteFile(name, Base64.encode(bytes)) }
+        scope.launch { opfsWriteFile(Constants.WEB_INTERNAL_FILES_DIR_NAME, name, Base64.encode(bytes)) }
     }
 
     /** Reload every OPFS-persisted file into the in-memory cache. Best-effort — a failure leaves the map empty. */
     private suspend fun warmUpFromOpfs() {
-        val json = opfsReadAllFiles()
+        val json = opfsReadAllFiles(Constants.WEB_INTERNAL_FILES_DIR_NAME)
         val entries = runCatching { Json.parseToJsonElement(json).jsonArray }.getOrNull() ?: return
         entries.forEach { entry ->
             val obj = entry.jsonObject

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/FileManager.web.kt
@@ -10,15 +10,28 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 /**
  * Web (js/wasmJs) file manager. The browser has no filesystem paths, so this keeps file bytes in an
  * in-memory map keyed by the same unique names the other platforms use, and resolves a name to a
- * `data:` URL for display (Coil on web loads it through the Ktor/fetch engine). Byte storage is
- * **session-scoped** — images do not survive a page reload (Room rows do, but their bytes are gone).
+ * `data:` URL for display (Coil on web loads it through the Ktor/fetch engine).
+ *
+ * The map is a **cache over OPFS**, not the source of truth: writes also persist to OPFS (see
+ * [WebFileStore]) and a warm-up on construction reloads every persisted file back into the map, so
+ * images survive a page reload / new tab (matching the OPFS-backed Room database). The warm-up races the
+ * first render — a not-yet-loaded image resolves to an empty string until the map fills — but boot +
+ * navigation is far slower than reading a handful of files, so in practice the map is warm before any
+ * gallery read.
  *
  * Any string that leaves this class as an "absolute path" is a `data:` URL, and any web-internal
  * resolution accepts either such a URL or a bare store name.
@@ -31,6 +44,13 @@ class FileManagerImpl(
 ) : FileManager {
 
     private val store = mutableMapOf<String, ByteArray>()
+
+    // SupervisorJob: a failed OPFS write must not tear down the warm-up or later persists.
+    private val scope = CoroutineScope(SupervisorJob() + defaultDispatcher)
+
+    init {
+        scope.launch { warmUpFromOpfs() }
+    }
 
     override fun getAbsoluteFilePathRelativeToInternal(relativePathToInternal: String): String {
         val bytes = store[relativePathToInternal] ?: return ""
@@ -45,7 +65,7 @@ class FileManagerImpl(
             ?: return@execute Result.failure(Exception("No file to copy for: $originalFileAbsolutePath"))
         val extension = originalFileAbsolutePath.fileExtension().ifEmpty { "png" }
         val name = newFileName ?: createNewUniqueFileNameWithExtension(extension)
-        store[name] = bytes
+        put(name, bytes)
         Result.success(name)
     }
 
@@ -56,7 +76,7 @@ class FileManagerImpl(
         val bytes = base64Image.decodeBase64OrNull()
             ?: return@execute Result.failure(Exception("Invalid base64 image"))
         val name = createNewUniqueFileNameWithExtension(fileExtension = imageExtension)
-        store[name] = bytes
+        put(name, bytes)
         Result.success(name)
     }.getOrNull()
 
@@ -79,7 +99,7 @@ class FileManagerImpl(
             ?: return@execute Result.failure(Exception("Failed to download. Please specify file extension"))
         val bytes = httpClient.get(url.throughDevProxy()).readRawBytes()
         val name = createNewUniqueFileNameWithExtension(fileExtension = extension)
-        store[name] = bytes
+        put(name, bytes)
         Result.success(name)
     }
 
@@ -94,6 +114,24 @@ class FileManagerImpl(
     override suspend fun readInternalFileBytes(fileNameWithExtension: String): ByteArray = resolveBytes(fileNameWithExtension) ?: error("No file bytes for: $fileNameWithExtension")
 
     override fun getPlatformFile(absoluteFilePath: String): PlatformFile = throw UnsupportedOperationException("getPlatformFile is not supported on web")
+
+    /** Cache the bytes in memory and persist them to OPFS (fire-and-forget) so they survive a reload. */
+    private fun put(name: String, bytes: ByteArray) {
+        store[name] = bytes
+        scope.launch { opfsWriteFile(name, Base64.encode(bytes)) }
+    }
+
+    /** Reload every OPFS-persisted file into the in-memory cache. Best-effort — a failure leaves the map empty. */
+    private suspend fun warmUpFromOpfs() {
+        val json = opfsReadAllFiles()
+        val entries = runCatching { Json.parseToJsonElement(json).jsonArray }.getOrNull() ?: return
+        entries.forEach { entry ->
+            val obj = entry.jsonObject
+            val name = obj["n"]?.jsonPrimitive?.content ?: return@forEach
+            val bytes = obj["d"]?.jsonPrimitive?.content?.decodeBase64OrNull() ?: return@forEach
+            store.getOrPut(name) { bytes } // don't clobber a write that landed during warm-up
+        }
+    }
 
     private fun resolveBytes(pathOrDataUrl: String): ByteArray? = when {
         pathOrDataUrl.startsWith("data:") -> pathOrDataUrl.substringAfter(',', "").decodeBase64OrNull()

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.kt
@@ -5,11 +5,12 @@ package com.kotlinfoundation.koko.util.file
  * saved images survive a page reload or a new tab — the in-memory map alone is session-scoped.
  *
  * Bytes cross the JS boundary as **base64 strings** (clean on both js and wasmJs; avoids typed-array
- * interop differences). Files live under an `koko_files/` OPFS subdirectory so they don't collide with
- * the SQLite database file at the OPFS root. The only per-target difference is these two functions
- * (`@JsFun` on wasmJs, `js("…")` on js) — same split as `createSQLiteWorker()`.
+ * interop differences). Files live under a [dirName] OPFS subdirectory so they don't collide with the
+ * SQLite database file at the OPFS root. [dirName] is passed in (not a literal in the JS) so it stays a
+ * Kotlin constant — see `Constants.WEB_INTERNAL_FILES_DIR_NAME`. The only per-target difference is these
+ * two functions (`@JsFun` on wasmJs, `js("…")` on js) — same split as `createSQLiteWorker()`.
  */
-internal expect suspend fun opfsWriteFile(name: String, base64: String)
+internal expect suspend fun opfsWriteFile(dirName: String, name: String, base64: String)
 
 /** Reads every persisted file back as a JSON array `[{ "n": name, "d": base64 }, …]` (for warm-up). */
-internal expect suspend fun opfsReadAllFiles(): String
+internal expect suspend fun opfsReadAllFiles(dirName: String): String

--- a/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.kt
+++ b/MobileApp/shared/src/webMain/kotlin/com/kotlinfoundation/koko/util/file/WebFileStore.kt
@@ -1,0 +1,15 @@
+package com.kotlinfoundation.koko.util.file
+
+/**
+ * OPFS (Origin Private File System) persistence for the web [FileManagerImpl]'s bytes, so generated /
+ * saved images survive a page reload or a new tab — the in-memory map alone is session-scoped.
+ *
+ * Bytes cross the JS boundary as **base64 strings** (clean on both js and wasmJs; avoids typed-array
+ * interop differences). Files live under an `koko_files/` OPFS subdirectory so they don't collide with
+ * the SQLite database file at the OPFS root. The only per-target difference is these two functions
+ * (`@JsFun` on wasmJs, `js("…")` on js) — same split as `createSQLiteWorker()`.
+ */
+internal expect suspend fun opfsWriteFile(name: String, base64: String)
+
+/** Reads every persisted file back as a JSON array `[{ "n": name, "d": base64 }, …]` (for warm-up). */
+internal expect suspend fun opfsReadAllFiles(): String


### PR DESCRIPTION
## Problem

On web, the `FileManager` kept image bytes only in an in-memory map, so generated / saved images disappeared on a **page reload or in a new tab**. Room rows persisted (OPFS-backed DB), but their bytes did not — the gallery showed broken images.

## Approach

Back the in-memory map with **OPFS** (already used for the SQLite DB):

- Writes (`save` / `copy` / `download`) also persist to a `koko_files/` OPFS subdirectory (fire-and-forget).
- A **warm-up** on `FileManagerImpl` construction reloads every persisted file back into the map. The map becomes a *cache over OPFS*, not the source of truth.
- New `WebFileStore` expect/actual does the OPFS I/O. Bytes cross the JS boundary as **base64 strings** (clean on both targets; avoids typed-array interop differences): `@JsFun` async/await on wasmJs, Promise chains on js (Kotlin/JS `js(...)` rejects async/await).

The `getAbsoluteFilePathRelativeToInternal` getter stays synchronous. The warm-up races the first render, but boot + navigation is far slower than reading a handful of files, so the cache is warm before any gallery read.

## Verified (wasmJs)

Generate an image → confirm it lands in OPFS (`koko_files/IMG_….jpeg`) → **hard-reload** (fresh runtime, empty map) → open Gallery → image renders, reloaded from OPFS. wasmJs + js compile clean; spotless applied.

## Notes

- OPFS subdir `koko_files/` keeps image files off the OPFS root so they don't mix with the SQLite DB file.
- No new dependencies (OPFS is browser-native).