### PR TITLE
Link new-app and getting-started with a loop-proof state guard

### DIFF
--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -74,8 +74,9 @@ Verify: `./scripts/check_env.sh --phase getting-started`.
 
 ### C. Define the product (grounds everything downstream)
 
-7. **Agent Action** — The product should already be defined by the **`new-app`** skill: `AiGuidelines/project/prd.md`, `user_flow.md`, and `ui_ux.md` filled, name/id decided, deferred decisions marked `TODO(<phase>)` in `root/AppConfiguration.kt`.
-   - If those files are still blank (just a heading), **stop and run `new-app` first** — it interviews the developer and writes them. Never invent the product yourself.
+7. **Agent Action** — The product must be defined before building: `AiGuidelines/project/prd.md`, `user_flow.md`, and `ui_ux.md` filled, **app name + id decided**, deferred decisions marked `TODO(<phase>)` in `root/AppConfiguration.kt`. This is normally produced by the **`new-app`** skill.
+   - **If any of that is missing** — the docs are still just a heading, or no name/id has been chosen (common when the developer jumped straight into `getting-started`) — invoke **`new-app`** to produce it. It interviews the developer and writes the docs + picks the name/id; never invent the product yourself. When it finishes, **resume this guide at the next unchecked item** (don't restart from step A).
+   - **This cannot loop.** `new-app` fills exactly the files/values checked here, so on return the precondition is satisfied and `new-app` is never re-invoked. The trigger is state-based (docs present + name/id set), not a blind re-run — if the state is already good, skip straight past this step.
 
 ### D. Build your features
 

--- a/skills/new-app/SKILL.md
+++ b/skills/new-app/SKILL.md
@@ -99,9 +99,15 @@ Use `TODO(integrations)` / `TODO(publish)` / `TODO(monetization)` to name the ph
 
 ### 5. Hand off — **Agent Action**
 
-Product is defined. **Continue straight into the [`getting-started`](../getting-started/SKILL.md)
-guide** (don't make the developer ask) — it installs prereqs, runs the app, rebrands it with the name
-and id decided in step 2, and builds the MVP features via **`build-features`**.
+Product is defined. **Continue into the [`getting-started`](../getting-started/SKILL.md) guide** (don't
+make the developer ask) — it installs prereqs, runs the app, rebrands it with the name and id decided in
+step 2, and builds the MVP features via **`build-features`**.
+
+**If `getting-started` invoked you** (it found the product docs / name+id missing and called `new-app`
+to fill them): once the docs are written and the name/id chosen, just **hand back** — `getting-started`
+resumes at its next unchecked item. It will **not** call `new-app` again, because the values it checks
+for now exist. This is the only link between the two skills, and it is one-way + state-guarded, so it
+cannot loop.
 
 ---
 


### PR DESCRIPTION
## Problem

`new-app` and `getting-started` already cross-referenced, but the link wasn't explicit and risked looping. A developer who jumps straight into `getting-started` skips the useful product-definition work `new-app` does (prd/user_flow/ui_ux + name/id + deferred TODOs).

## Fix — one-way, state-guarded link

- **getting-started (step C):** if the product docs **or** app name/id are missing, invoke `new-app` to fill them, then **resume at the next unchecked item** (don't restart). Trigger broadened to include name/id, not just the docs.
- **new-app (hand-off):** if it was invoked *by* `getting-started`, hand back once docs + name/id exist; `getting-started` resumes and won't call `new-app` again.

**Cannot loop:** the trigger is *state* (docs present + name/id set), satisfied after `new-app` runs, so the precondition never re-fires.

Docs-only.