### PR TITLE
Declare iOS orientations and export compliance in Info.plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Entries start with the first template change after the sync tooling landed — g
 
 ## 2026-08-17
 
+- `[app]` **Info.plist declares orientations and export compliance** (#53): the target builds for
+  iPhone and iPad but declared no orientations, so App Store Connect rejects the upload with
+  ITMS-90474. All four orientations are now declared for both device families.
+  `ITSAppUsesNonExemptEncryption=false` answers the export-compliance question once instead of on
+  every upload. Manual: nothing, unless you ship non-exempt cryptography — then set it `true`.
 - `[app]` **Only the permission modules the app uses are linked** (#52): the kit depended on Calf's
   umbrella `calf-permissions` artifact, which links every permission API — location, bluetooth,
   contacts and the rest. App Store review scans for those symbols, so uploads came back with

--- a/MobileApp/iosApp/iosApp/Info.plist
+++ b/MobileApp/iosApp/iosApp/Info.plist
@@ -4,6 +4,22 @@
 <dict>
     <key>CADisableMinimumFrameDurationOnPhone</key>
     <true/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+      <string>UIInterfaceOrientationPortrait</string>
+      <string>UIInterfaceOrientationPortraitUpsideDown</string>
+      <string>UIInterfaceOrientationLandscapeLeft</string>
+      <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+      <string>UIInterfaceOrientationPortrait</string>
+      <string>UIInterfaceOrientationPortraitUpsideDown</string>
+      <string>UIInterfaceOrientationLandscapeLeft</string>
+      <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>UILaunchScreen</key>
     <dict>
         <key>UIColorName</key>


### PR DESCRIPTION
`main` declares no supported orientations — not in `Info.plist`, not as an `INFOPLIST_KEY_*` build setting — while the target builds for iPhone and iPad (`TARGETED_DEVICE_FAMILY = "1,2"`). App Store Connect rejects that upload with **ITMS-90474**.

Adds:

- **All four orientations**, for both iPhone and iPad.
- **`ITSAppUsesNonExemptEncryption=false`** — answers the export-compliance question once instead of on every upload. The app uses only HTTPS/TLS, which is exempt.

Neither key exists on the build-settings side, so nothing is declared twice.

Verified: `plutil -lint` passes, and an `xcodebuild` run for the simulator succeeds with both keys present in the built `Koko.app/Info.plist`.

