### PR TITLE
Teach agents to parallelize work by default

### DIFF
--- a/.agents/skills/koko-getting-started/SKILL.md
+++ b/.agents/skills/koko-getting-started/SKILL.md
@@ -60,6 +60,7 @@ Once the KMP app is ready (the getting started skill mentioned above is complete
 - [ ] **[setup-firebase](../../../skills/setup-firebase/SKILL.md)**: Connect the app to Firebase services.
 - [ ] **[enable-auth](../../../skills/enable-auth/SKILL.md)**: Integrate social sign-in (Google/Apple).
 - [ ] **[integrate-web-proxy](../../../skills/integrate-web-proxy/SKILL.md)**: Connect the mobile app to the Firebase Cloud Functions proxy.
+- [ ] **[sync-data-firebase](../../../skills/sync-data-firebase/SKILL.md)**: Put data in Firestore, sync across devices, or make state server-authoritative (optional — asks the wasmJs trade-off first).
 
 ### Phase 3: Publication
 - [ ] **[generate-app-icons](../../../skills/generate-app-icons/SKILL.md)**: Generate and set launcher icons.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,37 @@ These three scoped tasks ARE the whole validation. Do not improvise around them:
 ### `@Preview` annotation
 Always use `androidx.compose.ui.tooling.preview.Preview`, NOT `org.jetbrains.compose.ui.tooling.preview.Preview` (the latter is deprecated as of CMP 1.10 and not discovered by ComposablePreviewScanner). The multiplatform-aware AndroidX import comes from `org.jetbrains.compose.ui:ui-tooling-preview` (already wired in `shared` and `designsystem`).
 
+## Agent Working Style — parallelize by default
+
+Most tasks in this repo decompose into independent pieces (screens, models, docs, skills, per-file
+edits). Working through them one at a time is the main reason sessions feel slow. If your harness
+supports subagents / parallel tool calls (Claude Code, Cursor, Copilot Workspace, …), **fan out
+whenever the pieces are independent** — for any task, not just feature builds:
+
+- **Reads are always safe to parallelize.** Product docs, multiple source files, several skills —
+  read them concurrently, never one-by-one.
+- **Fan out implementation when files are disjoint.** One subagent per screen / model / feature
+  folder / doc file. The biggest case is `build-features` (see its step 3), but the same applies to
+  refactors, doc sweeps, multi-screen UI passes, test authoring.
+- **File-ownership rule** (what makes fan-out safe): a subagent edits **only files it exclusively
+  owns** (its feature folder). Shared, single-instance files are edited **only by the orchestrating
+  agent**, merging what subagents return: `Routes.kt`, `AppNavigation.kt`, `root/Di.kt`,
+  `AppDatabase.kt`, `DatabaseModule.kt`, `composeResources/values/strings.xml`, gradle files.
+  Two subagents writing one file concurrently = lost updates.
+- **Never parallelize the scaffold scripts** (`generate_screen.sh`, `make_local.sh`,
+  `refactor_package.sh`) — they patch shared files at insertion markers; concurrent runs corrupt
+  them. Scaffold sequentially (they're fast), then fan out the implementation.
+- **One Gradle invocation at a time, run by the orchestrator.** Subagents should not build or test;
+  concurrent Gradle runs in one checkout just serialize on the daemon lock. Validate **once** after
+  merging all subagent output — `spotlessApply`, the scoped gates, and a single
+  `recordRoborazziAndroidHostTest` run (it snapshots every `@Preview` in one pass).
+- **Long-running tasks run in the background** — `:desktopApp:run`, the wasm dev server. Don't block
+  a session waiting on a task that never exits (see Validation guardrails).
+- **Git worktrees** are for genuinely independent workstreams that must not interfere (a risky
+  refactor alongside feature work, two large PRs in flight) — each worktree pays a full fresh Gradle
+  build, so they are **not** worth it for per-screen fan-out. Default to subagents in one checkout;
+  reach for a worktree when isolation matters more than build reuse.
+
 ## Architecture & Key Conventions
 
 ### Core Principles

--- a/MobileApp/AGENTS.md
+++ b/MobileApp/AGENTS.md
@@ -10,5 +10,8 @@ auto-load — read it now:
   (`../skills/<name>/SKILL.md`). Read the matching skill before doing a task it covers.
 - **Progress files:** `../PROGRESS_*.md` (at the git root, **not** in `MobileApp/`) — read before
   resuming work; continue from the first unchecked item.
+- **Work in parallel by default:** independent pieces (screens, models, docs) get one subagent
+  each, fanned out concurrently — see "Agent Working Style" in [`../AGENTS.md`](../AGENTS.md) for
+  the file-ownership and single-Gradle rules that make it safe.
 
 All Gradle commands run from this directory (`MobileApp/`).

--- a/MobileApp/CLAUDE.md
+++ b/MobileApp/CLAUDE.md
@@ -10,5 +10,8 @@ auto-load — read it now:
   (`../skills/<name>/SKILL.md`). Read the matching skill before doing a task it covers.
 - **Progress files:** `../PROGRESS_*.md` (at the git root, **not** in `MobileApp/`) — read before
   resuming work; continue from the first unchecked item.
+- **Work in parallel by default:** independent pieces (screens, models, docs) get one subagent
+  each, fanned out concurrently — see "Agent Working Style" in [`../AGENTS.md`](../AGENTS.md) for
+  the file-ownership and single-Gradle rules that make it safe.
 
 All Gradle commands run from this directory (`MobileApp/`).

--- a/MobileApp/GEMINI.md
+++ b/MobileApp/GEMINI.md
@@ -10,5 +10,8 @@ auto-load — read it now:
   (`../skills/<name>/SKILL.md`). Read the matching skill before doing a task it covers.
 - **Progress files:** `../PROGRESS_*.md` (at the git root, **not** in `MobileApp/`) — read before
   resuming work; continue from the first unchecked item.
+- **Work in parallel by default:** independent pieces (screens, models, docs) get one subagent
+  each, fanned out concurrently — see "Agent Working Style" in [`../AGENTS.md`](../AGENTS.md) for
+  the file-ownership and single-Gradle rules that make it safe.
 
 All Gradle commands run from this directory (`MobileApp/`).

--- a/skills/build-features/SKILL.md
+++ b/skills/build-features/SKILL.md
@@ -62,16 +62,34 @@ before you generate anything — that's what makes the build resumable.
 
 Use the **`new-local-model`** and **`new-screen`** skills for the rules each one expects.
 
-## 3. Implement — **Agent Action, parallelize here**
+## 3. Implement — **Agent Action — fan out subagents in parallel**
 
-Once scaffolding is done, the per-feature work lives in **separate folders**, so it's safe to fan out
-**one subagent per screen/model**:
+Scaffolding was sequential; implementation must not be. The per-feature work lives in **separate
+folders**, so launch **one subagent per screen and per model — all at once, not one after another**.
+On a 4-screen app this is the single biggest time saving of the whole phase; only fall back to
+sequential if your harness has no subagent support.
+
+**File-ownership rule (what makes the fan-out safe):**
+
+- A subagent edits **only its own feature's files**: `presentation/screens/<feature>/` for a screen,
+  the model's `@Entity`/`@Dao`/domain files for a model.
+- **Shared files stay with you**, the orchestrator: `Routes.kt`, `AppNavigation.kt`, `root/Di.kt`,
+  `AppDatabase.kt`, `DatabaseModule.kt`, and `composeResources/values/strings.xml`. If a subagent
+  needs new string resources, have it **return them** and merge them yourself — two subagents
+  editing `strings.xml` concurrently is a lost update.
+- Subagents **don't run Gradle** — no per-screen builds or tests. Concurrent Gradle runs in one
+  checkout just serialize on the daemon lock. You validate everything once in step 5.
+
+What each subagent does:
 
 - **Models** — real columns on the `@Entity`, update both mappers, DAO queries the feature needs.
 - **Screens** — build the UI in the pure composable overload per `ui_ux.md`; keep logic in the
   ViewModel; use `designsystem` components (`AppButton`, `AppCard`, …).
 - **Navigation** — edit the generated `entry<…>` blocks in `AppNavigation.kt` to add the callbacks
   the flow needs. *(This file is shared — do this yourself, not in a subagent.)*
+
+The step-4 branding work below is independent of the feature screens — put it **in the same
+fan-out** rather than doing it afterwards.
 
 Reach for these only if the feature actually needs them:
 - **`add-api-service`** — a remote call (any public URL; no backend needed).
@@ -88,7 +106,9 @@ Reach for these only if the feature actually needs them:
 
 The kit **already includes an onboarding flow and a paywall** (`presentation/screens/onboarding/`,
 `presentation/screens/paywall/`). Out of the box they show boilerplate copy about the wrong product —
-the developer will hit them the moment they run the app, so fix them now, not at publish time:
+the developer will hit them the moment they run the app, so fix them now, not at publish time.
+Both jobs are independent of your feature screens — run them as **two more subagents in the step-3
+fan-out** (same ownership rule: they return their `strings.xml` entries; you merge them):
 
 - **Onboarding** — rebuild the copy/steps from
   [`AiGuidelines/project/onboarding.md`](../../AiGuidelines/project/onboarding.md): the chosen pattern,
@@ -103,6 +123,10 @@ the developer will hit them the moment they run the app, so fix them now, not at
     the real store products exist.
 
 ## 5. Validate — **Agent Action → User confirms**
+
+Run this **once, after all subagents are merged** — not per screen. One
+`recordRoborazziAndroidHostTest` run snapshots **every** `@Preview` in a single Gradle invocation,
+so N screens still cost one build.
 
 Verify each screen you built with the **`verify-ui`** skill *before* handing back:
 - **Behaviour** — a headless `runComposeUiTest` against the screen's pure `(uiState, onUiEvent)`

--- a/skills/getting-started/SKILL.md
+++ b/skills/getting-started/SKILL.md
@@ -81,6 +81,7 @@ Verify: `./scripts/check_env.sh --phase getting-started`.
 ### D. Build your features
 
 8. **Agent Action** — Build the MVP with the **`build-features`** skill: it derives the screens + local models from `prd.md`/`user_flow.md`, scaffolds them (`make_local.sh` / `generate_screen.sh`, **run sequentially** — they patch shared files), implements the UI per `ui_ux.md`, and brands the onboarding + paywall screens that already ship.
+   - **Speed matters here:** after the sequential scaffold, `build-features` step 3 **fans out one subagent per screen/model in parallel** (onboarding + paywall branding join the same fan-out). Implementing screens one after another is the main reason this phase feels slow — see "Agent Working Style" in the root `AGENTS.md`.
    - It records every model/screen in **`PROGRESS_FEATURES.md`** at the **git repo root** (the folder that contains `MobileApp/` — from the MobileApp Window that's one level up, `../PROGRESS_FEATURES.md`; never inside `MobileApp/`) and ticks them off as it goes — so if a session stops, the next one resumes from the first unchecked item instead of guessing.
    - Underlying skills it uses: **`new-local-model`**, **`new-screen`**, and — only if a feature needs them — **`add-api-service`** (any public URL, no backend), **`save-preferences`**, **`add-permission`**.
    - Everything stays local: **no Firebase, no provider account, no store account** in this phase. The paywall runs on the mock provider if you touch it.


### PR DESCRIPTION
Agent sessions in this repo default to sequential work — screens implemented one after another, files read one at a time — which is the main reason a fresh `new-app` → `build-features` run feels slow. Nothing in the agent context told them otherwise.

## What this adds

**`AGENTS.md` — new "Agent Working Style — parallelize by default" section.** General doctrine for any task, not just feature builds:

- Reads are always safe to parallelize; fan out implementation subagents whenever files are disjoint.
- **File-ownership rule** that makes fan-out safe: a subagent edits only files it exclusively owns (its feature folder); shared single-instance files (`Routes.kt`, `AppNavigation.kt`, `root/Di.kt`, `AppDatabase.kt`, `DatabaseModule.kt`, `strings.xml`, gradle files) are merged only by the orchestrator.
- Scaffold scripts stay strictly sequential (they patch shared insertion markers).
- **One Gradle invocation at a time**, run by the orchestrator, once, after merging — concurrent runs just serialize on the daemon lock.
- Long-running run tasks go to the background (they never exit).
- **Worktrees**: for genuinely independent workstreams that need isolation (risky refactor alongside feature work), not for per-screen fan-out — each worktree costs a full fresh Gradle build.

**`skills/build-features/SKILL.md` — step 3 becomes a concrete fan-out recipe.** One subagent per screen and per model, launched all at once; the onboarding/paywall branding (step 4) joins the same fan-out; subagents return their `strings.xml` entries for the orchestrator to merge; validation runs once at the end (a single `recordRoborazziAndroidHostTest` pass snapshots every preview).

**`skills/getting-started/SKILL.md`** — step D8 points at the fan-out so Phase 1 sessions expect it.

**`MobileApp/{AGENTS,CLAUDE,GEMINI}.md`** — pointer bullet, since root `AGENTS.md` doesn't auto-load in the MobileApp window.

Docs only — no code changes.