### PR TITLE
Link only the permission modules the app actually uses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,9 +357,9 @@ Per-app compile-time config lives in **`root/AppConfiguration.kt`** (`object App
 - `expect`/`actual` for platform abstractions
 
 ### Runtime Permissions
-- Backed by **Calf** (`calf-permissions`, commonMain — real dialogs on Android/iOS, granted no-ops on desktop/web).
+- Backed by **Calf** (commonMain — real dialogs on Android/iOS, granted no-ops on desktop/web). Only the **per-permission modules** the app uses are on the classpath: `calf-permissions-core`, `-camera`, `-gallery`, `-notifications`. **Never depend on the umbrella `calf-permissions`** — it links every permission API and App Store review then fails the upload with ITMS-90683, demanding purpose strings for permissions the app never requests.
 - App-level API: `util/permissions/AppPermissionState.kt`. Never use Calf types directly in screens — go through `AppPermissionState`.
-- Per-permission helpers: `rememberNotificationPermissionState()`, `rememberCameraPermissionState()`, `rememberGalleryPermissionState()`, `rememberLocationPermissionState()`, `rememberMicrophonePermissionState()`. Each returns `AppPermissionState { isGranted, shouldShowRationale, request(), openSettings() }`.
+- Per-permission helpers: `rememberNotificationPermissionState()`, `rememberCameraPermissionState()`, `rememberGalleryPermissionState()`. Each returns `AppPermissionState { isGranted, shouldShowRationale, request(), openSettings() }`. Adding another permission means adding its Calf module first, then `rememberAppPermissionState(Permission.X)`.
 - Any other permission: `rememberAppPermissionState(Permission.X)` — same wrapper, one extra import.
 - Ask-on-entry pattern: `RequestPermissionOnEntry(state)` (skips if already granted or rationale pending). Used for the notification permission in `HomeScreen`.
 - iOS: camera/gallery/location/microphone need their `NS*UsageDescription` keys in `iosApp/iosApp/Info.plist`; notification permission needs none.
@@ -587,7 +587,7 @@ Period units are **plurals** (`paywall_unit_day`, `paywall_unit_day_count`, etc.
 | RevenueCat | 3.0.6 | In-app purchases — alternate provider (`purchases-kmp` 3.x — bundles purchases-hybrid-common internally; no iOS pod needed). Set `SUBSCRIPTION_PROVIDER=REVENUECAT` to use. |
 | Coil | 3.5.0 | Image loading |
 | DataStore | 1.3.0-alpha09 | Preferences storage (KMP — pin to 1.3.0-alpha09+, first version with js/wasmJs targets) |
-| Calf | 0.12.0 | Runtime permissions (`calf-permissions`, all targets) |
+| Calf | 0.13.0 | Runtime permissions (`calf-permissions-core` + one module per permission used, all targets) |
 | Napier | — | Logging |
 | Spotless | 8.6.0 | Formatting + ktlint runner (root `build.gradle.kts`) |
 | ktlint | 1.8.0 | Kotlin linter (driven by Spotless) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Entry format — one bullet per merged PR, tagged by scope:
 Entries start with the first template change after the sync tooling landed — group them under a
 `## <year>-<month>-<date>` heading, newest first.
 
+## 2026-08-17
+
+- `[app]` **Only the permission modules the app uses are linked** (#52): the kit depended on Calf's
+  umbrella `calf-permissions` artifact, which links every permission API — location, bluetooth,
+  contacts and the rest. App Store review scans for those symbols, so uploads came back with
+  **ITMS-90683: Missing purpose string in Info.plist** demanding `NSLocationWhenInUseUsageDescription`
+  for a permission the app never requests. Calf 0.12.0 → 0.13.0 and the dependency is now
+  `calf-permissions-core` plus one module per permission actually used: camera, gallery,
+  notifications. Manual: `rememberLocationPermissionState()` and `rememberMicrophonePermissionState()`
+  are gone — if you used them, add `calf-permissions-location` / `-microphone` in
+  `libs.versions.toml` and `shared/build.gradle.kts` and call
+  `rememberAppPermissionState(Permission.FineLocation)` instead. Do not switch back to the umbrella
+  module.
+
 ## 2026-08-16
 
 - `[app]` **iOS publishing works without a Mac** (#48): the iOS publish workflow had never run on a

--- a/MobileApp/gradle/libs.versions.toml
+++ b/MobileApp/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ androidx-core-splashscreen = "1.0.1"
 androidx-uiTest = "1.9.4"
 androidxLifecycle = "2.9.4"
 buildConfig = "6.0.10"
-calf = "0.12.0"
+calf = "0.13.0"
 coil = "3.5.0"
 composablePreviewScanner = "0.9.0"
 compose = "1.11.1"
@@ -58,7 +58,10 @@ androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-p
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidxLifecycle" }
 androidx-uitest-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-uiTest" }
 androidx-uitest-testManifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-uiTest" }
-calf-permissions = { module = "com.mohamedrejeb.calf:calf-permissions", version.ref = "calf" }
+calf-permissions-core = { module = "com.mohamedrejeb.calf:calf-permissions-core", version.ref = "calf" }
+calf-permissions-camera = { module = "com.mohamedrejeb.calf:calf-permissions-camera", version.ref = "calf" }
+calf-permissions-gallery = { module = "com.mohamedrejeb.calf:calf-permissions-gallery", version.ref = "calf" }
+calf-permissions-notifications = { module = "com.mohamedrejeb.calf:calf-permissions-notifications", version.ref = "calf" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 composable-preview-scanner-android = { module = "io.github.sergio-sastre.ComposablePreviewScanner:android", version.ref = "composablePreviewScanner" }

--- a/MobileApp/shared/build.gradle.kts
+++ b/MobileApp/shared/build.gradle.kts
@@ -101,7 +101,14 @@ kotlin {
             implementation(libs.koin.compose.navigation3)
             implementation(libs.lifecyle.runtime)
             implementation(libs.uuid)
-            implementation(libs.calf.permissions)
+            // Only the permission modules this app actually uses. The umbrella
+            // calf-permissions artifact links location, bluetooth, contacts and more,
+            // and App Store review then demands a purpose string for each (ITMS-90683)
+            // even though nothing calls them. Add a module here when you add a permission.
+            implementation(libs.calf.permissions.core)
+            implementation(libs.calf.permissions.camera)
+            implementation(libs.calf.permissions.gallery)
+            implementation(libs.calf.permissions.notifications)
             implementation(libs.androidx.datastore.preferences.core)
             implementation(libs.coil.compose)
             implementation(libs.coil.ktor)

--- a/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/permissions/AppPermissionState.kt
+++ b/MobileApp/shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/permissions/AppPermissionState.kt
@@ -6,12 +6,10 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import com.mohamedrejeb.calf.permissions.Camera
 import com.mohamedrejeb.calf.permissions.ExperimentalPermissionsApi
-import com.mohamedrejeb.calf.permissions.FineLocation
 import com.mohamedrejeb.calf.permissions.Gallery
 import com.mohamedrejeb.calf.permissions.Notification
 import com.mohamedrejeb.calf.permissions.Permission
 import com.mohamedrejeb.calf.permissions.PermissionState
-import com.mohamedrejeb.calf.permissions.RecordAudio
 import com.mohamedrejeb.calf.permissions.isGranted
 import com.mohamedrejeb.calf.permissions.rememberPermissionState
 import com.mohamedrejeb.calf.permissions.shouldShowRationale
@@ -48,9 +46,14 @@ interface AppPermissionState {
 /**
  * Remembers an [AppPermissionState] for any Calf [Permission].
  *
- * To support a permission that has no dedicated helper below, call this directly:
- * `rememberAppPermissionState(Permission.Bluetooth)` (after adding the matching
- * iOS usage-description key to Info.plist).
+ * Only the permissions this app ships are on the classpath: camera, gallery and
+ * notifications. To use another one, add its Calf module in `shared/build.gradle.kts`
+ * (e.g. `calf-permissions-location`) and the matching iOS usage-description key, then
+ * call this directly: `rememberAppPermissionState(Permission.FineLocation)`.
+ *
+ * Do not reach for the umbrella `calf-permissions` artifact. It links every permission
+ * API, and App Store review then rejects the build with ITMS-90683 for each purpose
+ * string you have not written — for permissions your app never uses.
  *
  * @param onResult called with the grant result after [AppPermissionState.request].
  */
@@ -78,16 +81,6 @@ fun rememberCameraPermissionState(onResult: (Boolean) -> Unit = {}): AppPermissi
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
 fun rememberGalleryPermissionState(onResult: (Boolean) -> Unit = {}): AppPermissionState = rememberAppPermissionState(Permission.Gallery, onResult)
-
-/** Precise location permission. iOS requires NSLocationWhenInUseUsageDescription in Info.plist. */
-@OptIn(ExperimentalPermissionsApi::class)
-@Composable
-fun rememberLocationPermissionState(onResult: (Boolean) -> Unit = {}): AppPermissionState = rememberAppPermissionState(Permission.FineLocation, onResult)
-
-/** Microphone permission. iOS requires NSMicrophoneUsageDescription in Info.plist. */
-@OptIn(ExperimentalPermissionsApi::class)
-@Composable
-fun rememberMicrophonePermissionState(onResult: (Boolean) -> Unit = {}): AppPermissionState = rememberAppPermissionState(Permission.RecordAudio, onResult)
 
 /**
  * Requests [permissionState] once when it enters composition, unless already granted

--- a/skills/add-permission/SKILL.md
+++ b/skills/add-permission/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-permission
-description: Request a runtime permission (camera, gallery, location, microphone, notifications, or any other) via the app-level AppPermissionState API. Use when a screen needs to ask the user for a device permission. For full push/FCM setup (not just the notification permission prompt), use enable-notifications instead.
+description: Request a runtime permission (notifications, camera, gallery out of the box; location, microphone or any other after adding its Calf module) via the app-level AppPermissionState API. Use when a screen needs to ask the user for a device permission. For full push/FCM setup (not just the notification permission prompt), use enable-notifications instead.
 ---
 
 # Add a runtime permission
@@ -17,10 +17,28 @@ Helpers live in `shared/src/commonMain/kotlin/com/kotlinfoundation/koko/util/per
 | `rememberNotificationPermissionState()` | — |
 | `rememberCameraPermissionState()` | `NSCameraUsageDescription` |
 | `rememberGalleryPermissionState()` | `NSPhotoLibraryUsageDescription` |
-| `rememberLocationPermissionState()` | `NSLocationWhenInUseUsageDescription` |
-| `rememberMicrophonePermissionState()` | `NSMicrophoneUsageDescription` |
 
-Any other permission: `rememberAppPermissionState(Permission.Bluetooth)`.
+Those three are the permissions the kit ships. **Any other permission needs its Calf module added
+first** — the kit deliberately does not depend on the umbrella `calf-permissions` artifact:
+
+```kotlin
+// MobileApp/gradle/libs.versions.toml
+calf-permissions-location = { module = "com.mohamedrejeb.calf:calf-permissions-location", version.ref = "calf" }
+
+// MobileApp/shared/build.gradle.kts, commonMain
+implementation(libs.calf.permissions.location)
+```
+
+Then call the generic helper and add the iOS key:
+
+```kotlin
+rememberAppPermissionState(Permission.FineLocation)   // + NSLocationWhenInUseUsageDescription
+```
+
+> **Never switch to the umbrella `calf-permissions` module.** It links every permission API, so
+> App Store review rejects the build with **ITMS-90683** demanding a purpose string for location,
+> bluetooth, contacts and the rest — permissions the app never uses. One module per permission you
+> actually request.
 
 ## Use it in a screen
 


### PR DESCRIPTION
Fixes a real App Store rejection.

## The rejection

```
ITMS-90683: Missing purpose string in Info.plist — The Info.plist file for the
"ClipUGC.app" bundle should contain a NSLocationWhenInUseUsageDescription key…
```

The app never touches location. The cause is Calf's **umbrella `calf-permissions` artifact**: it links every permission API — location, bluetooth, contacts, calendar, wifi — and App Store review scans for those symbols regardless of whether anything calls them. Each one then demands a purpose string. Calf's own docs say the umbrella module is "not recommended for iOS App Store submissions".

## The fix

Calf **0.12.0 → 0.13.0**, which splits the library per permission. The dependency is now `calf-permissions-core` plus exactly what the demo screens request:

```kotlin
implementation(libs.calf.permissions.core)
implementation(libs.calf.permissions.camera)
implementation(libs.calf.permissions.gallery)
implementation(libs.calf.permissions.notifications)
```

## Removed wrappers

`rememberLocationPermissionState()` and `rememberMicrophonePermissionState()` are gone. Neither was called anywhere in the kit, and keeping either would mean keeping the module that caused the rejection. Their `FineLocation` / `RecordAudio` imports failed to resolve the moment the modules left the classpath, which confirms the umbrella really was what pulled them in.

`rememberAppPermissionState(Permission.X)` still covers everything else.

**Migration** (also in the changelog): if you used them, add `calf-permissions-location` / `-microphone` to `libs.versions.toml` and `shared/build.gradle.kts`, then call the generic helper with the matching Info.plist key.

## Docs

`AGENTS.md`, the `add-permission` skill and the docs-site permissions page now state which modules ship, how to add another one, and warn explicitly against switching back to the umbrella artifact — that is the trap this PR removes, and it is invisible until an upload is rejected. The skill's description was also advertising location and microphone as available out of the box.

## Validation

| | |
|---|---|
| `spotlessCheck`, `jvmTest`, `testAndroidHostTest`, `assembleDebug` | ✅ |
| `:shared:compileKotlinWasmJs` | ✅ |
| `:shared:linkDebugFrameworkIosSimulatorArm64` | ✅ |

Nothing references the removed helpers anywhere in the repo.

One note: `NSCameraUsageDescription` is already in `Info.plist` and is genuinely needed (FileKit's camera picker hard-crashes without it). Gallery does not need a key — the iOS picker is `PHPickerViewController`, which runs out of process.