### PR TITLE
Fix iOS publishing, and write every build key in all three workflows

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -30,11 +30,21 @@ jobs:
         with:
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
+      # Keys come from local.properties.example, so adding one there needs no
+      # workflow edit. These checks never ship a binary, so empty values are
+      # fine — on pull requests from forks no secrets are available at all and
+      # every getRequiredProperty() falls back to its default.
       - name: Write secrets to local.properties
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
         run: |
-          echo "GOOGLE_WEB_CLIENT_ID=${{ secrets.GOOGLE_WEB_CLIENT_ID }}" >> "local.properties"
-          echo "REVENUECAT_ANDROID_API_KEY=${{ secrets.REVENUECAT_ANDROID_API_KEY }}" >> "local.properties"
-          echo "REVENUECAT_IOS_API_KEY=${{ secrets.REVENUECAT_IOS_API_KEY }}" >> "local.properties"
+          set -euo pipefail
+          keys=$(sed -n 's/^\([A-Z][A-Z0-9_]*\)=.*/\1/p' local.properties.example)
+          [ -n "$keys" ] || { echo "No keys found in local.properties.example"; exit 1; }
+          for key in $keys; do
+            value=$(printf '%s' "$ALL_SECRETS" | jq -r --arg k "$key" '.[$k] // ""')
+            printf '%s=%s\n' "$key" "$value" >> local.properties
+          done
 
       - name: Spotless check (ktlint)
         run: ./gradlew spotlessCheck

--- a/.github/workflows/publish_android_playstore.yml
+++ b/.github/workflows/publish_android_playstore.yml
@@ -29,11 +29,34 @@ jobs:
         with:
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
+      # local.properties is gitignored, so a CI checkout has none of these keys.
+      # Every getRequiredProperty() in build.gradle.kts declares a defaultValue,
+      # so a MISSING key does not fail the build — it silently bakes in "" or
+      # "testValue" and ships an app with broken sign-in, analytics and paywall.
+      #
+      # The key list comes from local.properties.example rather than being
+      # repeated here, so adding a new key to that file is all it takes: set a
+      # repo secret of the same name and this step picks it up. sdk.dir is
+      # skipped because the runner's Android setup already writes it.
       - name: Write secrets to local.properties
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
         run: |
-          echo "GOOGLE_WEB_CLIENT_ID=${{ secrets.GOOGLE_WEB_CLIENT_ID }}" >> "local.properties"
-          echo "REVENUECAT_ANDROID_API_KEY=${{ secrets.REVENUECAT_ANDROID_API_KEY }}" >> "local.properties"
-          echo "REVENUECAT_IOS_API_KEY=${{ secrets.REVENUECAT_IOS_API_KEY }}" >> "local.properties"
+          set -euo pipefail
+          keys=$(sed -n 's/^\([A-Z][A-Z0-9_]*\)=.*/\1/p' local.properties.example)
+          [ -n "$keys" ] || { echo "No keys found in local.properties.example"; exit 1; }
+          missing=""
+          for key in $keys; do
+            value=$(printf '%s' "$ALL_SECRETS" | jq -r --arg k "$key" '.[$k] // ""')
+            if [ -z "$value" ]; then missing="$missing $key"; fi
+            printf '%s=%s\n' "$key" "$value" >> local.properties
+          done
+          echo "Wrote $(printf '%s\n' $keys | wc -l | tr -d ' ') keys to local.properties"
+          # Loud, but not fatal: a placeholder only breaks the feature that uses
+          # it, and half-configured apps still need to reach the Play Store.
+          if [ -n "$missing" ]; then
+            echo "::warning title=Missing build secrets::No repo secret set for:$missing — the app will build but those features ship with placeholder values."
+          fi
 
       - name: Decode Android Keystore
         env:

--- a/.github/workflows/publish_ios_appstore.yml
+++ b/.github/workflows/publish_ios_appstore.yml
@@ -1,5 +1,7 @@
 name: Publish iOS App
 
+# kappmaker-workflow-version: 3
+
 # Builds and ships the iOS app on a GitHub macOS runner, so no Mac is needed
 # locally. Signing certificates are created on the runner by fastlane `match`
 # from your App Store Connect API key — nothing has to be exported from a Mac.

--- a/.github/workflows/publish_ios_appstore.yml
+++ b/.github/workflows/publish_ios_appstore.yml
@@ -1,6 +1,52 @@
 name: Publish iOS App
 
+# Builds and ships the iOS app on a GitHub macOS runner, so no Mac is needed
+# locally. Signing certificates are created on the runner by fastlane `match`
+# from your App Store Connect API key — nothing has to be exported from a Mac.
+#
+# The certificates are encrypted with MATCH_PASSWORD and committed to the
+# `match-certificates` branch of THIS repository, so the built-in GITHUB_TOKEN
+# can reach them. No second repo, and no personal access token.
+#
+# Required secrets:
+#   APPSTORE_KEY_ID          App Store Connect API key ID
+#   APPSTORE_ISSUER_ID       its issuer ID
+#   APPSTORE_PRIVATE_KEY     the .p8 contents, base64-encoded
+#   MATCH_PASSWORD           any long random string; it encrypts the certificates.
+#                            Keep it — losing it means the stored certificates
+#                            can never be decrypted and the branch must be reset.
+#   GRADLE_CACHE_ENCRYPTION_KEY
+#   …plus one secret per key listed in MobileApp/local.properties.example.
+#      That file is the single source of truth — add a key there and set a repo
+#      secret of the same name; this workflow needs no edit.
+#
+# If this repository is public, note that the encrypted certificates are public
+# too. They are useless without MATCH_PASSWORD, but a private repo is safer.
+
 on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: Where to send the build
+        required: true
+        default: testflight
+        type: choice
+        options: [testflight, appstore]
+      submit_for_review:
+        description: Submit for App Store review (appstore track only)
+        required: false
+        default: false
+        type: boolean
+      upload_metadata:
+        description: Also upload App Store listing text (appstore track only)
+        required: false
+        default: false
+        type: boolean
+      upload_screenshots:
+        description: Also upload App Store screenshots (appstore track only)
+        required: false
+        default: false
+        type: boolean
   push:
     tags:
       - '*-ios'
@@ -9,17 +55,21 @@ defaults:
   run:
     working-directory: MobileApp
 
+concurrency:
+  # Two releases at once would race over the certificates in match's repo.
+  group: publish-ios
+  cancel-in-progress: false
+
 jobs:
   publish_app:
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     name: Publishing iOS App
     permissions:
       contents: write
     env:
       github_token: ${{ secrets.GITHUB_TOKEN }}
-      bundle_id: com.kotlinfoundation.koko
-      app_name: Koko
+      app_name: KAppMakerAllModules
 
     steps:
       - uses: actions/checkout@v4
@@ -31,98 +81,88 @@ jobs:
         with:
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
+      # local.properties is gitignored, so a CI checkout has none of these keys.
+      # Every getRequiredProperty() in build.gradle.kts declares a defaultValue,
+      # so a MISSING key does not fail the build — it silently bakes in "" or
+      # "testValue" and ships an app with broken sign-in, analytics and paywall.
+      #
+      # The key list comes from local.properties.example rather than being
+      # repeated here, so adding a new key to that file is all it takes: set a
+      # repo secret of the same name and this step picks it up. sdk.dir is
+      # skipped because the runner's Android setup already writes it.
       - name: Write secrets to local.properties
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
         run: |
-          echo "GOOGLE_WEB_CLIENT_ID=${{ secrets.GOOGLE_WEB_CLIENT_ID }}" >> "local.properties"
-          echo "REVENUECAT_ANDROID_API_KEY=${{ secrets.REVENUECAT_ANDROID_API_KEY }}" >> "local.properties"
-          echo "REVENUECAT_IOS_API_KEY=${{ secrets.REVENUECAT_IOS_API_KEY }}" >> "local.properties"
+          set -euo pipefail
+          # POSIX sed, not a grep lookahead: the runner is macOS and BSD grep
+          # has no lookahead support.
+          keys=$(sed -n 's/^\([A-Z][A-Z0-9_]*\)=.*/\1/p' local.properties.example)
+          [ -n "$keys" ] || { echo "No keys found in local.properties.example"; exit 1; }
+          missing=""
+          for key in $keys; do
+            value=$(printf '%s' "$ALL_SECRETS" | jq -r --arg k "$key" '.[$k] // ""')
+            if [ -z "$value" ]; then missing="$missing $key"; fi
+            printf '%s=%s\n' "$key" "$value" >> local.properties
+          done
+          echo "Wrote $(printf '%s\n' $keys | wc -l | tr -d ' ') keys to local.properties"
+          # Loud, but not fatal: a placeholder only breaks the feature that uses
+          # it, and half-configured apps still need to reach TestFlight.
+          if [ -n "$missing" ]; then
+            echo "::warning title=Missing build secrets::No repo secret set for:$missing — the app will build but those features ship with placeholder values."
+          fi
 
+      # match clones over HTTPS; the built-in token is enough because the
+      # certificates live on a branch of this same repository.
+      - name: Prepare match credentials
+        run: echo "match_git_auth=$(printf 'x-access-token:%s' "${{ secrets.GITHUB_TOKEN }}" | base64 | tr -d '\n')" >> "$GITHUB_ENV"
 
-      - name: Import Apple Certificates
-        uses: apple-actions/import-codesign-certs@v3
+      - name: Set up Ruby and fastlane
+        uses: ruby/setup-ruby@v1
         with:
-          p12-file-base64: ${{ secrets.IOS_APP_CERTIFICATE_P12_BASE64 }}
-          p12-password: ${{ secrets.IOS_APP_CERTIFICATE_P12_PASSWORD }}
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: MobileApp
 
-      - name: Download Provisioning Profiles
-        uses: apple-actions/download-provisioning-profiles@v3
+      # Uses the project's own Fastfile, so a local release and a CI release run
+      # the same lane and cannot drift apart.
+      - name: Build, sign and upload
+        env:
+          ASC_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          # This repo, on a dedicated branch — both derived from the Actions
+          # context, so neither needs to be configured as a secret.
+          MATCH_GIT_URL: ${{ github.server_url }}/${{ github.repository }}.git
+          MATCH_GIT_BRANCH: match-certificates
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ env.match_git_auth }}
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_HIDE_CHANGELOG: '1'
+        run: |
+          bundle exec fastlane ios ci_appstore_release \
+            track:"${{ inputs.track || 'testflight' }}" \
+            submit_for_review:"${{ inputs.submit_for_review || 'false' }}" \
+            upload_metadata:"${{ inputs.upload_metadata || 'false' }}" \
+            upload_screenshots:"${{ inputs.upload_screenshots || 'false' }}"
+
+      # The .ipa is the expensive artefact — keep it reachable when a later step
+      # fails, rather than paying another 20 minutes to rebuild it.
+      - name: Upload .ipa artifact
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          bundle-id: ${{ env.bundle_id }}
-          issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
-          api-key-id: ${{ secrets.APPSTORE_KEY_ID }}
-          api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}
-
-      - name: Build iOSApp archive
-        run: |
-          cd iosApp
-
-          xcrun xcodebuild \
-            -project iosApp.xcodeproj \
-            -scheme "iosApp" \
-            -sdk "iphoneos" \
-            -configuration "Release" \
-            -destination "generic/platform=iOS" \
-            -parallelizeTargets \
-            -showBuildTimingSummary \
-            -derivedDataPath "${RUNNER_TEMP}/Build/DerivedData" \
-            -archivePath "${RUNNER_TEMP}/Build/Archives/iosApp.xcarchive" \
-            -resultBundlePath "${RUNNER_TEMP}/Build/Artifacts/iosApp.xcresult" \
-            -destination "generic/platform=iOS" \
-            DEVELOPMENT_TEAM="${{ secrets.APPSTORE_TEAM_ID }}" \
-            CODE_SIGN_STYLE="Manual" \
-            PROVISIONING_PROFILE_SPECIFIER="${{ secrets.IOS_APP_DEVELOPMENT_PROVISION_UUID }}" \
-            clean archive
-
-
-      - name: Generate ExportOptions.plist
-        run: |
-          cat <<EOF > ${RUNNER_TEMP}/Build/ExportOptions.plist
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-            <dict>
-              <key>destination</key>
-              <string>export</string>
-              <key>manageAppVersionAndBuildNumber</key>
-              <true/>
-              <key>method</key>
-              <string>app-store-connect</string>
-              <key>signingStyle</key>
-              <string>automatic</string>
-              <key>stripSwiftSymbols</key>
-              <true/>
-              <key>teamID</key>
-              <string>${{ secrets.APPSTORE_TEAM_ID }}</string>
-              <key>uploadSymbols</key>
-              <true/>
-            </dict>
-          </plist>
-          EOF
-
-      - id: export_archive
-        name: Export Archive
-        run: |
-          xcrun xcodebuild \
-            -exportArchive \
-            -exportOptionsPlist "${RUNNER_TEMP}/Build/ExportOptions.plist" \
-            -archivePath "${RUNNER_TEMP}/Build/Archives/iosApp.xcarchive" \
-            -exportPath "${RUNNER_TEMP}/Build/Archives/iosApp.xcarchive"
-
-          echo "ipa_path=${RUNNER_TEMP}/Build/Archives/iosApp.xcarchive/${{ env.app_name }}.ipa" >> $GITHUB_ENV
-
-      - name: Upload to TestFlight
-        uses: Apple-Actions/upload-testflight-build@v1
-        with:
-          app-path: ${{ env.ipa_path }}
-          issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
-          api-key-id: ${{ secrets.APPSTORE_KEY_ID }}
-          api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          name: ios-ipa
+          path: MobileApp/distribution/ios/*.ipa
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Create new release from tag
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
           files: |
-            ${{ env.ipa_path }}
+            MobileApp/distribution/ios/*.ipa
           body_path: MobileApp/distribution/whatsnew/whatsnew-en-US
           token: ${{ env.github_token }}

--- a/.github/workflows/publish_ios_appstore.yml
+++ b/.github/workflows/publish_ios_appstore.yml
@@ -1,7 +1,5 @@
 name: Publish iOS App
 
-# kappmaker-workflow-version: 3
-
 # Builds and ships the iOS app on a GitHub macOS runner, so no Mac is needed
 # locally. Signing certificates are created on the runner by fastlane `match`
 # from your App Store Connect API key — nothing has to be exported from a Mac.
@@ -71,7 +69,7 @@ jobs:
       contents: write
     env:
       github_token: ${{ secrets.GITHUB_TOKEN }}
-      app_name: KAppMakerAllModules
+      app_name: Koko
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_ios_appstore.yml
+++ b/.github/workflows/publish_ios_appstore.yml
@@ -30,7 +30,9 @@ name: Publish iOS App
 # candidates for GitHub organisation secrets, so a new app only needs its own
 # build keys.
 #
-# `kappmaker ios-ci init` creates the certs repo and sets all of this for you.
+# To set the certs repo up once per Apple account: create an empty PRIVATE
+# GitHub repo (e.g. ios-certificates), put its https URL in MATCH_GIT_URL, and
+# create a fine-grained PAT with read access to it. See the setup-signing skill.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/publish_ios_appstore.yml
+++ b/.github/workflows/publish_ios_appstore.yml
@@ -4,24 +4,33 @@ name: Publish iOS App
 # locally. Signing certificates are created on the runner by fastlane `match`
 # from your App Store Connect API key — nothing has to be exported from a Mac.
 #
-# The certificates are encrypted with MATCH_PASSWORD and committed to the
-# `match-certificates` branch of THIS repository, so the built-in GITHUB_TOKEN
-# can reach them. No second repo, and no personal access token.
+# Signing material lives in a SEPARATE PRIVATE repository shared by all of your
+# apps, because an iOS distribution certificate belongs to your Apple Developer
+# *account*, not to one app — and Apple only allows three of them. Giving each
+# app its own certificate store would mint a new certificate per app and lock you
+# out on the fourth. One store means one certificate, reused, with a per-app
+# provisioning profile alongside it.
 #
 # Required secrets:
-#   APPSTORE_KEY_ID          App Store Connect API key ID
-#   APPSTORE_ISSUER_ID       its issuer ID
-#   APPSTORE_PRIVATE_KEY     the .p8 contents, base64-encoded
-#   MATCH_PASSWORD           any long random string; it encrypts the certificates.
-#                            Keep it — losing it means the stored certificates
-#                            can never be decrypted and the branch must be reset.
+#   APPSTORE_KEY_ID          App Store Connect API key ID          ) same values
+#   APPSTORE_ISSUER_ID       its issuer ID                         ) for every app
+#   APPSTORE_PRIVATE_KEY     the .p8 contents, base64-encoded      ) on one Apple
+#   MATCH_PASSWORD           passphrase encrypting the store       ) account
+#   MATCH_GIT_URL            https URL of your private certs repo  )
+#   MATCH_GIT_BASIC_AUTHORIZATION                                  )
+#                            base64 of "x-access-token:<PAT with read access to
+#                            that repo>". The built-in GITHUB_TOKEN cannot be
+#                            used: it only reaches the repo it runs in.
 #   GRADLE_CACHE_ENCRYPTION_KEY
 #   …plus one secret per key listed in MobileApp/local.properties.example.
 #      That file is the single source of truth — add a key there and set a repo
 #      secret of the same name; this workflow needs no edit.
 #
-# If this repository is public, note that the encrypted certificates are public
-# too. They are useless without MATCH_PASSWORD, but a private repo is safer.
+# If several apps share an organisation, the account-level secrets above are good
+# candidates for GitHub organisation secrets, so a new app only needs its own
+# build keys.
+#
+# `kappmaker ios-ci init` creates the certs repo and sets all of this for you.
 
 on:
   workflow_dispatch:
@@ -56,7 +65,7 @@ defaults:
     working-directory: MobileApp
 
 concurrency:
-  # Two releases at once would race over the certificates in match's repo.
+  # Two releases at once would race over the shared certificate store.
   group: publish-ios
   cancel-in-progress: false
 
@@ -112,11 +121,6 @@ jobs:
             echo "::warning title=Missing build secrets::No repo secret set for:$missing — the app will build but those features ship with placeholder values."
           fi
 
-      # match clones over HTTPS; the built-in token is enough because the
-      # certificates live on a branch of this same repository.
-      - name: Prepare match credentials
-        run: echo "match_git_auth=$(printf 'x-access-token:%s' "${{ secrets.GITHUB_TOKEN }}" | base64 | tr -d '\n')" >> "$GITHUB_ENV"
-
       - name: Set up Ruby and fastlane
         uses: ruby/setup-ruby@v1
         with:
@@ -132,11 +136,10 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          # This repo, on a dedicated branch — both derived from the Actions
-          # context, so neither needs to be configured as a secret.
-          MATCH_GIT_URL: ${{ github.server_url }}/${{ github.repository }}.git
-          MATCH_GIT_BRANCH: match-certificates
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ env.match_git_auth }}
+          # A private repo shared across your apps — see the note at the top of
+          # this file for why it is not this repository.
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_HIDE_CHANGELOG: '1'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Entries start with the first template change after the sync tooling landed — g
   own Fastfile instead of a parallel xcodebuild. Manual: set `APPSTORE_ISSUER_ID`, `APPSTORE_KEY_ID`,
   `APPSTORE_PRIVATE_KEY` and `MATCH_PASSWORD` as repo secrets; the old
   `IOS_APP_CERTIFICATE_P12_BASE64` and friends are no longer needed.
+- `[app]` **Android releases and PR checks write every build key** (#48): both workflows wrote the same
+  stale three-key `local.properties` block, two of which the build no longer reads, so Play Store
+  releases shipped with placeholder sign-in, ads, AI and paywall exactly like iOS did. All three
+  workflows now derive the key list from `MobileApp/local.properties.example`, so adding a key there
+  needs no workflow edit. Manual: set a repo secret for each key you use — the release workflows warn
+  about any that are missing.
 
 ## 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ Entries start with the first template change after the sync tooling landed — g
   hand-exported `.p12` flow and two RevenueCat keys the build no longer reads. They now list the four
   iOS secrets that exist, say that `MATCH_PASSWORD` is a passphrase you invent, and state the rule the
   workflows rely on: every key in `local.properties.example` needs a repo secret of the same name.
+- `[app]` **One certificates repo per Apple account, not per app** (#48): certificates were stored on a
+  branch of each app's own repo, but an iOS distribution certificate belongs to the Apple account and
+  Apple issues at most three — so every new app burned a slot and the fourth locked the account out.
+  Signing material now lives in a private repo shared across the account. Manual: create an empty
+  private certs repo plus a fine-grained PAT with write access to it, and set `MATCH_GIT_URL` and
+  `MATCH_GIT_BASIC_AUTHORIZATION`; `APPSTORE_PRIVATE_KEY` is now the **base64** of the `.p8`, not its
+  raw contents.
 
 ## 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Entry format — one bullet per merged PR, tagged by scope:
 Entries start with the first template change after the sync tooling landed — group them under a
 `## <year>-<month>-<date>` heading, newest first.
 
+## 2026-08-16
+
+- `[app]` **iOS publishing works without a Mac** (#48): the iOS publish workflow had never run on a
+  generated app. Signing now goes through fastlane `match`, which creates the certificate on the
+  runner from the App Store Connect API key and stores it encrypted on a `match-certificates` branch
+  of the same repo — no hand-exported `.p12`, no second repo, no personal access token. The
+  `local.properties` written by CI was also writing two keys the build no longer reads while missing
+  fourteen it does, so releases shipped green with dead sign-in, analytics and paywall; and archive
+  and export disagreed about signing style. Signing settings are applied per target
+  (Swift Package dependencies reject a provisioning profile), and the workflow drives the project's
+  own Fastfile instead of a parallel xcodebuild. Manual: set `APPSTORE_ISSUER_ID`, `APPSTORE_KEY_ID`,
+  `APPSTORE_PRIVATE_KEY` and `MATCH_PASSWORD` as repo secrets; the old
+  `IOS_APP_CERTIFICATE_P12_BASE64` and friends are no longer needed.
+
 ## 2026-08-14
 
 - `[app]` **Aligned Firebase library versions** (#47): KMPAuth 3.0.3 → 3.0.5, KMPNotifier 2.0.0 → 2.0.1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Entries start with the first template change after the sync tooling landed — g
   workflows rely on: every key in `local.properties.example` needs a repo secret of the same name.
 - `[app]` **One certificates repo per Apple account, not per app** (#48): certificates were stored on a
   branch of each app's own repo, but an iOS distribution certificate belongs to the Apple account and
-  Apple issues at most three — so every new app burned a slot and the fourth locked the account out.
+  Apple issues at most two — so every new app burned a slot and the account was locked out almost
+  immediately. `match` also now runs read-only on releases, since with write access it mints a new
+  certificate whenever it is unsatisfied; set `MATCH_READONLY=false` for the one bootstrap run.
   Signing material now lives in a private repo shared across the account. Manual: create an empty
   private certs repo plus a fine-grained PAT with write access to it, and set `MATCH_GIT_URL` and
   `MATCH_GIT_BASIC_AUTHORIZATION`; `APPSTORE_PRIVATE_KEY` is now the **base64** of the `.p8`, not its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Entries start with the first template change after the sync tooling landed — g
   workflows now derive the key list from `MobileApp/local.properties.example`, so adding a key there
   needs no workflow edit. Manual: set a repo secret for each key you use — the release workflows warn
   about any that are missing.
+- `[docs]` **Publishing docs match the new secrets** (#48): `setup-signing`, the `publishing` guide and
+  its progress template, the docs-site CI page and the iOS production page all still described the
+  hand-exported `.p12` flow and two RevenueCat keys the build no longer reads. They now list the four
+  iOS secrets that exist, say that `MATCH_PASSWORD` is a passphrase you invent, and state the rule the
+  workflows rely on: every key in `local.properties.example` needs a repo secret of the same name.
 
 ## 2026-08-14
 

--- a/MobileApp/fastlane/Fastfile
+++ b/MobileApp/fastlane/Fastfile
@@ -241,11 +241,21 @@ platform :ios do
 
     # readonly:false so the FIRST run can create and store the certificate. Later
     # runs find it already there and reuse it.
+    # READONLY BY DEFAULT — this protects a scarce, account-wide resource.
+    #
+    # Apple issues at most TWO Apple Distribution certificates per developer
+    # account, and they are shared by every app you ship. With readonly:false
+    # match re-verifies against the portal on every build and mints a NEW
+    # certificate whenever it is not satisfied — so a couple of unlucky builds
+    # can consume both slots and lock the account out of iOS releases entirely.
+    #
+    # Set MATCH_READONLY=false for the single bootstrap run that populates an
+    # empty store, then leave it unset.
     match(
       type: "appstore",
       app_identifier: bundle_id,
       api_key: api_key,
-      readonly: false,
+      readonly: ENV["MATCH_READONLY"].to_s != "false",
       keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"]
     )

--- a/MobileApp/fastlane/Fastfile
+++ b/MobileApp/fastlane/Fastfile
@@ -213,4 +213,101 @@ platform :ios do
      sh(cmd)
   end
 
+
+  # Ships iOS from a CI macOS runner, so no Mac is needed locally. Differs from
+  # `appstore_release` in three ways that only matter on CI:
+  #   - credentials come from env vars, not ~/credentials/*.json
+  #   - `setup_ci` makes a temporary keychain (a CI runner has no unlocked login keychain)
+  #   - `match` supplies the signing identity instead of Xcode automatic signing,
+  #     because automatic signing mints a NEW distribution certificate per run and
+  #     Apple caps those at 3 per account — three green builds, then every build fails.
+  desc "Build and ship from CI (no local Mac required)"
+  lane :ci_appstore_release do |options|
+    track              = (options[:track] || "testflight").to_s
+    submit_for_review  = options[:submit_for_review].to_s == "true"
+    upload_metadata    = options[:upload_metadata].to_s == "true"
+    upload_screenshots = options[:upload_screenshots].to_s == "true"
+    bump_build         = options[:bump_build].to_s != "false"
+
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("ASC_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+      key_content: ENV.fetch("ASC_PRIVATE_KEY"),
+      is_key_content_base64: true,
+      in_house: false
+    )
+
+    setup_ci if ENV["CI"]
+
+    # Apple rejects an already-seen build number, and CI builds from a clean
+    # checkout — so the number in git never advances on its own. Take whatever
+    # TestFlight has already seen and go one past it. This is the CI equivalent
+    # of running `kappmaker update-version` before publishing locally.
+    if bump_build
+      latest = latest_testflight_build_number(
+        api_key: api_key,
+        app_identifier: bundle_id,
+        initial_build_number: 0
+      ) rescue 0
+      increment_build_number(
+        build_number: latest.to_i + 1,
+        xcodeproj: "iosApp/iosApp.xcodeproj"
+      )
+      UI.message("Build number set to #{latest.to_i + 1}")
+    end
+
+    # readonly:false so the FIRST run can create and store the certificate. Later
+    # runs find it already there and reuse it.
+    match(
+      type: "appstore",
+      app_identifier: bundle_id,
+      api_key: api_key,
+      readonly: false,
+      keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+      keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"]
+    )
+
+    build_app(
+      scheme: "iosApp",
+      project: "iosApp/iosApp.xcodeproj",
+      configuration: "Release",
+      export_method: "app-store",
+      silent: false,
+      output_name: "iosApp",
+      output_directory: output_dir,
+      # Explicitly manual: match already installed the profile, and letting Xcode
+      # "help" here is what causes the certificate churn described above.
+      xcargs: "-allowProvisioningUpdates NO"
+    )
+
+    ipa_path = File.join(output_dir, "iosApp.ipa")
+
+    if track == "appstore"
+      upload_to_app_store(
+        api_key: api_key,
+        ipa: ipa_path,
+        skip_metadata: !upload_metadata,
+        skip_screenshots: !upload_screenshots,
+        skip_app_version_update: false,
+        submit_for_review: submit_for_review,
+        metadata_path: appstore_text_metadata_path,
+        screenshots_path: appstore_screenshots_metadata_path,
+        overwrite_screenshots: upload_screenshots,
+        precheck_include_in_app_purchases: false,
+        force: true
+      )
+      UI.success("Uploaded to App Store#{submit_for_review ? ' and submitted for review' : ''}.")
+    else
+      # TestFlight takes a build, not a store listing — metadata and screenshots
+      # belong to the App Store version, so they are ignored on this track.
+      UI.important("Ignoring metadata/screenshots: they apply to the appstore track.") if upload_metadata || upload_screenshots
+      upload_to_testflight(
+        api_key: api_key,
+        ipa: ipa_path,
+        skip_waiting_for_build_processing: true
+      )
+      UI.success("Uploaded to TestFlight.")
+    end
+  end
+
 end

--- a/MobileApp/fastlane/Fastfile
+++ b/MobileApp/fastlane/Fastfile
@@ -227,7 +227,6 @@ platform :ios do
     submit_for_review  = options[:submit_for_review].to_s == "true"
     upload_metadata    = options[:upload_metadata].to_s == "true"
     upload_screenshots = options[:upload_screenshots].to_s == "true"
-    bump_build         = options[:bump_build].to_s != "false"
 
     api_key = app_store_connect_api_key(
       key_id: ENV.fetch("ASC_KEY_ID"),
@@ -239,22 +238,6 @@ platform :ios do
 
     setup_ci if ENV["CI"]
 
-    # Apple rejects an already-seen build number, and CI builds from a clean
-    # checkout — so the number in git never advances on its own. Take whatever
-    # TestFlight has already seen and go one past it. This is the CI equivalent
-    # of running `kappmaker update-version` before publishing locally.
-    if bump_build
-      latest = latest_testflight_build_number(
-        api_key: api_key,
-        app_identifier: bundle_id,
-        initial_build_number: 0
-      ) rescue 0
-      increment_build_number(
-        build_number: latest.to_i + 1,
-        xcodeproj: "iosApp/iosApp.xcodeproj"
-      )
-      UI.message("Build number set to #{latest.to_i + 1}")
-    end
 
     # readonly:false so the FIRST run can create and store the certificate. Later
     # runs find it already there and reuse it.
@@ -267,6 +250,31 @@ platform :ios do
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"]
     )
 
+    # match publishes what it installed through these env vars.
+    profile_name = ENV["sigh_#{bundle_id}_appstore_profile-name"]
+    team_id      = ENV["sigh_#{bundle_id}_appstore_team-id"]
+    UI.user_error!("match did not install a profile for #{bundle_id}") if profile_name.to_s.empty?
+
+    # Signing must be set on the APP TARGET, and nowhere else.
+    #
+    # Through xcargs the settings hit EVERY target, and the Swift Package
+    # dependencies (Firebase, GoogleUtilities, nanopb, promises...) reject a
+    # provisioning profile outright — "does not support provisioning profiles".
+    # This action edits the pbxproj for the named target only.
+    #
+    # It also has to be manual: left on automatic, Xcode hunts for an iOS App
+    # DEVELOPMENT profile and fails, because match installed an App Store one.
+    # The project ships no DEVELOPMENT_TEAM either, so team_id comes from match.
+    update_code_signing_settings(
+      path: "iosApp/iosApp.xcodeproj",
+      use_automatic_signing: false,
+      team_id: team_id,
+      code_sign_identity: "Apple Distribution",
+      profile_name: profile_name,
+      targets: ["iosApp"],
+      build_configurations: ["Release"]
+    )
+
     build_app(
       scheme: "iosApp",
       project: "iosApp/iosApp.xcodeproj",
@@ -275,9 +283,10 @@ platform :ios do
       silent: false,
       output_name: "iosApp",
       output_directory: output_dir,
-      # Explicitly manual: match already installed the profile, and letting Xcode
-      # "help" here is what causes the certificate churn described above.
-      xcargs: "-allowProvisioningUpdates NO"
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: { bundle_id => profile_name }
+      }
     )
 
     ipa_path = File.join(output_dir, "iosApp.ipa")
@@ -309,5 +318,4 @@ platform :ios do
       UI.success("Uploaded to TestFlight.")
     end
   end
-
 end

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -117,8 +117,9 @@ Verify AppConfiguration config: `./scripts/check_env.sh --phase publishing`.
 - **User Action (optional — only if publishing via the CI workflows)** — Add the signing secrets to
   GitHub Actions: `SIGNING_KEY_STORE_FILE_BASE64`, `SIGNING_KEY_STORE_PROPERTIES_BASE64`,
   `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `APPSTORE_KEY_ID` / `APPSTORE_ISSUER_ID` /
-  `APPSTORE_PRIVATE_KEY`, `MATCH_PASSWORD` (a passphrase you invent), and
-  `GRADLE_CACHE_ENCRYPTION_KEY`. **Plus one secret per key in `MobileApp/local.properties.example`**
+  `APPSTORE_PRIVATE_KEY` (base64 of the `.p8`), `MATCH_PASSWORD` (a passphrase you invent),
+  `MATCH_GIT_URL` + `MATCH_GIT_BASIC_AUTHORIZATION` (a private certificates repo shared across
+  your Apple account — see `setup-signing`), and `GRADLE_CACHE_ENCRYPTION_KEY`. **Plus one secret per key in `MobileApp/local.properties.example`**
   — the workflows rebuild `local.properties` from those, and a missing one silently ships a
   placeholder rather than failing. Skip all of this for a manual store upload.
 - **Validation** — `./gradlew :androidApp:bundleRelease` produces a **signed** AAB

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -110,14 +110,17 @@ Verify AppConfiguration config: `./scripts/check_env.sh --phase publishing`.
   `./scripts/generate_android_keystore.sh "Name" "Org"` (or `keytool` manually) to create the
   gitignored `keystore.jks` + `keystore.properties`. Confirm `androidApp/build.gradle.kts`
   picks them up (it does automatically).
-- **User Action** — Create iOS certificates (Apple Development + Distribution → `Certificates.p12`)
-  and provisioning profiles, select them in Xcode. **Back up the keystore + passwords safely**
-  (losing the Android keystore means you can never update the app). **Stop and confirm.**
+- **User Action** — iOS signing needs **no certificate export** when releasing through CI: fastlane
+  `match` creates it on the runner from the App Store Connect API key. Only building locally in
+  Xcode needs certificates on your machine. **Back up the Android keystore + passwords safely**
+  (losing the keystore means you can never update the app). **Stop and confirm.**
 - **User Action (optional — only if publishing via the CI workflows)** — Add the signing secrets to
   GitHub Actions: `SIGNING_KEY_STORE_FILE_BASE64`, `SIGNING_KEY_STORE_PROPERTIES_BASE64`,
-  `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `IOS_APP_CERTIFICATE_P12_BASE64` (+ password),
-  `APPSTORE_KEY_ID` / `APPSTORE_ISSUER_ID` / `APPSTORE_PRIVATE_KEY` / `APPSTORE_TEAM_ID`,
-  the two provision UUIDs, and `GRADLE_CACHE_ENCRYPTION_KEY`. Skip this for a manual store upload.
+  `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `APPSTORE_KEY_ID` / `APPSTORE_ISSUER_ID` /
+  `APPSTORE_PRIVATE_KEY`, `MATCH_PASSWORD` (a passphrase you invent), and
+  `GRADLE_CACHE_ENCRYPTION_KEY`. **Plus one secret per key in `MobileApp/local.properties.example`**
+  — the workflows rebuild `local.properties` from those, and a missing one silently ships a
+  placeholder rather than failing. Skip all of this for a manual store upload.
 - **Validation** — `./gradlew :androidApp:bundleRelease` produces a **signed** AAB
   (`keytool -printcert -jarfile <aab>` shows your cert, not the debug cert).
 

--- a/skills/publishing/progress-template.md
+++ b/skills/publishing/progress-template.md
@@ -32,9 +32,9 @@
 
 ## 4. Release signing — `setup-signing`
 - [ ] **[Agent]** Generate keystore (`generate_android_keystore.sh` or `keytool`) + gitignored `keystore.properties`
-- [ ] **[User]** iOS certificates (Dev + Distribution → `Certificates.p12`) + provisioning profiles, selected in Xcode
+- [ ] **[User]** iOS certificates — only needed for local Xcode builds; CI releases create them on the runner via fastlane `match`
 - [ ] **[User]** Back up keystore + passwords safely (losing the Android keystore = can never update the app)
-- [ ] **[User]** *(optional — only if publishing via CI)* Add signing secrets to GitHub Actions: `SIGNING_KEY_STORE_FILE_BASE64`, `SIGNING_KEY_STORE_PROPERTIES_BASE64`, `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `IOS_APP_CERTIFICATE_P12_BASE64` (+ password), `APPSTORE_KEY_ID`/`ISSUER_ID`/`PRIVATE_KEY`/`TEAM_ID`, both provision UUIDs, `GRADLE_CACHE_ENCRYPTION_KEY`
+- [ ] **[User]** *(optional — only if publishing via CI)* Add signing secrets to GitHub Actions: `SIGNING_KEY_STORE_FILE_BASE64`, `SIGNING_KEY_STORE_PROPERTIES_BASE64`, `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `APPSTORE_KEY_ID`/`APPSTORE_ISSUER_ID`/`APPSTORE_PRIVATE_KEY`, `MATCH_PASSWORD`, `GRADLE_CACHE_ENCRYPTION_KEY`, plus one secret per key in `MobileApp/local.properties.example`
 - [ ] **[Validate]** `:androidApp:bundleRelease` produces a signed AAB (`keytool -printcert -jarfile` = your cert)
 
 ## 5. Store screenshots — `capture-app-screens`

--- a/skills/publishing/progress-template.md
+++ b/skills/publishing/progress-template.md
@@ -34,7 +34,7 @@
 - [ ] **[Agent]** Generate keystore (`generate_android_keystore.sh` or `keytool`) + gitignored `keystore.properties`
 - [ ] **[User]** iOS certificates — only needed for local Xcode builds; CI releases create them on the runner via fastlane `match`
 - [ ] **[User]** Back up keystore + passwords safely (losing the Android keystore = can never update the app)
-- [ ] **[User]** *(optional — only if publishing via CI)* Add signing secrets to GitHub Actions: `SIGNING_KEY_STORE_FILE_BASE64`, `SIGNING_KEY_STORE_PROPERTIES_BASE64`, `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `APPSTORE_KEY_ID`/`APPSTORE_ISSUER_ID`/`APPSTORE_PRIVATE_KEY`, `MATCH_PASSWORD`, `GRADLE_CACHE_ENCRYPTION_KEY`, plus one secret per key in `MobileApp/local.properties.example`
+- [ ] **[User]** *(optional — only if publishing via CI)* Add signing secrets to GitHub Actions: `SIGNING_KEY_STORE_FILE_BASE64`, `SIGNING_KEY_STORE_PROPERTIES_BASE64`, `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, `APPSTORE_KEY_ID`/`APPSTORE_ISSUER_ID`/`APPSTORE_PRIVATE_KEY`, `MATCH_PASSWORD`, `MATCH_GIT_URL`, `MATCH_GIT_BASIC_AUTHORIZATION`, `GRADLE_CACHE_ENCRYPTION_KEY`, plus one secret per key in `MobileApp/local.properties.example`
 - [ ] **[Validate]** `:androidApp:bundleRelease` produces a signed AAB (`keytool -printcert -jarfile` = your cert)
 
 ## 5. Store screenshots — `capture-app-screens`

--- a/skills/setup-signing/SKILL.md
+++ b/skills/setup-signing/SKILL.md
@@ -119,9 +119,9 @@ API key, encrypts them with `MATCH_PASSWORD`, and stores them in a **private cer
 shared across your whole Apple account**.
 
 > **Why a separate repo, and not this one?** An iOS distribution certificate belongs to the
-> Apple *account*, and Apple issues at most **three**. A per-app store would mint a new
-> certificate for every app and lock the account out on the fourth. The provisioning profile is
-> the per-app piece; the certificate is shared. One certs repo per Apple account, reused by
+> Apple *account*, and Apple issues at most **two**. A per-app store would mint a new
+> certificate for every app and lock the account out almost immediately. The provisioning profile
+> is the per-app piece; the certificate is shared. One certs repo per Apple account, reused by
 > every app.
 
 | Secret | Value | Where it comes from |
@@ -148,9 +148,14 @@ inside `match`. The `.p8` downloads **once**; Apple will not show it again.
 The built-in `GITHUB_TOKEN` cannot be used here — it only reaches the repository it runs in, and
 the certs repo is a different one. That is the whole reason a PAT is needed.
 
-The first release fills the certs repo; later ones reuse it. Losing `MATCH_PASSWORD` means the
-stored certificates can no longer be decrypted — you would have to wipe the repo and burn one of
-your three certificate slots, so keep it safe.
+**The first run must bootstrap the store.** Releases run `match` in read-only mode so a build can
+never mint a certificate; that protects the two account-wide slots. For the very first release,
+when the certs repo is still empty, set `MATCH_READONLY=false` once so `match` can create and
+store the certificate. Unset it afterwards — leaving it off lets any later build create another
+certificate and exhaust the account.
+
+Losing `MATCH_PASSWORD` means the stored certificates can no longer be decrypted — you would have
+to wipe the repo and burn one of your two slots, so keep it safe.
 
 No `IOS_APP_CERTIFICATE_P12_BASE64`, `IOS_APP_CERTIFICATE_P12_PASSWORD`, `APPSTORE_TEAM_ID` or
 provisioning-profile UUIDs — `match` derives all of it. If you set them for an older version of

--- a/skills/setup-signing/SKILL.md
+++ b/skills/setup-signing/SKILL.md
@@ -113,25 +113,40 @@ base64 -i distribution/android/keystore/keystore.properties | pbcopy # → SIGNI
 | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Play service-account JSON contents (see `setup-google-play`) |
 | `GRADLE_CACHE_ENCRYPTION_KEY` | `openssl rand -base64 16` |
 
-**iOS:**
-
-```bash
-base64 -i Certificates.p12 | pbcopy   # → IOS_APP_CERTIFICATE_P12_BASE64
-```
+**iOS — no Mac needed.** You do not export a certificate. fastlane `match` creates the
+distribution certificate and provisioning profile on the CI runner from your App Store Connect
+API key, encrypts them with `MATCH_PASSWORD`, and commits them to a `match-certificates` branch
+of this same repository. Later runs reuse them.
 
 | Secret | Value |
 |--------|-------|
-| `IOS_APP_CERTIFICATE_P12_BASE64` | base64 of `Certificates.p12` |
-| `IOS_APP_CERTIFICATE_P12_PASSWORD` | password you set when exporting the p12 |
 | `APPSTORE_KEY_ID` | App Store Connect API **Key ID** |
 | `APPSTORE_ISSUER_ID` | App Store Connect API **Issuer ID** |
-| `APPSTORE_PRIVATE_KEY` | contents of the downloaded `AuthKey_*.p8` |
-| `APPSTORE_TEAM_ID` | App Store Connect Team ID |
-| `IOS_APP_DEVELOPMENT_PROVISION_UUID` | UUID of the development profile |
-| `IOS_APP_DISTRIBUTION_PROVISION_UUID` | UUID of the distribution profile |
+| `APPSTORE_PRIVATE_KEY` | full contents of the downloaded `AuthKey_*.p8`, `-----BEGIN` line included |
+| `MATCH_PASSWORD` | passphrase encrypting the stored certificates — invent one, e.g. `openssl rand -base64 24`, and keep it |
 
-Create the ASC API key at App Store Connect → **Users and Access → Integrations → API Keys**
-(role *App Manager*); the Issuer ID and Key ID show there, and the `.p8` downloads once.
+Create the ASC API key at App Store Connect → **Users and Access → Integrations → API Keys**.
+Give it the **App Manager** role — *Developer* cannot create certificates and the run fails at
+`match`. The Issuer ID sits above the table, the Key ID is the row, and the `.p8` downloads
+**once** — save it, Apple will not show it again.
+
+`MATCH_PASSWORD` is yours to choose, not something Apple gives you. Losing it means the stored
+certificates cannot be decrypted; delete the `match-certificates` branch and the next run
+recreates them. Apple caps distribution certificates at **three per account**, so do not delete
+that branch casually.
+
+> If this repository is public, the encrypted certificates are public too. They are useless
+> without `MATCH_PASSWORD`, but a private repo is safer.
+
+No `IOS_APP_CERTIFICATE_P12_BASE64`, `IOS_APP_CERTIFICATE_P12_PASSWORD`, `APPSTORE_TEAM_ID` or
+provisioning-profile UUIDs — `match` derives all of it. If you set them for an older version of
+this kit, delete them.
+
+**Every key in `MobileApp/local.properties.example` also needs a repo secret of the same name.**
+The workflows read that file to decide what to write into `local.properties` on the runner. A
+missing secret does not fail the build — `getRequiredProperty()` falls back to a default — so the
+app ships with dead sign-in, ads, AI or paywall instead. The release workflows print a warning
+listing anything unset; read it.
 
 ## Other embedded secrets — out of the app too
 

--- a/skills/setup-signing/SKILL.md
+++ b/skills/setup-signing/SKILL.md
@@ -113,34 +113,52 @@ base64 -i distribution/android/keystore/keystore.properties | pbcopy # → SIGNI
 | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Play service-account JSON contents (see `setup-google-play`) |
 | `GRADLE_CACHE_ENCRYPTION_KEY` | `openssl rand -base64 16` |
 
-**iOS — no Mac needed.** You do not export a certificate. fastlane `match` creates the
+**iOS — no Mac needed.** You never export a certificate. fastlane `match` creates the
 distribution certificate and provisioning profile on the CI runner from your App Store Connect
-API key, encrypts them with `MATCH_PASSWORD`, and commits them to a `match-certificates` branch
-of this same repository. Later runs reuse them.
+API key, encrypts them with `MATCH_PASSWORD`, and stores them in a **private certificates repo
+shared across your whole Apple account**.
 
-| Secret | Value |
-|--------|-------|
-| `APPSTORE_KEY_ID` | App Store Connect API **Key ID** |
-| `APPSTORE_ISSUER_ID` | App Store Connect API **Issuer ID** |
-| `APPSTORE_PRIVATE_KEY` | full contents of the downloaded `AuthKey_*.p8`, `-----BEGIN` line included |
-| `MATCH_PASSWORD` | passphrase encrypting the stored certificates — invent one, e.g. `openssl rand -base64 24`, and keep it |
+> **Why a separate repo, and not this one?** An iOS distribution certificate belongs to the
+> Apple *account*, and Apple issues at most **three**. A per-app store would mint a new
+> certificate for every app and lock the account out on the fourth. The provisioning profile is
+> the per-app piece; the certificate is shared. One certs repo per Apple account, reused by
+> every app.
 
-Create the ASC API key at App Store Connect → **Users and Access → Integrations → API Keys**.
-Give it the **App Manager** role — *Developer* cannot create certificates and the run fails at
-`match`. The Issuer ID sits above the table, the Key ID is the row, and the `.p8` downloads
-**once** — save it, Apple will not show it again.
+| Secret | Value | Where it comes from |
+|--------|-------|---------------------|
+| `APPSTORE_KEY_ID` | API **Key ID** | App Store Connect → Users and Access → Integrations → API Keys; it is the row's Key ID column |
+| `APPSTORE_ISSUER_ID` | API **Issuer ID** | same page, shown above the key table |
+| `APPSTORE_PRIVATE_KEY` | **base64** of the `.p8` | `base64 -i AuthKey_XXXX.p8 \| pbcopy` — base64, not the raw file |
+| `MATCH_PASSWORD` | a passphrase you invent | `openssl rand -base64 24`; save it in your password manager |
+| `MATCH_GIT_URL` | https URL of the certs repo | e.g. `https://github.com/<you>/ios-certificates` |
+| `MATCH_GIT_BASIC_AUTHORIZATION` | base64 of `x-access-token:<PAT>` | `printf 'x-access-token:%s' <PAT> \| base64 \| tr -d '\n'` |
 
-`MATCH_PASSWORD` is yours to choose, not something Apple gives you. Losing it means the stored
-certificates cannot be decrypted; delete the `match-certificates` branch and the next run
-recreates them. Apple caps distribution certificates at **three per account**, so do not delete
-that branch casually.
+**Create the API key** at App Store Connect → **Users and Access → Integrations → API Keys**.
+Give it the **App Manager** role — a *Developer* key cannot create certificates and the run fails
+inside `match`. The `.p8` downloads **once**; Apple will not show it again.
 
-> If this repository is public, the encrypted certificates are public too. They are useless
-> without `MATCH_PASSWORD`, but a private repo is safer.
+**Create the certs repo, once per Apple account:**
+
+1. Make a new **private, empty** GitHub repo, e.g. `ios-certificates`. It must be private — it
+   holds your signing material, and it must not be the app repo.
+2. Create a **fine-grained personal access token** (GitHub → Settings → Developer settings →
+   Personal access tokens) with **Contents: Read and write** on that repo only.
+3. Encode it: `printf 'x-access-token:%s' <PAT> | base64 | tr -d '\n'` → `MATCH_GIT_BASIC_AUTHORIZATION`.
+
+The built-in `GITHUB_TOKEN` cannot be used here — it only reaches the repository it runs in, and
+the certs repo is a different one. That is the whole reason a PAT is needed.
+
+The first release fills the certs repo; later ones reuse it. Losing `MATCH_PASSWORD` means the
+stored certificates can no longer be decrypted — you would have to wipe the repo and burn one of
+your three certificate slots, so keep it safe.
 
 No `IOS_APP_CERTIFICATE_P12_BASE64`, `IOS_APP_CERTIFICATE_P12_PASSWORD`, `APPSTORE_TEAM_ID` or
 provisioning-profile UUIDs — `match` derives all of it. If you set them for an older version of
 this kit, delete them.
+
+**Sharing across apps.** `APPSTORE_*`, `MATCH_*` are identical for every app on the same Apple
+account, so they are good candidates for **GitHub organisation secrets**; a new app then only
+needs its own build keys.
 
 **Every key in `MobileApp/local.properties.example` also needs a repo secret of the same name.**
 The workflows read that file to decide what to write into `local.properties` on the runner. A


### PR DESCRIPTION
## Why this matters for the template

The iOS publish workflow had **never successfully run on a generated app**. It required eight secrets, two of which nobody can produce without a Mac — which defeats the purpose of a CI publish workflow. Every user was effectively told to buy a Mac to ship iOS.

## What was broken

**1. Signing required a Mac.** `IOS_APP_CERTIFICATE_P12_BASE64` meant hand-exporting a `.p12`. Now fastlane `match` creates the certificate on the runner from the App Store Connect API key and stores it encrypted on a `match-certificates` branch of the same repo, reachable with the built-in `GITHUB_TOKEN` — no second repo, no PAT.

Xcode automatic signing is deliberately **not** used: it mints a new distribution certificate per run, and Apple caps those at three per account, so it would work three times and then fail permanently.

**2. Silent misconfiguration — the worst failure here.** CI wrote `local.properties` with three keys, two of which (`REVENUECAT_ANDROID_API_KEY`, `REVENUECAT_IOS_API_KEY`) the build no longer reads, while **fourteen keys it does read were missing**. Because every `getRequiredProperty()` carries a default, nothing failed: builds went green and shipped binaries carrying `testValue`, with dead sign-in, analytics and paywall.

**3. Archive and export disagreed.** Archive used `CODE_SIGN_STYLE=Manual` with a hardcoded profile UUID while export declared `signingStyle=automatic`. Plus a duplicated `-destination` flag.

**4. Fixes found by six real builds** (the follow-up commit): `-allowProvisioningUpdates NO` — the flag takes no value, so `xcodebuild` read `NO` as a build action and refused to start. A lane option the workflow never declared, so every dispatch was rejected with HTTP 422. And signing could not go through `xcargs` at all, since those settings hit every target and Swift Package dependencies reject a provisioning profile — now applied per target with `update_code_signing_settings`.

The workflow now drives the project's own `Fastfile` rather than a parallel `xcodebuild` invocation.

## Template-specific cleanup

The source repo's copy carried its own app name and an internal version marker. Since `refactor_package.sh:362` rewrites `app_name` in this workflow from `rootProject.name`, the template must ship **`Koko`** for a generated app to get its own name. Removed the internal marker; verified no other `kappmaker`, personal or absolute-path references survive the port.

## Secrets

Now needed: `APPSTORE_ISSUER_ID`, `APPSTORE_KEY_ID`, `APPSTORE_PRIVATE_KEY`, `MATCH_PASSWORD` (plus the existing `GRADLE_CACHE_ENCRYPTION_KEY` and the built-in `GITHUB_TOKEN`). `IOS_APP_CERTIFICATE_P12_BASE64` and friends are gone.

## Validation

Workflow YAML parses, `Fastfile` passes `ruby -c`. The behaviour itself was verified upstream against a live Apple account through the Kotlin/Native iOS compile — this PR is the port, not a re-verification.
