### PR TITLE
Add build-loop guardrails to validation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,13 @@ All Gradle commands run from `MobileApp/`.
 2. **Unit + UI tests**: `./gradlew :shared:jvmTest :shared:testAndroidHostTest` — both source sets pull from `commonTest`. `jvmTest` also includes `jvmTest/`-only tests (e.g. headless `runComposeUiTest`).
 3. **Android debug build**: `./gradlew :androidApp:assembleDebug` — also builds `:shared` transitively.
 
+### Validation guardrails (avoid the build loop)
+These three scoped tasks ARE the whole validation. Do not improvise around them:
+- **Never run the aggregate tasks `check`, `build`, or `clean build`.** They pull in **every** target — including iOS — so an unrelated iOS cache/link failure fails the whole run, which reads as "broken" and tempts a retry loop. They are also far slower. Run only the three scoped gates above (plus the web/iOS compile checks below when relevant).
+- **`assembleDebug` succeeding IS the Android validation.** Do **not** then auto-install + launch via `adb` and poll to "confirm it works" — the launcher Activity is `.AppActivity` (Application class `.AndroidApp`), but guessing/parsing it via adb is fragile and is what spirals into a loop. To see the app actually render, use the `verify-ui` skill (headless PNG) or hand off to the developer to hit Run in the IDE.
+- **Run tasks are long-running and never exit**: `:desktopApp:run`, `:webApp:wasmJsBrowserDevelopmentRun`, `:androidApp:installDebug`+launch. Start once (background if you need the shell back); a task that hasn't returned is **running, not hung** — do not kill and re-run.
+- **A failed or slow gate is not a retry signal.** Read the error and fix it, or STOP and report to the developer. Never re-run the same command hoping it passes. First build is slow (downloads JBR + Compose) — expected, not a hang.
+
 ### Other test paths
 - **Android UI/logic** (instrumented): `./gradlew :androidApp:connectedDebugAndroidTest` (device required).
 - **Design system only**: just compile with build tasks; no tests yet.

--- a/skills/run-quality-gates/SKILL.md
+++ b/skills/run-quality-gates/SKILL.md
@@ -40,6 +40,15 @@ Rules:
 - Web check when web code changed: `./gradlew :shared:compileKotlinWasmJs :shared:compileKotlinJs`.
 - Quick iOS-code compile check without a full build: `./gradlew :shared:compileAppleMainKotlinMetadata`.
 
+## Do NOT (this is what causes a build loop)
+
+The three scoped tasks above ARE the whole validation. Improvising around them is what spirals.
+
+- **Never run `check`, `build`, or `clean build`.** They aggregate **every** target — including iOS — so an unrelated iOS cache/link failure fails the whole run and reads as "broken", tempting a retry. They're also far slower. Use the scoped gates, nothing wider.
+- **Don't launch the app to "verify" a code change.** `:androidApp:assembleDebug` compiling green IS the Android gate. Do **not** auto-install + launch via `adb` and poll for the process — the launcher Activity is `.AppActivity` (Application class `.AndroidApp`), but detecting it via adb is fragile and is exactly what loops. To watch it render, use **`verify-ui`** (headless PNG) or ask the developer to hit Run in the IDE.
+- **Run tasks never return** (`:desktopApp:run`, `:webApp:wasmJsBrowserDevelopmentRun`, `installDebug`+launch). A command that hasn't exited is **running, not hung** — start it once (in the background if you need the shell) and move on; do not kill and re-run.
+- **A failed or slow command is not a retry signal.** Read the error → fix it, or STOP and report. Never re-run the same command hoping for a different result. The **first** build is slow (downloads JBR + Compose) — expected, not a hang.
+
 ---
 
 *Cross-phase — every guide's validation steps call this skill.*

--- a/skills/run-the-app/SKILL.md
+++ b/skills/run-the-app/SKILL.md
@@ -51,6 +51,23 @@ open iosApp/iosApp.xcodeproj
 ```
 Do NOT run iOS builds for routine validation — they are slow. Only when the change is iOS-specific.
 
+## Run vs. verify — don't loop
+
+`run-the-app` is for a **human** to see the app. When you (the agent) just need to confirm a change is
+sound, do **not** launch it:
+
+- **Compiling is the check.** `:androidApp:assembleDebug` (or `:desktopApp:run` for a one-off visual) is
+  enough. Do **not** auto-install and launch via `adb` and poll for the process to "confirm it works" —
+  the launcher Activity is `.AppActivity` (Application class `.AndroidApp`), but detecting it via adb is
+  fragile and is a classic retry-loop trap. For behaviour/appearance use the **`verify-ui`** skill.
+- **`run` tasks never exit** (`:desktopApp:run`, `:webApp:wasmJsBrowserDevelopmentRun`, `installDebug`+launch).
+  A task that hasn't returned is **running, not hung** — start it once (background if you need the shell)
+  and stop; do not kill and re-run.
+- **Never run `check` / `build` / `clean build`** to validate — they aggregate every target (incl. iOS) and
+  a single iOS cache failure fails the whole thing, which loops. See `run-quality-gates` for the scoped gates.
+- A failed/slow command is **not** a retry signal: read the error, fix or STOP. First build is slow
+  (JBR + Compose download) — expected.
+
 ## First-run failures
 
 - `SDK location not found` → `sdk.dir` missing/wrong in `MobileApp/local.properties`.


### PR DESCRIPTION
## Problem

An agent building a generated app got stuck **re-running gradle in a loop** — `check`, `build`, `clean build`, `:shared:testAndroidHostTest`, `:desktopApp:run` over and over (screenshots from the user's session).

Its own explanation named the two causes, both **guidance gaps**:
1. It ran the aggregate **`check`** task, which pulls in **iOS** — an unrelated iOS cache issue failed the whole run, which read as "broken" → retry.
2. It tried to **auto-install + launch on the emulator via `adb`**, misidentified the Activity name → retry.

## Fix

Explicit guardrails added to `AGENTS.md`, `skills/run-quality-gates/SKILL.md`, and `skills/run-the-app/SKILL.md`:

- **Never run `check` / `build` / `clean build`** — they aggregate every target (incl. iOS); one iOS failure fails everything. Only the three scoped gates.
- **`assembleDebug` compiling IS the Android validation** — don't adb-launch-and-poll to "confirm it works". Launcher Activity is `.AppActivity` (Application `.AndroidApp`), but detecting it via adb is fragile. Use `verify-ui` or hand off to the IDE.
- **Run tasks never exit** (`:desktopApp:run`, `:webApp:wasmJsBrowserDevelopmentRun`, `installDebug`+launch) — a non-returning task is *running, not hung*; don't kill and re-run.
- **A failed/slow command is not a retry signal** — fix or STOP, never loop. First build is slow (JBR + Compose download) by design.

Docs-only; no code changes.