### PR TITLE
Hotfix: iOS splash background, demo paywall dialog, purchase-success flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,7 +326,7 @@ Each platform uses its **native** launch screen — no library.
 - **Android** (`androidx.core:core-splashscreen`): theme `Theme.App.Starting` in `androidApp/src/main/res/values/styles.xml`. Background is `@color/windowBackgroundColor` — **the same as the app window**, so the hand-off to `AppTheme` has no color flash. The icon is the **adaptive launcher icon** `@mipmap/ic_launcher`. (The system masks the splash icon to a circle; adaptive icons are built for that, so it stays crisp and uncropped — a full-bleed brand logo would get its corners cut. The native theme also can't reference Compose/`designsystem` resources like `ic_logo`, only `res/` ones.) The brand logo (`ic_logo`) is shown **uncut** by the Compose splash (the onboarding `LogoImage`). Wired via `android:theme="@style/Theme.App.Starting"` on `AppActivity` + `installSplashScreen()` (before `super.onCreate()`) in `App.android.kt`. To hold the splash while the app loads: `installSplashScreen().setKeepOnScreenCondition { !ready }`.
 - **iOS** (declarative `UILaunchScreen` in `iosApp/iosApp/Info.plist`, iOS 14+ — no storyboard, no `.xcodeproj` edit). iOS can't reference the designsystem/Compose resources, so the splash logo is **one** file you replace:
   - Logo → `iosApp/iosApp/Assets.xcassets/ic_logo.imageset/ic_logo.png` (single universal image; the brand logo, asset name `ic_logo`).
-  - Background → `SplashBackground.colorset` — keep it equal to the app window background (`windowBackgroundColor`, currently `#F0EDE5`) so the transition is seamless.
+  - Background → `SplashBackground.colorset` — keep it equal to the app window background (`AppTheme.colors.background` / Android `windowBackgroundColor`, currently `#F9F7FF` light and `#12101A` dark) so the transition is seamless. Give the colorset both a light (universal) and a dark (`luminosity` = `dark`) appearance so neither mode flashes.
   - The plist keys `UIColorName` / `UIImageName` reference those two asset names.
 
 ### Local Preferences (DataStore)
@@ -480,8 +480,8 @@ Two interchangeable billing backends live under `libs/subscription/` behind the
   == "testValue"`), DI swaps in `MockSubscriptionProvider` (in `subscription-api`, next to
   `NoOpSubscriptionProvider`) instead of the linked real provider. It returns demo packages and a
   "purchase" simulates success (persisted via `UserPreferences`), so the whole paywall → purchase →
-  unlock → cancel flow works on every platform with **no keys**. The paywall shows a red `DemoBanner`
-  (`SubscriptionProvider.isMockProvider` → `PaywallUiState.isMock`), buys skip the sign-in gate, and the
+  unlock → cancel flow works on every platform with **no keys**. The paywall shows a red demo warning
+  `AppDialog` on each open (`SubscriptionProvider.isMockProvider` → `PaywallUiState.isMock`), buys skip the sign-in gate, and the
   Subscriptions screen's "manage here" link cancels in-app via `cancelMockSubscription()` (an interface
   method — default no-op, only the mock implements it). Client-only fake (no receipt); auto-reverts to
   the real provider the moment a key is set. The mock stays dependency-free — its ids/persistence/clock

--- a/MobileApp/iosApp/iosApp/Assets.xcassets/SplashBackground.colorset/Contents.json
+++ b/MobileApp/iosApp/iosApp/Assets.xcassets/SplashBackground.colorset/Contents.json
@@ -5,9 +5,27 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xE5",
-          "green" : "0xED",
-          "red" : "0xF0"
+          "blue" : "0xFF",
+          "green" : "0xF7",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1A",
+          "green" : "0x10",
+          "red" : "0x12"
         }
       },
       "idiom" : "universal"

--- a/MobileApp/shared/src/commonMain/composeResources/values/strings.xml
+++ b/MobileApp/shared/src/commonMain/composeResources/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="paywall_footer_terms">Terms</string>
     <string name="paywall_badge_best_value">BEST VALUE</string>
     <string name="paywall_badge_save_percent">SAVE %1$d%%</string>
+    <string name="paywall_demo_title">Demo paywall</string>
     <string name="paywall_demo_banner">Demo paywall — no subscription key set. Purchases are simulated. Add your Adapty or RevenueCat key to go live.</string>
 
     <string name="paywall_msg_sign_in_required">You need to sign in first</string>

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/PaywallScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/PaywallScreen.kt
@@ -57,10 +57,7 @@ fun PaywallScreen(
             isRecurring = subscription.willRenew,
             isLifetime = subscription.isLifetime,
             expirationDate = subscription.expirationDateInMillis?.asFormattedDate(),
-            onContinue = {
-                onDismiss()
-                viewModel.onSuccessfulPurchaseHandled()
-            },
+            onContinue = { onDismiss() },
         )
         return
     }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/PaywallScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/PaywallScreen.kt
@@ -4,14 +4,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.kotlinfoundation.koko.designsystem.components.DemoBanner
 import com.kotlinfoundation.koko.designsystem.components.LoadingProgress
 import com.kotlinfoundation.koko.designsystem.components.LoadingProgressMode
 import com.kotlinfoundation.koko.designsystem.components.modals.AppDialog
@@ -19,6 +20,7 @@ import com.kotlinfoundation.koko.designsystem.components.modals.DialogType
 import com.kotlinfoundation.koko.designsystem.theme.AppTheme
 import com.kotlinfoundation.koko.generated.resources.Res
 import com.kotlinfoundation.koko.generated.resources.paywall_demo_banner
+import com.kotlinfoundation.koko.generated.resources.paywall_demo_title
 import com.kotlinfoundation.koko.presentation.components.premium.PremiumFeatureFactory
 import com.kotlinfoundation.koko.presentation.components.premium.SuccessfulPurchaseView
 import com.kotlinfoundation.koko.presentation.screens.paywall.creditpack.CreditPackPaywallScreen
@@ -86,17 +88,21 @@ fun PaywallScreen(
     onUiEvent: (PaywallUiEvent) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    var showDemoDialog by remember { mutableStateOf(false) }
+    LaunchedEffect(uiState.isMock) {
+        if (uiState.isMock) showDemoDialog = true
+    }
+    if (showDemoDialog) {
+        AppDialog(
+            type = DialogType.ERROR,
+            title = stringResource(Res.string.paywall_demo_title),
+            text = stringResource(Res.string.paywall_demo_banner),
+            onConfirm = { showDemoDialog = false },
+            onDismiss = { showDemoDialog = false },
+        )
+    }
+
     Column(modifier = modifier) {
-        // Shown for both subscription and credit-pack paywalls when the mock provider is active.
-        if (uiState.isMock) {
-            DemoBanner(
-                text = stringResource(Res.string.paywall_demo_banner),
-                modifier = Modifier.padding(
-                    horizontal = AppTheme.spacing.outerSpacing,
-                    vertical = AppTheme.spacing.defaultSpacing,
-                ),
-            )
-        }
         when {
             uiState.isLoading -> Box(modifier = Modifier.weight(1f)) {
                 LoadingProgress(mode = LoadingProgressMode.FULLSCREEN)

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/PaywallViewModel.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/PaywallViewModel.kt
@@ -109,10 +109,6 @@ class PaywallViewModel(
         _uiState.update { it.copy(errorMessage = null) }
     }
 
-    fun onSuccessfulPurchaseHandled() = viewModelScope.launch {
-        _uiState.update { it.copy(successfulSubscription = null) }
-    }
-
     fun onSignInActionHandled() = viewModelScope.launch {
         _uiState.update { it.copy(signInActionRequired = false) }
     }

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/remotepaywall/RemotePaywallScreen.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/presentation/screens/paywall/remotepaywall/RemotePaywallScreen.kt
@@ -66,10 +66,7 @@ fun RemotePaywallScreen(
             isRecurring = subscription.willRenew,
             isLifetime = subscription.isLifetime,
             expirationDate = subscription.expirationDateInMillis?.asFormattedDate(),
-            onContinue = {
-                onDismiss()
-                viewModel.onSuccessfulPurchaseHandled()
-            },
+            onContinue = { onDismiss() },
         )
     }
 


### PR DESCRIPTION
Three UI hotfixes, all off `initial_version`.

## iOS splash background color
`SplashBackground.colorset` was the old beige `#F0EDE5`; the theme background is now `#F9F7FF` (light) / `#12101A` (dark). Updated the colorset to match, with a `dark` appearance so neither mode flashes. Android already matched. (Existing native launch-screen cache means the simulator/device must delete the app + clean build to see it.)

## Demo paywall: dialog instead of banner
The mock-provider demo notice showed as a persistent top banner. It now shows as a red warning `AppDialog` on each paywall open, so it reads as a clear warning. Applies to both subscription and credit-pack modes. Added `paywall_demo_title` string; `DemoBanner` DS component is now unused (left in place).

## Purchase-success view no longer flashes the paywall
Tapping "explore premium benefits" on the success view cleared `successfulSubscription` in the same lambda as the dismiss, so the screen recomposed and rendered the real paywall for a frame before the back-stack pop landed. `onContinue` now only dismisses; the paywall is a nav entry popped on dismiss, so the per-entry ViewModel is destroyed and needs no manual reset. Removed the now-unused `onSuccessfulPurchaseHandled()`.

Docs (`AGENTS.md`) updated for the splash colors and the demo-dialog behavior.

Validation: `:shared:compileKotlinJvm` + `spotlessCheck` pass.