### PR TITLE
Pin progress-file location + add resume instruction (two-window fix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,14 +350,21 @@ Two layers:
 - **Guides** — one per phase of the developer journey. Each is an ordered checklist whose steps are tagged **Agent Action** / **User Action** / **Validation**; stop at each **User Action** and wait for the developer. Copy the guide's `progress-template.md` to track progress.
 - **Task skills** — one job each, usable standalone; the guides call them by name.
 
-**Progress tracking (read these before resuming any work):** progress files live at the repo root, are committed, and are how a new session learns what's already done.
+**Progress tracking (read these before resuming any work):** progress files live at the **git repository root**, are committed, and are how a new session learns what's already done.
+
+> **Where exactly is "the repo root"?** It is the folder that **contains** `MobileApp/`, `Web/`, and
+> `Documentation/` (the git root) — **not** inside `MobileApp/`. This matters because the developer
+> usually opens `MobileApp/` in Android Studio (the "MobileApp Window"), so from that window the progress
+> files are **one level up**: read/write them at `../PROGRESS_*.md`. Never create them inside `MobileApp/`
+> — that scatters duplicates and later sessions look in the wrong place. If you can't find them, look at
+> the git root before assuming they don't exist (`git rev-parse --show-toplevel`).
 
 | File | Tracks | Written by |
 |---|---|---|
 | `PROGRESS_FEATURES.md` | **What's actually built** — each model/screen from the PRD, plus the branded onboarding/paywall | `build-features` |
 | `PROGRESS_P1_GETTING_STARTED.md` … `PROGRESS_P5_GROWTH.md` | The *guide's* steps for each phase | the phase guides |
 
-**Resume rule:** before building, read the relevant progress file and continue from the **first unchecked item**. Never redo checked work; never re-derive a plan while unchecked items remain. Tick items off as you finish them, not at the end.
+**Resume rule:** before building, read the relevant progress file and continue from the **first unchecked item**. Never redo checked work; never re-derive a plan while unchecked items remain. Tick items off as you finish them, not at the end. If you finish a chunk (e.g. onboarding screens) and the guide has more unchecked items, **keep going through the guide** — do not stop and ask "what next"; the next step is the next unchecked item.
 
 **Starting from an idea** ("build me a habit tracker"): run **`skills/new-app/`** first — it interviews the developer, writes `AiGuidelines/project/{prd,user_flow,ui_ux}.md`, picks the app name/id, and records deferred decisions as `TODO(<phase>)` markers in `root/AppConfiguration.kt`. It then hands off to Phase 1. Phase 1 needs **no Firebase, no subscription provider, no store account** (mock provider + direct-mode AI cover it).
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,10 +28,13 @@ checklist whose steps are tagged **Agent Action** (an agent/dev does it: code, s
 moving on). An agent following a guide **stops at each User Action** and waits for you. Copy the
 guide's `progress-template.md` into your repo to track where you are.
 
-**Progress files** live at your repo root and get committed, so any session resumes where the last one
-stopped: **`PROGRESS_FEATURES.md`** (what's actually built — each model/screen from the PRD, written by
-[build-features](build-features/SKILL.md)) and **`PROGRESS_P1…P5`** (each phase guide's steps). The rule:
-read the file first, continue from the first unchecked item, tick items off as you go.
+**Progress files** live at your **git repo root** — the folder that contains `MobileApp/`, **not** inside
+it (if you opened `MobileApp/` in the IDE, they're one level up at `../PROGRESS_*.md`) — and get committed,
+so any session resumes where the last one stopped: **`PROGRESS_FEATURES.md`** (what's actually built — each
+model/screen from the PRD, written by [build-features](build-features/SKILL.md)) and **`PROGRESS_P1…P5`**
+(each phase guide's steps). The rule: read the file first, continue from the first unchecked item, tick
+items off as you go. If an agent stalls mid-guide, tell it **"continue @koko-mobileapp-getting-started"**
+(or the relevant guide) — it re-reads the progress file and picks up at the first unchecked item.
 
 **Task skills** do one job each and are usable standalone. The guides call them by name.
 

--- a/skills/build-features/SKILL.md
+++ b/skills/build-features/SKILL.md
@@ -15,12 +15,16 @@ All commands run from `MobileApp/`.
 
 ## 0. Resume before you build — **Agent Action, always first**
 
-**`PROGRESS_FEATURES.md`** at the repository root is the record of what has actually been built.
+**`PROGRESS_FEATURES.md`** at the **git repository root** is the record of what has actually been built.
+"Repo root" = the folder that contains `MobileApp/` — **not** inside `MobileApp/`. You're most likely
+running from the MobileApp Window, so it's **one level up**: `../PROGRESS_FEATURES.md`. Confirm the root
+with `git rev-parse --show-toplevel` before deciding the file is missing.
 
 - **If it exists:** read it and **continue from the first unchecked item**. Do **not** re-derive the
   plan and do **not** redo checked work.
 - **If it doesn't:** copy [`progress-template.md`](progress-template.md) (next to this file) to
-  `PROGRESS_FEATURES.md` at the repo root, then derive the plan (step 1) and fill it in.
+  `PROGRESS_FEATURES.md` at the git repo root (`../PROGRESS_FEATURES.md` from the MobileApp Window — never
+  inside `MobileApp/`), then derive the plan (step 1) and fill it in.
 
 **Tick items off as you finish them, not at the end** — a session can stop at any point, and this file
 is the only thing that tells the next one what's left. Commit it with the code.

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -31,6 +31,12 @@ the kit's mock subscription provider and direct-mode AI cover it.
 > If this skill is executed from the **Root Window**, the very first step is to instruct the developer to open a new Android Studio window pointing to the `MobileApp/` directory:
 > *"Our first step involves opening up a new Android Studio window for the MobileApp directory, so we can utilize the Two-Window Approach. Please open the `MobileApp/` directory (at the repository root) in a new window and type 'Run @koko-mobileapp-getting-started' there to load the client environment and begin building the local loop!"*
 
+> **Progress files still live at the repo root.** Even though Phase 1 is driven from the **MobileApp
+> Window**, the `PROGRESS_*.md` files belong at the **git repo root** (the folder containing `MobileApp/`),
+> so from this window write/read them **one level up** (`../PROGRESS_FEATURES.md`,
+> `../PROGRESS_P1_GETTING_STARTED.md`). Never create them inside `MobileApp/` — a later session (or the
+> Root Window) will look at the root and think nothing was done.
+
 > **STOP rule:** When the next unchecked item is a **User Action**, stop and wait for the developer to confirm they've done it before continuing. Never fabricate device state or credentials.
 
 ## Role labels
@@ -74,7 +80,7 @@ Verify: `./scripts/check_env.sh --phase getting-started`.
 ### D. Build your features
 
 8. **Agent Action** — Build the MVP with the **`build-features`** skill: it derives the screens + local models from `prd.md`/`user_flow.md`, scaffolds them (`make_local.sh` / `generate_screen.sh`, **run sequentially** — they patch shared files), implements the UI per `ui_ux.md`, and brands the onboarding + paywall screens that already ship.
-   - It records every model/screen in **`PROGRESS_FEATURES.md`** at the repo root and ticks them off as it goes — so if a session stops, the next one resumes from the first unchecked item instead of guessing.
+   - It records every model/screen in **`PROGRESS_FEATURES.md`** at the **git repo root** (the folder that contains `MobileApp/` — from the MobileApp Window that's one level up, `../PROGRESS_FEATURES.md`; never inside `MobileApp/`) and ticks them off as it goes — so if a session stops, the next one resumes from the first unchecked item instead of guessing.
    - Underlying skills it uses: **`new-local-model`**, **`new-screen`**, and — only if a feature needs them — **`add-api-service`** (any public URL, no backend), **`save-preferences`**, **`add-permission`**.
    - Everything stays local: **no Firebase, no provider account, no store account** in this phase. The paywall runs on the mock provider if you touch it.
 
@@ -89,7 +95,21 @@ Verify: `./scripts/check_env.sh --phase getting-started`.
 
 > **App launches on at least one platform and shows the Home screen; quality gates pass.**
 
-Progress is tracked in `PROGRESS_P1_GETTING_STARTED.md` at the root folder.
+Progress is tracked in `PROGRESS_P1_GETTING_STARTED.md` at the **git repo root** (the folder containing
+`MobileApp/`; from the MobileApp Window it's `../PROGRESS_P1_GETTING_STARTED.md` — never inside `MobileApp/`).
+
+## If the agent stalls or loses its place
+
+This guide is a single ordered checklist — after finishing any step (e.g. the onboarding screens), the
+agent should continue to the **next unchecked item**, not stop and ask "what's next". If it does stall,
+finishes prematurely, or can't find the progress files:
+
+- **Developer:** just say **"continue @koko-mobileapp-getting-started"** (in the MobileApp Window). That
+  reloads this guide; the agent then re-reads the progress files and resumes at the first unchecked item.
+- **Agent, on resume:** first locate the progress files at the **git repo root** — `git rev-parse
+  --show-toplevel`, then read `../PROGRESS_FEATURES.md` and `../PROGRESS_P1_GETTING_STARTED.md`. If they
+  genuinely don't exist yet, create them there (copy `progress-template.md`) — do **not** create them
+  inside `MobileApp/`, and do **not** re-derive a plan or redo checked work.
 
 ## Done → next phase
 


### PR DESCRIPTION
## Problem

Developers open **`MobileApp/`** in Android Studio, but the `PROGRESS_*.md` tracking files live at the **git repo root** (the folder *above* `MobileApp/`). "repo root" was ambiguous, so one agent wrote the files to the git root while the next looked *inside* `MobileApp/`, concluded nothing was tracked, and **stalled mid-guide** instead of continuing (real session: created onboarding screens, then stopped and asked "what next").

## Fix

- **Unambiguous location** across `AGENTS.md`, `skills/README.md`, `getting-started`, and `build-features`: the files live at the **git root** (contains `MobileApp/`), so from the MobileApp Window they're **one level up** (`../PROGRESS_*.md`), never inside `MobileApp/`. Confirm with `git rev-parse --show-toplevel` before assuming they're missing.
- **Developer recovery instruction** (getting-started + README): if the agent stalls or loses its place, say **"continue @koko-mobileapp-getting-started"** — it re-reads the progress files and resumes at the first unchecked item.
- **Reinforced resume rule**: after finishing a chunk (e.g. onboarding), keep going to the next unchecked item instead of stopping to ask.

Docs-only.