### PR TITLE
Add `sync-data-firebase` skill and update Wasm/Firebase compatibility rules

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -6,3 +6,8 @@ Read the matching skills/<name>/SKILL.md and follow it; the steps are exact
 (commands, file paths, console URLs) and work manually or agent-driven.
 
 Project conventions and the same skills index also live in AGENTS.md.
+
+Firebase data in shared code (Firestore, sync, storage, server-side balances):
+there is no Firebase client SDK for the wasmJs target, so this decision trades
+away the web build. Stop and ask the developer which they want before writing
+code or recommending an approach. See skills/setup-firebase/SKILL.md.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,3 +10,9 @@ check whether a skill already covers it.
   manually or by an agent.
 - Broader project conventions and the same skills index live in
   [`AGENTS.md`](../AGENTS.md).
+
+**Firebase data in shared code** (Firestore, sync, cloud storage, server-side
+balances): there is no Firebase client SDK for the `wasmJs` target, so this
+decision trades away the web build. **Stop and ask the developer which they
+want** before writing code or recommending an approach — see
+[`skills/setup-firebase/SKILL.md`](../skills/setup-firebase/SKILL.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,22 @@ common  (Room 3 @Database + DAOs live here — runs on all platforms)
 └── web (js + wasmJs — sqlite-web only on wasmJs)
 ```
 
+### Firebase client SDKs in shared code — ask first, always
+
+There is **no Firebase client SDK for the `wasmJs` target**. The GitLive
+[firebase-kotlin-sdk](https://github.com/GitLiveApp/firebase-kotlin-sdk) covers Android, iOS, JVM and JS
+but **not** Kotlin/Wasm, so putting Firestore (or any Firebase client SDK) in `commonMain` breaks the web
+build. Desktop is never the blocker — the browser target is.
+
+This applies to **any** task that puts Firebase data into shared code: Firestore, realtime database, cloud
+storage, cross-device sync, syncing credits/settings/user data, server-authoritative balances.
+
+**Stop and ask the developer which they want. Do not choose for them, do not answer with a
+recommendation as if the question were settled, and never drop the web target silently.** Two options:
+keep Wasm and put Firestore behind the Cloud Functions backend this kit already ships, or drop the
+`wasmJs` target and use GitLive directly. Full guidance + the Wasm-safe architecture:
+[`skills/setup-firebase/SKILL.md`](skills/setup-firebase/SKILL.md).
+
 ## Build & Run
 
 ### Android
@@ -384,7 +400,7 @@ Two layers:
 
 **Task skills** (grouped by phase):
 - **P1** `new-app`, `build-features`, `run-the-app`, `refactor-package`, `new-screen`, `new-local-model`, `add-api-service`, `save-preferences`, `add-permission`, `new-module`
-- **P2** `configure-environment`, `setup-firebase`, `enable-auth`, `integrate-web-proxy`
+- **P2** `configure-environment`, `setup-firebase`, `enable-auth`, `integrate-web-proxy`, `sync-data-firebase`
 - **P3** `generate-app-icons`, `bump-version`, `setup-signing`, `store-screenshots`, `setup-appstore-connect`, `setup-google-play`, `publish-release`
 - **P4** `design-paywall`, `setup-subscriptions`, `enable-credits`, `enable-ads`
 - **P5** `setup-analytics`, `enable-notifications`, `design-onboarding`, `add-virality-loop`

--- a/skills/README.md
+++ b/skills/README.md
@@ -90,6 +90,7 @@ no-Firebase AI path, so Firebase / Adapty / store accounts wait until the phase 
 | [setup-firebase](setup-firebase/SKILL.md) | Connecting the app to Firebase (project, apps, anonymous auth) |
 | [enable-auth](enable-auth/SKILL.md) | Adding Google / Apple social sign-in |
 | [integrate-web-proxy](integrate-web-proxy/SKILL.md) | Deploying the Cloud Functions AI proxy and calling it securely |
+| [sync-data-firebase](sync-data-firebase/SKILL.md) | Putting data in Firestore / syncing across devices / making state server-authoritative (asks the wasmJs question first) |
 
 **Phase 3 — Publication**
 

--- a/skills/add-api-service/SKILL.md
+++ b/skills/add-api-service/SKILL.md
@@ -86,3 +86,10 @@ Use Ktor `MockEngine` to stub responses/errors — never hit the real network in
 (`shared/src/commonTest/`). See `AiGuidelines/tech/api_services.md`.
 
 Validate with the `run-quality-gates` skill.
+
+## Talking to Firebase?
+
+If the endpoint is backed by Firestore — cloud sync, cross-device state, a server-authoritative balance
+— start from `sync-data-firebase`, not here. No Firebase client SDK supports the `wasmJs` target, so the
+approach has to be decided with the developer before any code is written. This skill still describes the
+client layering once that decision is made.

--- a/skills/enable-credits/SKILL.md
+++ b/skills/enable-credits/SKILL.md
@@ -99,6 +99,10 @@ Credits are **local-only** by default (on-device). That's fine for most early-st
 backend/server-verified credit sync (e.g. Firestore) if you see abuse, need cross-device sync, or need
 server-verified purchases — it adds real cost and complexity.
 
+When that time comes, use the **`sync-data-firebase`** skill; it has a worked credit-balance example.
+Don't design the sync ad hoc: no Firebase client SDK supports the `wasmJs` target, so the approach is a
+trade-off against the web build that the developer has to decide first.
+
 ## Validation
 
 - App builds (`./gradlew :androidApp:assembleDebug`) and the `CreditBalanceScreen` / toolbar badge

--- a/skills/integrate-web-proxy/SKILL.md
+++ b/skills/integrate-web-proxy/SKILL.md
@@ -153,3 +153,6 @@ confirm the function returns `data`. This is the phase's validation gate.
 ## Next
 
 Live remote calls + auth working completes the `integrations` phase → move to `publishing`.
+
+Adding Firestore-backed endpoints on top of this backend → `sync-data-firebase`. It reuses the same
+functions + ID-token shape, and starts with the `wasmJs` trade-off question the developer must answer.

--- a/skills/integrations/SKILL.md
+++ b/skills/integrations/SKILL.md
@@ -103,6 +103,14 @@ the SDK **credentials** early if they want them.
   wraps in `Result`). Optionally test the backend locally first with
   `firebase emulators:start --only functions` from `Web/`.
 
+### 5b. Cloud data — optional, only if the app needs it — `sync-data-firebase`
+- **Agent Action** — Skip unless the developer wants data in Firestore, cross-device sync, or
+  server-authoritative state (a credit balance, an entitlement). Nothing in this phase requires it.
+- **User Action** — If they do want it, the `sync-data-firebase` skill opens with a question the
+  developer must answer: **no Firebase client SDK supports the `wasmJs` target**, so the choice is
+  keeping the web build (Firestore behind Cloud Functions) or dropping it (GitLive SDK in shared code).
+  **Stop and ask. Never decide this for them.**
+
 ### 6. Validation gate
 - **Validation** — Run `./scripts/check_env.sh --phase integrations` from `MobileApp/`. For the
   recommended anonymous-only path it should report clean once your real Firebase config is in place

--- a/skills/new-local-model/SKILL.md
+++ b/skills/new-local-model/SKILL.md
@@ -29,6 +29,10 @@ Insertion points are marked `// Add new ... — make_local.sh inserts here.` —
 4. DAO tests go in `shared/src/jvmTest/` using `Room.inMemoryDatabaseBuilder<AppDatabase>().setDriver(BundledSQLiteDriver())` — see `ExampleDaoTest.kt` for the pattern.
 5. Validate with the `run-quality-gates` skill.
 
+**Want this model in the cloud too?** Use the `sync-data-firebase` skill rather than reaching for a
+Firestore SDK — no Firebase client SDK supports the `wasmJs` target, so that choice trades away the web
+build and the developer has to make it.
+
 ---
 
 *Phase 1 · First Run building block — part of the [getting-started](../getting-started/SKILL.md) guide.*

--- a/skills/setup-firebase/SKILL.md
+++ b/skills/setup-firebase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-firebase
-description: Create a Firebase project, register the Android + iOS apps, place google-services.json / GoogleService-Info.plist, and enable anonymous auth. Use when connecting the app to Firebase for the first time, or when the developer asks to set up Firebase / add the config files.
+description: Create a Firebase project, register the Android + iOS apps, place google-services.json / GoogleService-Info.plist, and enable anonymous auth. Use when connecting the app to Firebase for the first time, or when the developer asks to set up Firebase / add the config files. ALSO use before any work that puts Firebase data or a Firebase client SDK into shared code — Firestore, realtime database, cloud storage, cross-device sync, syncing credits/settings/user data to Firebase, server-side balances — because there is no Firebase client SDK for the wasmJs target and the developer must be asked which trade-off they want before an approach is chosen.
 ---
 
 # Set up Firebase
@@ -21,14 +21,21 @@ prep identifiers and the SHA-1, but the developer performs the console clicks an
 > the base setup below is affected — this only matters once the developer wants **Firestore** (or
 > another Firebase *client* SDK) in shared code.
 >
-> When that comes up, **stop and ask the developer which they want** — do not silently drop a target:
+> When that comes up, **put the question to the developer and wait for their answer** before writing
+> any code or naming a recommendation. Present both options below verbatim, then stop. Do not pick
+> one and proceed, do not answer with a recommendation as if it were settled, and do not silently
+> drop a target:
 >
 > - **Keep Wasm (recommended, default).** Don't use a Firebase client SDK in shared code at all.
 >   Put Firestore behind the Cloud Functions backend this kit already ships — see
 >   *Firestore via Cloud Functions* below. Every platform, Wasm included, keeps working.
 > - **Drop Wasm.** If the app doesn't need the web target, remove it and use the GitLive SDK
->   directly for a shorter path to Firestore. This is a real trade-off (no browser build), so it
->   must be the developer's explicit decision, not an assumption.
+>   directly for a shorter path to Firestore. GitLive covers Android, iOS, JVM **and** JS — only
+>   `wasmJs` is missing, so desktop is never the blocker; the browser build is. This is a real
+>   trade-off, so it must be the developer's explicit decision, not an assumption.
+>
+> "Recommended, default" describes which option to *present first*, not permission to skip the ask.
+> The web target is a deliverable the developer chose; trading it away is theirs to decide.
 >
 > If GitLive is used, take the **latest stable version** from its
 > [releases](https://github.com/GitLiveApp/firebase-kotlin-sdk/releases) — don't pin an old one.

--- a/skills/sync-data-firebase/SKILL.md
+++ b/skills/sync-data-firebase/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: sync-data-firebase
+description: Sync app data to Firebase — Firestore documents, cross-device sync, server-authoritative state (credit balances, settings, user profiles, saved items). Use when the developer wants to store data in Firestore, sync data across devices, back up local data to the cloud, make a balance or entitlement server-verified, or asks "how do I sync X with Firebase". Starts with a required question about the wasmJs target, because no Firebase client SDK supports Kotlin/Wasm.
+---
+
+# Sync app data to Firebase
+
+The kit stores data locally by default — Room for structured data, DataStore for preferences. This
+skill covers moving some of it to Firebase so it survives reinstalls, follows the user across devices,
+or becomes server-authoritative.
+
+Firebase setup (project, config files, anonymous auth) must already be done — that's `setup-firebase`.
+
+## 0. Ask the developer first — this step is not optional
+
+> [!IMPORTANT]
+> There is **no Firebase client SDK for the `wasmJs` target**. The GitLive
+> [firebase-kotlin-sdk](https://github.com/GitLiveApp/firebase-kotlin-sdk) covers Android, iOS, JVM and
+> JS but **not** Kotlin/Wasm, so a Firestore call in `commonMain` breaks the web build. Desktop is never
+> the blocker — the browser target is.
+>
+> **Put the question to the developer and wait for their answer.** Do not choose for them, do not
+> answer with a recommendation as if it were settled, and never drop a target silently. The web build
+> is a deliverable they chose; trading it away is theirs to decide.
+
+Present both options:
+
+| | **Keep Wasm** (present first) | **Drop Wasm** |
+|---|---|---|
+| How | Firestore lives behind the Cloud Functions backend this kit already ships. Client speaks plain REST. | GitLive SDK in `commonMain`, client talks to Firestore directly. |
+| Targets | All five keep working. | No browser build. Android, iOS, Desktop, JS only. |
+| Cost | More backend code: functions, security rules, DTOs, an API service. | Shorter path. Realtime listeners and offline persistence come free. |
+| Reversible | Yes. | Removing/re-adding the `wasmJs` target is a real chunk of work. |
+
+The rest of this skill covers the **Keep Wasm** path. For Drop Wasm, check the [GitHub releases page](https://github.com/GitLiveApp/firebase-kotlin-sdk/releases) explicitly 
+to take the latest stable GitLive version — don't pin an old one — and remove the `wasmJs` target from `shared`, `designsystem`, and `webApp`. Always use **at least version `2.6.0`** of the Gitlive Firebase Kotlin SDK.
+
+
+## 1. Ask what the sync is actually for
+
+The answer decides how much you build. These are different products:
+
+- **Backup / restore.** Server mirrors local state so a reinstall recovers it. Client stays the
+  authority. Cheapest — no rule logic moves server-side.
+- **Cross-device continuity.** Same state on phone and tablet. **Anonymous auth gives a per-install
+  uid**, so sync alone achieves nothing here — the user needs a real account first (`enable-auth`) and
+  an anon→permanent account link. Say this out loud before building; it's the most common wrong
+  assumption.
+- **Server-authoritative / anti-cheat.** The server holds the value and validates every mutation. This
+  is the expensive one: any business rules that currently run in Kotlin have to be ported to the
+  functions or duplicated.
+- **Server-verified purchases.** Entitlement or balance grants move off the client onto a store
+  webhook. Usually the highest-value piece and independent of the other three.
+
+## 2. Architecture (Wasm-safe)
+
+```
+KMP app (Android, iOS, Desktop, Wasm, JS)
+   │  HTTPS + Firebase ID token
+   ▼
+HTTPS Cloud Functions  ──►  Firebase Admin SDK  ──►  Cloud Firestore
+```
+
+Rules:
+
+- Every Firestore read/write goes through a Cloud Function. The client never touches Firestore.
+- Functions use the Firebase Admin SDK (already a dependency in `Web/functions/package.json`), not the
+  Firestore REST API.
+- Functions verify the caller's ID token before any database operation —
+  `Web/functions/utils/validation.js` → `admin.auth().verifyIdToken(...)` is the existing helper.
+- Plain REST endpoints, so one client implementation serves every platform.
+- Firestore security rules deny all direct client access. Admin SDK bypasses rules by design.
+
+## 3. Backend — `Web/functions/`
+
+Add handlers under `Web/functions/api/`, export them from `Web/functions/index.js`, deploy via
+`integrate-web-proxy`. Store the state under the caller's uid, never a uid taken from the request body:
+
+```
+users/{uid}/<collection>/{docId}
+```
+
+**Idempotency.** Any mutation the client might retry (a spend, a grant, a purchase) needs a
+client-generated id used as the document id, so a retry over a flaky connection is a no-op instead of a
+double-apply. The client already generates `Uuid.random()` in several places — reuse that value rather
+than inventing a server id.
+
+## 4. Client — normal API service, no Firebase types
+
+Firebase stays invisible to the app. Follow `add-api-service`:
+
+1. DTOs in `data/source/remote/request/` + `response/` (`@Serializable`, `asDomain()` mappers).
+2. An `*ApiService` under `data/source/remote/apiservices/`, returning raw response types.
+3. The repository wraps in `Result` via `BackgroundExecutor` and does the mapping.
+
+Requests go through the Firebase-interceptor Ktor client against
+`AppConfiguration.CLOUD_FUNCTIONS_URL` — the same path the AI proxy uses, so the ID token is attached
+for you. A blank `CLOUD_FUNCTIONS_URL` means no backend is deployed; the feature must degrade to
+local-only rather than crash.
+
+## 5. Keep the local store as the offline layer
+
+Don't delete the Room/DataStore path when the server arrives. Local becomes the cache:
+
+- Reads serve from local, then reconcile with the server response.
+- Writes apply locally first, queue for the server, and carry the idempotency id.
+- Add a `synced` flag to the affected entity, plus a Room `@Database(version = …)` bump and a
+  `Migration` if the app has already shipped.
+- Decide and write down the conflict policy — usually server wins, clamped so a value can't go
+  negative.
+- **Migrate existing installs once.** Users already have local state. Upload it on first sync, guarded
+  by a one-shot preference flag, or they lose it on update.
+
+## 6. Worked example — credit balance
+
+Credits are the most common thing developers want synced, so the shape is spelled out here.
+
+Today they're fully local: per-source counters and `KEY_CREDIT_GENERAL_BALANCE` in DataStore, plus a
+Room ledger in `credit_transaction`. `CreditRepository` applies the `CreditSystemConfig` rules
+(one-time bonuses, recurring refills, `condition` lambdas that read `SubscriptionRepository`).
+
+- Keep `CreditRepository`'s public API unchanged — `balance`, `useCredits`, `addCredits`,
+  `getRecentTransactionsFlow`. Inject the remote source behind it so screens and ViewModels don't move.
+- Firestore: `users/{uid}/credit` holding `{balance, sources: {id: {remaining, nextResetAt, granted}},
+  updatedAt}` plus a `transactions/{clientTxId}` subcollection.
+- The `CreditSystemConfig` DSL is Kotlin. Full server authority means porting it to JS or duplicating
+  it. The cheap middle ground: rules stay client-side, the function only validates `balance >= amount`
+  and applies the delta. Less strict, far less work — put the choice to the developer.
+- The biggest actual win is independent of all this: move credit-pack grants off client
+  `addCredits(...)` onto an Adapty/RevenueCat webhook → function → server grant. That closes the real
+  abuse vector; hardening client-side spend matters much less.
+
+## Validation
+
+- Build the targets the developer chose to keep — including
+  `./gradlew :webApp:wasmJsBrowserDistribution` if Wasm stayed.
+- Kill the network mid-flow: the app still works from local state and reconciles on reconnect.
+- Fire the same mutation twice with one idempotency id; the server applies it once.
+- Confirm Firestore rules reject a direct client read.
+- Run the `run-quality-gates` skill before committing.
+
+## Related skills
+
+`setup-firebase` (project + the same Wasm question) · `enable-auth` (real accounts — required for
+cross-device) · `add-api-service` (client layering) · `integrate-web-proxy` (deploying functions) ·
+`enable-credits` (local credit system this builds on) · `new-local-model` (the Room layer being cached).


### PR DESCRIPTION
Introduce a new skill for Firestore data synchronization and cross-device continuity. This includes a Wasm-safe architecture using Cloud Functions to bypass the lack of Firebase client SDK support for the `wasmJs` target.

Update project conventions in `AGENTS.md`, `.cursorrules`, and existing skills to ensure developers are explicitly asked to choose between maintaining Wasm support or using direct client SDKs before starting implementation.

* Add `sync-data-firebase` skill with a worked credit-balance example.
* Update `setup-firebase` and `integrations` to gate Firebase work on the Wasm decision.
* Link cloud sync guidance from local model, credits, and API service skills.
* Add pervasive warnings to agent instructions regarding Firebase SDK limitations on `wasmJs`.