### PR TITLE
Align .agents plugin skills with merged guidance + fill gaps

### DIFF
--- a/.agents/skills/koko-getting-started/SKILL.md
+++ b/.agents/skills/koko-getting-started/SKILL.md
@@ -44,7 +44,9 @@ Once the KMP app is ready (the getting started skill mentioned above is complete
 ## 🚀 Available Skills Index
 
 ### Phase 1: First Run (Local-only)
+- [ ] **[new-app](../../../skills/new-app/SKILL.md)**: Turn a raw idea into a defined product (prd/user_flow/ui_ux + name/id) — the entry point when starting from just an idea.
 - [ ] **[run-the-app](../../../skills/run-the-app/SKILL.md)**: Build and run the app on Android, Desktop, Web, or iOS.
+- [ ] **[build-features](../../../skills/build-features/SKILL.md)**: Derive and implement the MVP screens + local models from the product docs (tracked in PROGRESS_FEATURES.md).
 - [ ] **[refactor-package](../../../skills/refactor-package/SKILL.md)**: Rebrand the app by renaming package/applicationId/bundle ID and display name.
 - [ ] **[new-screen](../../../skills/new-screen/SKILL.md)**: Scaffold a new screen (UI, State, ViewModel, and Navigation).
 - [ ] **[new-local-model](../../../skills/new-local-model/SKILL.md)**: Scaffold a new Room 3 entity, DAO, and DI registration.
@@ -82,3 +84,4 @@ Once the KMP app is ready (the getting started skill mentioned above is complete
 
 ### 🛠️ Quality & Maintenance
 - [ ] **[run-quality-gates](../../../skills/run-quality-gates/SKILL.md)**: Execute lint checks, unit tests, and build validation.
+- [ ] **[verify-ui](../../../skills/verify-ui/SKILL.md)**: Verify a screen's behaviour (headless Compose test) and appearance (render a `@Preview` to a PNG).

--- a/MobileApp/.agents/skills/koko-mobileapp-getting-started/SKILL.md
+++ b/MobileApp/.agents/skills/koko-mobileapp-getting-started/SKILL.md
@@ -19,22 +19,40 @@ This repository uses a two-window approach:
 
 When the user asks to "proceed with koko-mobileapp-getting-started" or "get started" inside the `MobileApp/` workspace, perform the following steps:
 
-1. **Activate the Central Getting-Started Checklist:**
-   Read and load the root-level getting-started blueprint located at:
-   `../../../../skills/getting-started/SKILL.md`
+0. **Find the git repo root once.** Run `git rev-parse --show-toplevel` — it's the folder that contains
+   `MobileApp/`. From this MobileApp window that's **one level up** (`../`). Every `PROGRESS_*.md` and the
+   root `skills/` live there, **not** inside `MobileApp/` (or `MobileApp/.agents/`). All paths below are
+   written relative to `MobileApp/` (the window's working directory).
 
-2. **Initialize Phase 1 Progress Tracker:**
-   Copy the progress template from the root-level `../../../../skills/getting-started/progress-template.md` to:
-   `../../PROGRESS_P1_GETTING_STARTED.md` (which maps to the root-level `/PROGRESS_P1_GETTING_STARTED.md`).
-   This ensures that progress is saved in the root folder alongside any other phase trackers.
+1. **Activate the central getting-started checklist.**
+   Read and follow the blueprint at `../skills/getting-started/SKILL.md` (repo-root `skills/getting-started/`).
 
-3. **Drive Phase 1 Implementation:**
-   - Review `PROGRESS_P1_GETTING_STARTED.md` and build out the local loops (Room, Preferences, API service, permissions, etc.).
+2. **Initialize the Phase 1 progress tracker — at the repo root, NEVER inside `MobileApp/`.**
+   The tracker is `../PROGRESS_P1_GETTING_STARTED.md` (repo root, one level up from `MobileApp/`).
+   - If it **already exists**, do NOT recreate it — read it and resume from the first unchecked item.
+   - If it doesn't, copy `../skills/getting-started/progress-template.md` → `../PROGRESS_P1_GETTING_STARTED.md`.
+   - Writing it inside `MobileApp/` or `MobileApp/.agents/` is the classic mistake — a later session (or the
+     Root Window) looks at the repo root and thinks nothing was done.
+
+3. **Is the product defined yet?** Before building features, `AiGuidelines/project/prd.md` / `user_flow.md`
+   / `ui_ux.md` must be filled and the app name + id chosen. If the developer jumped straight here and those
+   are missing, the blueprint's step C routes to the **`new-app`** skill first (it interviews the developer
+   and writes them); then resume this guide. This is one-way and state-guarded — it can't loop.
+
+4. **Drive Phase 1 Implementation:**
+   - Review `../PROGRESS_P1_GETTING_STARTED.md` and build out the local loops (Room, Preferences, API service, permissions, etc.).
    - Follow the **STOP rule**: stop and wait for confirmation whenever a step is a **User Action**.
-   - Keep `PROGRESS_P1_GETTING_STARTED.md` updated as you complete tasks.
+   - After finishing a chunk (e.g. onboarding screens), **continue to the next unchecked item** — don't stop and ask "what next".
+   - Keep `../PROGRESS_P1_GETTING_STARTED.md` updated as you complete tasks (features also land in `../PROGRESS_FEATURES.md`, same repo root).
+   - **Don't loop on Gradle.** Validate with the scoped tasks only — `spotlessCheck`,
+     `:shared:jvmTest :shared:testAndroidHostTest`, `:androidApp:assembleDebug`. **Never** the aggregate
+     `check` / `build` / `clean build` (they pull in iOS and fail on unrelated cache issues, which looks
+     like a failure and tempts a re-run). A run task like `:desktopApp:run` never returns — that's
+     running, not hung; don't kill and re-run. `assembleDebug` compiling green is the Android check — don't
+     adb-install-and-launch to "confirm it works". See `run-quality-gates`.
    - **Environment Quirk:** If you need to run any `./gradlew` commands and you encounter an error about "different paths to the Android Preferences folder" (ANDROID_PREFS_ROOT vs ANDROID_USER_HOME), always prefix your commands with `unset ANDROID_PREFS_ROOT &&` (e.g., `unset ANDROID_PREFS_ROOT && ./gradlew assembleDebug`).
    - **Prototyping AI shortcut:** By default, the `AiGenerationProvider` looks for a deployed Cloud Function proxy. To test AI generation locally without deploying the backend in Phase 1, instruct the user to add `OPENAI_API_KEY=sk-your-key` or `REPLICATE_API_KEY=your-key` directly into their `MobileApp/local.properties` file. Ensure `CLOUD_FUNCTIONS_URL` in `AppConfiguration.kt` is left blank, which triggers the direct-device API call.
 
-4. **Phase 1 Hand-Off:**
+5. **Phase 1 Hand-Off:**
    Once all Phase 1 tasks are complete and verified, present a clear next-step message to the developer:
    > *"Phase 1 is officially complete! Your local loop is fully verified. To continue with Phase 2 (Integrations) or Phase 3 (Publishing), please switch back to your root directory Android Studio window and invoke the respective root-level skill there."*

--- a/MobileApp/.agents/skills/koko-skills/SKILL.md
+++ b/MobileApp/.agents/skills/koko-skills/SKILL.md
@@ -45,7 +45,9 @@ These sequential guides walk you from first-run setup to monetization and growth
 
 | Skill Name | Location | Description |
 | :--- | :--- | :--- |
+| **`new-app`** | [SKILL.md](../../../../skills/new-app/SKILL.md) | Turn a raw idea into a defined product (prd/user_flow/ui_ux + name/id) before building. Entry point when the developer arrives with just an idea. |
 | **`run-the-app`** | [SKILL.md](../../../../skills/run-the-app/SKILL.md) | Instructions to run/build the app on Android, Desktop, Web, or iOS from source. |
+| **`build-features`** | [SKILL.md](../../../../skills/build-features/SKILL.md) | Derive the MVP screens + local models from prd.md / user_flow.md and implement the UI per ui_ux.md (records progress in PROGRESS_FEATURES.md). |
 | **`refactor-package`** | [SKILL.md](../../../../skills/refactor-package/SKILL.md) | Shell-script command to safely rename Android package namespaces, app IDs, and iOS bundles. |
 | **`new-screen`** | [SKILL.md](../../../../skills/new-screen/SKILL.md) | Scaffold a new Screen, UiState, and ViewModel, and register them with Jetpack Navigation 3 & Koin. |
 | **`new-local-model`** | [SKILL.md](../../../../skills/new-local-model/SKILL.md) | Scaffold a new Room 3 Entity, Dao, Database registration, and dependency injection binding. |
@@ -108,6 +110,7 @@ These sequential guides walk you from first-run setup to monetization and growth
 | Skill Name | Location | Description |
 | :--- | :--- | :--- |
 | **`run-quality-gates`** | [SKILL.md](../../../../skills/run-quality-gates/SKILL.md) | Execute codebase standard checks (Spotless code formatting check, unit tests, debug build validations). |
+| **`verify-ui`** | [SKILL.md](../../../../skills/verify-ui/SKILL.md) | Verify a screen's behaviour with a headless Compose test and its appearance by rendering a `@Preview` to a PNG. |
 
 > [!NOTE]
 > When executing a skill, make sure you perform any associated bash/gradle commands from the `MobileApp/` directory. Every path inside the parent skills expects execution inside the mobile subproject.


### PR DESCRIPTION
## Context

The `@koko-*` skills live in `.agents/skills/` (root) and `MobileApp/.agents/skills/` and carry their **own copies** of guidance that had drifted from the canonical `skills/`.

## Fixes

**`koko-mobileapp-getting-started` (the MobileApp-window entry skill):**
- **Progress-path bug:** it copied the tracker to `../../PROGRESS_P1_GETTING_STARTED.md`, which resolves to `MobileApp/.agents/` — *not* the repo root. This is the exact bug that misplaced progress files. Corrected to `../PROGRESS_*` (repo root = one level up from `MobileApp/`), with `git rev-parse --show-toplevel` guidance and an explicit "never inside `MobileApp/`" warning.
- Added the **`new-app` product-definition precondition**, the **keep-going-through-the-guide** resume rule, and the **build-loop guardrails** (scoped gates only — never `check`/`build`/`clean build`; run tasks don't exit; don't adb-launch to "confirm").

**Index skills (`koko-skills`, `koko-getting-started`):** were missing **`new-app`**, **`build-features`**, and **`verify-ui`** — added them. All new relative links verified to resolve.

Docs-only.