### PR TITLE
Poll Replicate predictions instead of failing on a null output

### DIFF
--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/ai/ReplicateGenerationProvider.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/data/source/ai/ReplicateGenerationProvider.kt
@@ -2,6 +2,8 @@ package com.kotlinfoundation.koko.data.source.ai
 
 import com.kotlinfoundation.koko.data.source.remote.apiservices.ai.ReplicateApiService
 import com.kotlinfoundation.koko.data.source.remote.request.ai.replicate.ReplicatePredictionRequest
+import com.kotlinfoundation.koko.data.source.remote.response.ai.AiApiBaseResponse
+import com.kotlinfoundation.koko.data.source.remote.response.ai.replicate.ReplicatePredictionResponse
 import com.kotlinfoundation.koko.domain.model.generation.GenerationFile
 import com.kotlinfoundation.koko.domain.model.generation.GenerationInput
 import com.kotlinfoundation.koko.domain.model.generation.GenerationOutput
@@ -9,10 +11,13 @@ import com.kotlinfoundation.koko.domain.model.generation.GenerationParam
 import com.kotlinfoundation.koko.domain.model.generation.typedValue
 import com.kotlinfoundation.koko.domain.usecase.AiGenerationProvider
 import com.kotlinfoundation.koko.util.file.FileManager
+import com.kotlinfoundation.koko.util.logging.AppLogger
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [AiGenerationProvider] backed by Replicate. Maps a [GenerationInput] to the model's request
@@ -27,6 +32,14 @@ class ReplicateGenerationProvider(
     private companion object {
         const val IS_OFFICIAL_MODEL = true
         const val PROMPT_KEY_PARAM = "prompt"
+
+        // The request is sent with `Prefer: wait`, which Replicate honours for at most ~60s. A model
+        // that needs longer (cold start, heavy image-to-image, video) comes back HTTP 200 with
+        // status "starting"/"processing" and a null output — that means "poll me", not "failed".
+        // Tune these if your model routinely runs longer than the budget below.
+        val POLL_INITIAL_DELAY = 5.seconds
+        val POLL_MAX_INTERVAL = 15.seconds
+        const val POLL_MAX_ATTEMPTS = 20
 
         // TODO needs to be changed if needed
         const val MODEL_OWNER = "google"
@@ -53,11 +66,11 @@ class ReplicateGenerationProvider(
             }
 
             else -> createCommunityModelsPrediction(version = MODEL_VERSION, input = requestBody)
-        }
+        }.awaitOutput()
 
         return replicateResponse.handleAsResult { response ->
-            val output = response?.output
-                ?: return@handleAsResult Result.failure(Exception("AI generation failed"))
+            val output = response?.outputUrl()
+                ?: return@handleAsResult Result.failure(Exception(response.failureReason()))
 
             val outputFileName =
                 fileManager.downloadFileFromNetworkToInternalDirectory(
@@ -86,6 +99,52 @@ class ReplicateGenerationProvider(
 
             Result.success(generationOutput)
         }
+    }
+
+    /**
+     * Polls `getPredictionStatus` until the prediction leaves the starting/processing state, then
+     * returns the final response. Returns [this] untouched when there is nothing to wait for — the
+     * call failed, carries no id, or already finished within the `Prefer: wait` window. If the
+     * budget runs out the last in-progress response is returned, and [failureReason] reports it as
+     * a timeout rather than a generic failure.
+     */
+    private suspend fun AiApiBaseResponse<ReplicatePredictionResponse>.awaitOutput(): AiApiBaseResponse<ReplicatePredictionResponse> {
+        val predictionId = data?.id
+        if (!isSuccessful || predictionId == null || data?.isAwaitingOutput() != true) return this
+
+        delay(POLL_INITIAL_DELAY)
+
+        var response = this
+        repeat(POLL_MAX_ATTEMPTS) { attempt ->
+            response = replicateApiService.getPredictionStatus(predictionId)
+            val prediction = response.data
+            if (!response.isSuccessful || prediction?.isAwaitingOutput() != true) return response
+
+            AppLogger.d(
+                "Replicate prediction $predictionId is ${prediction.status} " +
+                    "(poll ${attempt + 1}/$POLL_MAX_ATTEMPTS)",
+            )
+            delay(minOf(POLL_MAX_INTERVAL, (1L shl attempt).seconds))
+        }
+        return response
+    }
+
+    /** True while Replicate is still working and has produced no output yet. */
+    private fun ReplicatePredictionResponse.isAwaitingOutput(): Boolean = isInProgress && outputUrl() == null
+
+    /**
+     * The output URL, or null when absent. Replicate occasionally serialises a missing output as the
+     * literal string `"null"`, which is not a URL — treat it as absent.
+     */
+    private fun ReplicatePredictionResponse.outputUrl(): String? = output?.takeIf { it.isNotBlank() && it != "null" }
+
+    /** Why no output came back, kept specific enough to diagnose without reading Replicate's logs. */
+    private fun ReplicatePredictionResponse?.failureReason(): String = when {
+        this == null -> "AI generation failed: no prediction returned"
+        isFailed -> "AI generation failed: ${error ?: "no error detail"}"
+        isCanceled -> "AI generation was canceled"
+        isInProgress -> "AI generation timed out: still $status after $POLL_MAX_ATTEMPTS polls"
+        else -> "AI generation returned no output (status=$status, error=${error ?: "none"})"
     }
 
     fun GenerationInput.toReplicateRequestBody(): JsonObject {


### PR DESCRIPTION
## Problem

The client sends `Prefer: wait`, which Replicate honours for at most ~60s. A model that needs longer — cold start, heavy image-to-image, video — returns **HTTP 200** with `status: "starting"/"processing"` and `output: null`. That means "poll me", not "failed".

`ReplicateGenerationProvider` read a null output as an instant failure and surfaced a bare `"AI generation failed"`. Result: slow generations failed intermittently, with no detail to diagnose them by.

`ReplicateApiService.getPredictionStatus` and the `isInProgress` / `isCompleted` / `isFailed` helpers on `ReplicatePredictionResponse` already existed — but git history shows they were **never called from anywhere**, in any version of the file. Scaffolding that was built and never wired.

## Change

One call site: `createOfficialModelsPrediction(...) / createCommunityModelsPrediction(...)` now chains `.awaitOutput()`.

- Returns immediately when there is nothing to wait for — the call failed, carries no id, or already finished inside the `Prefer: wait` window. The fast path is unchanged.
- Otherwise: 5s initial delay, then poll `getPredictionStatus` with exponential backoff capped at 15s, up to 20 attempts (~4.3 min of budget). Stops as soon as the prediction leaves the in-progress state.
- Poll timings are companion constants next to the existing model constants, so a model that routinely runs longer is tuned in one place.

### Errors now say what happened

| State | Message |
|---|---|
| `status: "failed"` | the model's own `error` string |
| Poll budget exhausted | explicit timeout, with attempt count |
| Finished, no output | terminal `status` + `error` |
| No prediction returned | stated as such |

Also: an output serialised as the literal string `"null"` is treated as absent rather than used as a URL. Replicate does occasionally emit that.

## Backoff shape

Deliberately capped rather than pure `2^n`. Uncapped over 20 attempts ends with multi-minute gaps between checks, so a prediction that finishes early isn't noticed until long after. Capped at 15s, the same wall-clock budget is spread across many more checks and completion is picked up within 15s.

## Validation

- `./gradlew :shared:compileKotlinJvm` — clean
- `./gradlew spotlessCheck :shared:jvmTest :shared:testAndroidHostTest` — BUILD SUCCESSFUL

**Not covered by a test.** `ReplicateGenerationProvider` takes a concrete `ReplicateApiService`, so there is no seam to stub without either making it an interface (against the repo's "no interfaces unless 2+ implementations" convention) or standing up `AiTransport` with a Ktor `MockEngine`. Happy to add either if there's a preference.

**Not yet exercised against live Replicate.** The polling path only runs on a generation that actually exceeds 60s — worth one real slow run before merging.

## Notes

- Overlaps #38, which documents this behaviour in `integrate-web-proxy` and states the polling primitives "exist but are never called". True today, false once this merges — whichever lands second should update that sentence.
- Still open from the same review, not addressed here: `output: String?` → `JsonElement?` for models that return an array of URIs, and the Cloud Function's 60s timeout sitting exactly at Replicate's `Prefer: wait` ceiling.
