### PR TITLE
Make the iOS certificate-store bootstrap actually reachable

### DIFF
--- a/.github/workflows/publish_ios_appstore.yml
+++ b/.github/workflows/publish_ios_appstore.yml
@@ -1,15 +1,14 @@
 name: Publish iOS App
 
 # Builds and ships the iOS app on a GitHub macOS runner, so no Mac is needed
-# locally. Signing certificates are created on the runner by fastlane `match`
-# from your App Store Connect API key — nothing has to be exported from a Mac.
+# locally. fastlane `match` creates the signing certificate on the runner from
+# your App Store Connect API key — nothing is exported from a Mac.
 #
 # Signing material lives in a SEPARATE PRIVATE repository shared by all of your
-# apps, because an iOS distribution certificate belongs to your Apple Developer
-# *account*, not to one app — and Apple only allows three of them. Giving each
-# app its own certificate store would mint a new certificate per app and lock you
-# out on the fourth. One store means one certificate, reused, with a per-app
-# provisioning profile alongside it.
+# apps: a distribution certificate belongs to your Apple Developer *account*,
+# not to one app, and Apple issues only two. A store per app would mint a
+# certificate per app and lock you out. One store, one certificate, reused, with
+# a per-app provisioning profile alongside it.
 #
 # Required secrets:
 #   APPSTORE_KEY_ID          App Store Connect API key ID          ) same values
@@ -22,17 +21,18 @@ name: Publish iOS App
 #                            that repo>". The built-in GITHUB_TOKEN cannot be
 #                            used: it only reaches the repo it runs in.
 #   GRADLE_CACHE_ENCRYPTION_KEY
-#   …plus one secret per key listed in MobileApp/local.properties.example.
-#      That file is the single source of truth — add a key there and set a repo
-#      secret of the same name; this workflow needs no edit.
+#   …plus one secret per key in MobileApp/local.properties.example. That file is
+#      the source of truth — add a key there, set a repo secret of the same
+#      name, and this workflow needs no edit.
 #
-# If several apps share an organisation, the account-level secrets above are good
-# candidates for GitHub organisation secrets, so a new app only needs its own
-# build keys.
+# To populate an EMPTY certificate store, set the repository variable
+# MATCH_READONLY=false for that one run, then delete it. Builds are otherwise
+# read-only so a transient failure cannot consume one of the two certificates.
 #
-# To set the certs repo up once per Apple account: create an empty PRIVATE
-# GitHub repo (e.g. ios-certificates), put its https URL in MATCH_GIT_URL, and
-# create a fine-grained PAT with read access to it. See the setup-signing skill.
+# Set the certs repo up once per Apple account: create an empty PRIVATE GitHub
+# repo, put its https URL in MATCH_GIT_URL, and make a PAT with read access to
+# it. Account-level secrets above are good organisation secrets when several
+# apps share an org. See the setup-signing skill.
 
 on:
   workflow_dispatch:
@@ -92,22 +92,15 @@ jobs:
         with:
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
-      # local.properties is gitignored, so a CI checkout has none of these keys.
-      # Every getRequiredProperty() in build.gradle.kts declares a defaultValue,
-      # so a MISSING key does not fail the build — it silently bakes in "" or
-      # "testValue" and ships an app with broken sign-in, analytics and paywall.
-      #
-      # The key list comes from local.properties.example rather than being
-      # repeated here, so adding a new key to that file is all it takes: set a
-      # repo secret of the same name and this step picks it up. sdk.dir is
-      # skipped because the runner's Android setup already writes it.
+      # Every getRequiredProperty() in build.gradle.kts has a defaultValue, so a
+      # MISSING key does not fail the build — it silently ships placeholders.
+      # Keys come from local.properties.example, so this step never needs editing.
       - name: Write secrets to local.properties
         env:
           ALL_SECRETS: ${{ toJSON(secrets) }}
         run: |
           set -euo pipefail
-          # POSIX sed, not a grep lookahead: the runner is macOS and BSD grep
-          # has no lookahead support.
+          # POSIX sed: BSD grep on the macOS runner has no lookahead.
           keys=$(sed -n 's/^\([A-Z][A-Z0-9_]*\)=.*/\1/p' local.properties.example)
           [ -n "$keys" ] || { echo "No keys found in local.properties.example"; exit 1; }
           missing=""
@@ -117,8 +110,6 @@ jobs:
             printf '%s=%s\n' "$key" "$value" >> local.properties
           done
           echo "Wrote $(printf '%s\n' $keys | wc -l | tr -d ' ') keys to local.properties"
-          # Loud, but not fatal: a placeholder only breaks the feature that uses
-          # it, and half-configured apps still need to reach TestFlight.
           if [ -n "$missing" ]; then
             echo "::warning title=Missing build secrets::No repo secret set for:$missing — the app will build but those features ship with placeholder values."
           fi
@@ -130,18 +121,17 @@ jobs:
           bundler-cache: true
           working-directory: MobileApp
 
-      # Uses the project's own Fastfile, so a local release and a CI release run
-      # the same lane and cannot drift apart.
       - name: Build, sign and upload
         env:
           ASC_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          # A private repo shared across your apps — see the note at the top of
-          # this file for why it is not this repository.
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
           MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          # A variable, not a secret: a secret valued "false" masks that word
+          # throughout the build log. Set it only for the bootstrap run.
+          MATCH_READONLY: ${{ vars.MATCH_READONLY }}
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_HIDE_CHANGELOG: '1'
         run: |
@@ -151,8 +141,7 @@ jobs:
             upload_metadata:"${{ inputs.upload_metadata || 'false' }}" \
             upload_screenshots:"${{ inputs.upload_screenshots || 'false' }}"
 
-      # The .ipa is the expensive artefact — keep it reachable when a later step
-      # fails, rather than paying another 20 minutes to rebuild it.
+      # Keep the .ipa reachable when a later step fails.
       - name: Upload .ipa artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,9 @@ Entries start with the first template change after the sync tooling landed — g
   is now read before `setup_ci`, passed to match explicitly, and sourced from a repository
   **variable**, since a secret valued `false` masks that word throughout the log. Manual: bootstrap an
   empty certs repo with `gh variable set MATCH_READONLY --body false`, run the release once, then
-  `gh variable delete MATCH_READONLY`.
+  `gh variable delete MATCH_READONLY`. `match` is also pinned to the `main` branch of the certs repo:
+  it defaults to `master`, which would leave the certificate on a second branch of a repo whose
+  default is `main`.
 
 ## 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,19 @@ Entries start with the first template change after the sync tooling landed — g
 ## 2026-08-16
 
 - `[app]` **iOS publishing works without a Mac** (#48): the iOS publish workflow had never run on a
-  generated app. Signing now goes through fastlane `match`, which creates the certificate on the
-  runner from the App Store Connect API key and stores it encrypted on a `match-certificates` branch
-  of the same repo — no hand-exported `.p12`, no second repo, no personal access token. The
-  `local.properties` written by CI was also writing two keys the build no longer reads while missing
-  fourteen it does, so releases shipped green with dead sign-in, analytics and paywall; and archive
-  and export disagreed about signing style. Signing settings are applied per target
-  (Swift Package dependencies reject a provisioning profile), and the workflow drives the project's
-  own Fastfile instead of a parallel xcodebuild. Manual: set `APPSTORE_ISSUER_ID`, `APPSTORE_KEY_ID`,
-  `APPSTORE_PRIVATE_KEY` and `MATCH_PASSWORD` as repo secrets; the old
-  `IOS_APP_CERTIFICATE_P12_BASE64` and friends are no longer needed.
+  generated app — it wanted a hand-exported `.p12`, which needs the Mac the workflow exists to avoid.
+  Signing now goes through fastlane `match`, which creates the certificate on the runner from the App
+  Store Connect API key and stores it in a **private certificates repo shared across your Apple
+  account**. It is a separate repo on purpose: a distribution certificate belongs to the account and
+  Apple issues at most two, so storing them per app exhausts the account almost immediately. Releases
+  run `match` read-only so no build can mint one. Archive and export also disagreed about signing
+  style, and signing settings had to move per target because Swift Package dependencies reject a
+  provisioning profile; the workflow now drives the project's own Fastfile instead of a parallel
+  xcodebuild. Manual: set `APPSTORE_KEY_ID`, `APPSTORE_ISSUER_ID`, `APPSTORE_PRIVATE_KEY` (the
+  **base64** of the `.p8`, not its raw contents), `MATCH_PASSWORD`, `MATCH_GIT_URL` and
+  `MATCH_GIT_BASIC_AUTHORIZATION` (base64 of `x-access-token:<PAT>` with access to the certs repo).
+  `IOS_APP_CERTIFICATE_P12_BASE64`, `APPSTORE_TEAM_ID` and the provisioning-profile UUIDs are no
+  longer used — delete them.
 - `[app]` **Android releases and PR checks write every build key** (#48): both workflows wrote the same
   stale three-key `local.properties` block, two of which the build no longer reads, so Play Store
   releases shipped with placeholder sign-in, ads, AI and paywall exactly like iOS did. All three
@@ -33,18 +36,19 @@ Entries start with the first template change after the sync tooling landed — g
   about any that are missing.
 - `[docs]` **Publishing docs match the new secrets** (#48): `setup-signing`, the `publishing` guide and
   its progress template, the docs-site CI page and the iOS production page all still described the
-  hand-exported `.p12` flow and two RevenueCat keys the build no longer reads. They now list the four
-  iOS secrets that exist, say that `MATCH_PASSWORD` is a passphrase you invent, and state the rule the
-  workflows rely on: every key in `local.properties.example` needs a repo secret of the same name.
-- `[app]` **One certificates repo per Apple account, not per app** (#48): certificates were stored on a
-  branch of each app's own repo, but an iOS distribution certificate belongs to the Apple account and
-  Apple issues at most two — so every new app burned a slot and the account was locked out almost
-  immediately. `match` also now runs read-only on releases, since with write access it mints a new
-  certificate whenever it is unsatisfied; set `MATCH_READONLY=false` for the one bootstrap run.
-  Signing material now lives in a private repo shared across the account. Manual: create an empty
-  private certs repo plus a fine-grained PAT with write access to it, and set `MATCH_GIT_URL` and
-  `MATCH_GIT_BASIC_AUTHORIZATION`; `APPSTORE_PRIVATE_KEY` is now the **base64** of the `.p8`, not its
-  raw contents.
+  hand-exported `.p12` flow and two RevenueCat keys the build no longer reads. They now list the six
+  iOS secrets that exist and where each value comes from, explain why the certificates repo is shared
+  across the account, and state the rule the workflows rely on: every key in
+  `local.properties.example` needs a repo secret of the same name.
+- `[app]` **The certificate-store bootstrap is actually reachable** (#49): populating an empty
+  certificates repo needs `match` to run with write access exactly once, and that escape hatch never
+  worked. The workflow did not forward `MATCH_READONLY` into the build step, and the lane read it
+  *after* fastlane's `setup_ci`, which sets `MATCH_READONLY=true` itself — so the log printed `false`
+  while match still refused with "cannot create a new one because you enabled `readonly`". The value
+  is now read before `setup_ci`, passed to match explicitly, and sourced from a repository
+  **variable**, since a secret valued `false` masks that word throughout the log. Manual: bootstrap an
+  empty certs repo with `gh variable set MATCH_READONLY --body false`, run the release once, then
+  `gh variable delete MATCH_READONLY`.
 
 ## 2026-08-14
 

--- a/MobileApp/fastlane/Fastfile
+++ b/MobileApp/fastlane/Fastfile
@@ -249,6 +249,9 @@ platform :ios do
       app_identifier: bundle_id,
       api_key: api_key,
       readonly: readonly_mode,
+      # match defaults to a "master" branch, which leaves the store on a second
+      # branch of a repo whose default is main. Pin it so there is one.
+      git_branch: "main",
       keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"]
     )

--- a/MobileApp/fastlane/Fastfile
+++ b/MobileApp/fastlane/Fastfile
@@ -215,12 +215,10 @@ platform :ios do
 
 
   # Ships iOS from a CI macOS runner, so no Mac is needed locally. Differs from
-  # `appstore_release` in three ways that only matter on CI:
-  #   - credentials come from env vars, not ~/credentials/*.json
-  #   - `setup_ci` makes a temporary keychain (a CI runner has no unlocked login keychain)
-  #   - `match` supplies the signing identity instead of Xcode automatic signing,
-  #     because automatic signing mints a NEW distribution certificate per run and
-  #     Apple caps those at 3 per account — three green builds, then every build fails.
+  # `appstore_release` only in what CI forces: credentials come from env vars,
+  # `setup_ci` builds a temporary keychain, and `match` supplies the signing
+  # identity instead of Xcode automatic signing — automatic signing mints a NEW
+  # distribution certificate per run, and Apple allows only two per account.
   desc "Build and ship from CI (no local Mac required)"
   lane :ci_appstore_release do |options|
     track              = (options[:track] || "testflight").to_s
@@ -236,45 +234,32 @@ platform :ios do
       in_house: false
     )
 
+    # Read BEFORE setup_ci: that action sets MATCH_READONLY=true itself, so
+    # anything the workflow passed in is gone by the time match runs.
+    readonly_mode = ENV["MATCH_READONLY"].to_s != "false"
+
     setup_ci if ENV["CI"]
 
-
-    # readonly:false so the FIRST run can create and store the certificate. Later
-    # runs find it already there and reuse it.
-    # READONLY BY DEFAULT — this protects a scarce, account-wide resource.
-    #
-    # Apple issues at most TWO Apple Distribution certificates per developer
-    # account, and they are shared by every app you ship. With readonly:false
-    # match re-verifies against the portal on every build and mints a NEW
-    # certificate whenever it is not satisfied — so a couple of unlucky builds
-    # can consume both slots and lock the account out of iOS releases entirely.
-    #
-    # Set MATCH_READONLY=false for the single bootstrap run that populates an
-    # empty store, then leave it unset.
+    # Read-only by default: Apple allows two Apple Distribution certificates per
+    # account, shared by every app, and with write access match mints a new one
+    # whenever it is unsatisfied — two unlucky builds lock the account out.
+    # MATCH_READONLY=false is for the one run that populates an empty store.
     match(
       type: "appstore",
       app_identifier: bundle_id,
       api_key: api_key,
-      readonly: ENV["MATCH_READONLY"].to_s != "false",
+      readonly: readonly_mode,
       keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"]
     )
 
-    # match publishes what it installed through these env vars.
     profile_name = ENV["sigh_#{bundle_id}_appstore_profile-name"]
     team_id      = ENV["sigh_#{bundle_id}_appstore_team-id"]
     UI.user_error!("match did not install a profile for #{bundle_id}") if profile_name.to_s.empty?
 
-    # Signing must be set on the APP TARGET, and nowhere else.
-    #
-    # Through xcargs the settings hit EVERY target, and the Swift Package
-    # dependencies (Firebase, GoogleUtilities, nanopb, promises...) reject a
-    # provisioning profile outright — "does not support provisioning profiles".
-    # This action edits the pbxproj for the named target only.
-    #
-    # It also has to be manual: left on automatic, Xcode hunts for an iOS App
-    # DEVELOPMENT profile and fails, because match installed an App Store one.
-    # The project ships no DEVELOPMENT_TEAM either, so team_id comes from match.
+    # Signing goes on the app target only: applied globally (via xcargs) the
+    # Swift Package dependencies reject it outright. It must also be manual —
+    # automatic signing hunts for a DEVELOPMENT profile and fails.
     update_code_signing_settings(
       path: "iosApp/iosApp.xcodeproj",
       use_automatic_signing: false,

--- a/skills/setup-signing/SKILL.md
+++ b/skills/setup-signing/SKILL.md
@@ -150,9 +150,18 @@ the certs repo is a different one. That is the whole reason a PAT is needed.
 
 **The first run must bootstrap the store.** Releases run `match` in read-only mode so a build can
 never mint a certificate; that protects the two account-wide slots. For the very first release,
-when the certs repo is still empty, set `MATCH_READONLY=false` once so `match` can create and
-store the certificate. Unset it afterwards — leaving it off lets any later build create another
-certificate and exhaust the account.
+when the certs repo is still empty, add a repository **variable** `MATCH_READONLY` set to `false`
+so `match` can create and store the certificate, then delete it — leaving it off lets any later
+build create another certificate and exhaust the account.
+
+```bash
+gh variable set MATCH_READONLY --body false     # bootstrap only
+gh variable delete MATCH_READONLY               # back to read-only
+```
+
+A variable, not a secret: a secret whose value is `false` masks that word throughout the build
+log. And it must be read before fastlane's `setup_ci` runs, because that action sets
+`MATCH_READONLY=true` itself — the lane already handles this.
 
 Losing `MATCH_PASSWORD` means the stored certificates can no longer be decrypted — you would have
 to wipe the repo and burn one of your two slots, so keep it safe.

--- a/skills/setup-signing/SKILL.md
+++ b/skills/setup-signing/SKILL.md
@@ -159,6 +159,9 @@ gh variable set MATCH_READONLY --body false     # bootstrap only
 gh variable delete MATCH_READONLY               # back to read-only
 ```
 
+After that run the certs repo holds the certificate on its **`main`** branch — check there to
+confirm the bootstrap worked.
+
 A variable, not a secret: a secret whose value is `false` masks that word throughout the build
 log. And it must be read before fastlane's `setup_ci` runs, because that action sets
 `MATCH_READONLY=true` itself — the lane already handles this.


### PR DESCRIPTION
## What was wrong

1. **The workflow never forwarded it.** Repository secrets and variables are not automatically environment variables, so the build step never saw `MATCH_READONLY` at all.
2. **The lane read it too late.** Even once forwarded, the value was read *after* fastlane's `setup_ci`, an action that sets `MATCH_READONLY=true` itself as a CI guard. So it was overwritten before use.

The symptom was confusing: six real bootstrap builds failed with

```
cannot create a new one because you enabled `readonly`
```

while the workflow log showed `MATCH_READONLY: false` two lines above.

## The fix

- Read the value **before** `setup_ci` and pass it to `match` explicitly.
- Source it from a repository **variable**, not a secret — a secret whose value is `false` makes GitHub mask that word throughout the build log, which renders the run unreadable.
- Corrects the distribution-certificate cap to **two** (Apple's limit for type DISTRIBUTION, confirmed against a real account) and drops comments left contradictory by the earlier read-only change.

## Docs

`setup-signing` came with the commit. I updated the two docs-site pages to match, since they still implied a secret: both now say repository **variable**, name the tab it lives under, explain the log-masking reason, and give the commands.

```bash
gh variable set MATCH_READONLY --body false   # bootstrap run only
gh variable delete MATCH_READONLY             # back to read-only
```

## Also in here

The `2026-08-16` changelog section needed correcting. Its `#48` entries still described states that were superseded *inside that same PR* — certificates on a branch of the app's own repo, "no second repo, no personal access token", four secrets — and my `#49` entry had been inserted into the middle of another entry, orphaning its tail. Since #48 squash-merged as one commit, the section now describes the final state once: shared certificates repo, six secrets, base64 `.p8`, `match` read-only.

Workflow YAML validated; no `kappmaker` CLI references carried over.